### PR TITLE
Add CRDA static analysis workflow

### DIFF
--- a/.github/workflows/crda.yml
+++ b/.github/workflows/crda.yml
@@ -1,0 +1,126 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow performs a static analysis of your source code using
+# Red Hat CodeReady Dependency Analytics.
+
+# Scans are triggered:
+# 1. On every push to default and protected branches
+# 2. On every Pull Request targeting the default branch
+# 3. On a weekly schedule
+# 4. Manually, on demand, via the "workflow_dispatch" event
+
+# 💁 The CRDA Starter workflow will:
+# - Checkout your repository
+# - Setup the required tool stack
+# - Install the CRDA command line tool
+# - Auto detect the manifest file and install the project's dependencies
+# - Perform the security scan using CRDA
+# - Upload the SARIF result to the GitHub Code Scanning which can be viewed under the security tab
+# - Optionally upload the SARIF file as an artifact for the future reference
+
+# ℹ️ Configure your repository and the workflow with the following steps:
+# 1. Setup the tool stack based on the project's requirement.
+#    Refer to: https://github.com/redhat-actions/crda/#1-set-up-the-tool-stack
+# 2. (Optional) CRDA action attempt to detect the language and install the
+#    required dependencies for your project. If your project doesn't aligns
+#    with the default dependency installation command mentioned here
+#    https://github.com/redhat-actions/crda/#3-installing-dependencies.
+#    Use the required inputs to setup the same
+# 3. (Optional) CRDA action attempts to detect the manifest file if it is
+#    present in the root of the project and named as per the default mentioned
+#    here https://github.com/redhat-actions/crda/#3-installing-dependencies.
+#    If it deviates from the default, use the required inputs to setup the same
+# 4. Setup Authentication - Create the CRDA_KEY or SNYK_TOKEN.
+#    Refer to: https://github.com/redhat-actions/crda/#4-set-up-authentication
+# 5. (Optional) Upload SARIF file as an Artifact to download and view
+# 6. Commit and push the workflow file to your default branch to trigger a workflow run.
+
+# 👋 Visit our GitHub organization at https://github.com/redhat-actions/ to see our actions and provide feedback.
+
+name: CRDA Scan
+
+# Controls when the workflow will run
+on:
+  # TODO: Customize trigger events based on your DevSecOps processes
+  #
+  # This workflow is made to run with OpenShift starter workflow
+  # https://github.com/actions/starter-workflows/blob/main/deployments/openshift.yml
+  # However, if you want to run this workflow as a standalone workflow, please
+  # uncomment the 'push' trigger below and configure it based on your requirements.
+  #
+  workflow_call:
+    secrets:
+      CRDA_KEY:
+        required: false
+      SNYK_TOKEN:
+        required: false
+  workflow_dispatch:
+
+  # push:
+  #   branches: [ "main" ]
+
+  # pull_request_target is used to securely share secret to the PR's workflow run.
+  # For more info visit: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    branches: [ "main" ]
+    types: [ assigned, opened, synchronize, reopened, labeled, edited ]
+
+permissions:
+  contents: read
+
+jobs:
+  crda-scan:
+    permissions:
+      contents: read            # for actions/checkout to fetch code
+      security-events: write    # for redhat-actions/crda to upload SARIF results
+    name: Scan project vulnerabilities with CRDA
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # *******************************************************************
+      # Required: Instructions to setup project
+      # 1. Setup Go, Java, Node.js or Python depending on your project type
+      # 2. Setup Actions are listed below, choose one from them:
+      #    - Go: https://github.com/actions/setup-go
+      #    - Java: https://github.com/actions/setup-java
+      #    - Node.js: https://github.com/actions/setup-node
+      #    - Python: https://github.com/actions/setup-python
+      #
+      # Example:
+      # - name: Setup Node
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: '20'
+
+      # https://github.com/redhat-actions/openshift-tools-installer/blob/main/README.md
+      - name: Install CRDA CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: github
+          github_pat: ${{ github.token }}
+          # Choose the desired version of the CRDA CLI
+          crda: "latest"
+
+      ######################################################################################
+      # https://github.com/redhat-actions/crda/blob/main/README.md
+      #
+      # By default, CRDA will detect the manifest file and install the required dependencies
+      # using the standard command for the project type.
+      # If your project doesn't aligns with the defaults mentioned in this action, you will
+      # need to set few inputs that are described here:
+      # https://github.com/redhat-actions/crda/blob/main/README.md#3-installing-dependencies
+      # Visit https://github.com/redhat-actions/crda/#4-set-up-authentication to understand
+      # process to get a SNYK_TOKEN or a CRDA_KEY
+      - name: CRDA Scan
+        id: scan
+        uses: redhat-actions/crda@v1
+        with:
+          crda_key: ${{ secrets.CRDA_KEY }}           # Either use crda_key or snyk_token
+          # snyk_token: ${{ secrets.SNYK_TOKEN }}
+          # upload_artifact: false                    # Set this to false to skip artifact upload


### PR DESCRIPTION
This workflow performs static analysis of source code using Red Hat CodeReady Dependency Analytics, triggered on various events including pushes and pull requests.

## Summary

Describe the intent of this change in 2-4 lines.

## Surface

- [ ] Corpus/data
- [ ] Coding/analysis
- [ ] Writing/docs
- [ ] Infra/publishing

## Checks

- [ ] `python tools/scripts/validate_schemas.py data/processed/records.jsonl --schema master-record --verbose`
- [ ] `python tools/scripts/code_purification.py --status` if coding-related
- [ ] `python tools/scripts/vault_sync.py status` or `diff` if vault-facing
- [ ] Release/docs updated if GitHub Pages or Hugging Face is affected

## Notes

List any known drift, skipped checks, or external follow-up.
