### PR TITLE
feat(companion): add upload_thumbnails.py for R2 thumbnail pipeline

### DIFF
--- a/tese/anchors/historian-1910-1920-br.md
+++ b/tese/anchors/historian-1910-1920-br.md
@@ -1,0 +1,42 @@
+---
+title: Âncoras históricas externas — Brasil, 1910–1920
+generated_by: agency-agents/Historian
+generated_at: 2026-04-25
+purpose: Fontes primárias verificáveis para a tese ICONOCRACIA, década 1910s.
+status: rascunho — itens [needs catalog check] requerem consulta direta à Hemeroteca Digital BN
+---
+
+# Âncoras históricas externas — Brasil, 1910–1920
+
+## Contexto periódico
+
+A década é estruturada pela transição República Velha sob Hermes da Fonseca (1910–14), Wenceslau Brás (1914–18) e Delfim Moreira/Epitácio Pessoa (1918–22), com três motores iconográficos centrais:
+
+1. Promulgação do **Código Civil (Lei nº 3.071, de 1º de janeiro de 1916)**, que consolida a arquitetura jurídica civilista e codifica a "incapacidade relativa" da mulher casada (art. 6º, II), tensionando a alegoria feminina da Justiça com a sujeição jurídica das mulheres reais;
+2. **Entrada do Brasil na Primeira Guerra (outubro/1917)**, que mobiliza a iconografia da Pátria/República em capas de revistas e cartazes cívicos;
+3. Crises sociais — Revolta da Chibata (1910), greve geral de 1917, gripe espanhola (1918) — que disputam o imaginário republicano em chave satírica e oficial.
+
+## Fontes primárias
+
+1. **BRASIL.** Lei nº 3.071, de 1º de janeiro de 1916. Código Civil dos Estados Unidos do Brasil. *Diário Oficial da União*, Rio de Janeiro, 5 jan. 1916. Disponível em: https://www.planalto.gov.br/ccivil_03/leis/l3071.htm. — Texto legal que codifica a moldura jurídica em que a alegoria feminina da Justiça opera. Consulta: Planalto, Senado/LexML, edições fac-similadas no **Arquivo Nacional (RJ)**.
+
+2. **BEVILAQUA, Clóvis.** *Código Civil dos Estados Unidos do Brasil commentado.* Rio de Janeiro: Francisco Alves, 1916–1919. 6 v. — Comentário doutrinário coetâneo do redator do Código; frontispícios das primeiras edições frequentemente trazem alegoria togada da Justiça [needs catalog check]. Consulta: **Biblioteca Nacional (RJ)**, **Biblioteca do STF**, FGV/Direito Rio.
+
+3. **O MALHO**: hebdomadário humorístico, ilustrado, artístico e literário. Rio de Janeiro: Editora O Malho, 1902–1954. — Capas e charges 1910–1920 recorrentemente personificam a República como matrona de barrete frígio e a Pátria como figura feminina drapeada (especialmente número-aniversário e edições de 7 set. e 15 nov.) [needs catalog check]. Consulta: **Hemeroteca Digital Brasileira / Biblioteca Nacional**.
+
+4. **CARETA**: semanário de variedades. Rio de Janeiro: Kosmos, 1908–1964. — Em 1917–1918, capas mobilizam alegoria da Pátria/Marianne brasileira em apoio à entrada na guerra; charges satirizam a Justiça vendada nos escândalos da Justiça eleitoral republicana [needs catalog check]. Consulta: **Hemeroteca Digital Brasileira / BN**.
+
+5. **REVISTA DA SEMANA.** Rio de Janeiro: Officinas Graphicas do Jornal do Brasil, 1900–1959. — Periódico ilustrado com fotorreportagem de inaugurações cívicas, monumentos e cerimônias oficiais entre 1910–1920; valioso para registrar a estatuária alegórica da República no espaço urbano carioca [needs catalog check]. Consulta: **Hemeroteca Digital Brasileira / BN**, **IHGB**.
+
+## Notas de cautela
+
+- Itens 3–5 citados em nível de **corpus** (periódico verificável); números/datas/páginas exatas exigem consulta direta à Hemeroteca Digital (https://memoria.bn.br/hdb/).
+- Monumentos cívicos específicos não incluídos — datas de inauguração precisas exigem checagem em **IPHAN/Arquivo Nacional**.
+- Formatação ABNT NBR 6023:2025: **[verificar pontuação 2025]** para item lei (separador entre número e data) e periódico oficial.
+
+## Próximos passos sugeridos
+
+- [ ] Cross-check com Hemeroteca Digital BN: capas O Malho e Careta 1917–1918 (entrada na guerra)
+- [ ] Bevilaqua: localizar exemplares físicos com frontispício alegórico
+- [ ] Adicionar inaugurações monumentais 1910–1920 via IPHAN
+- [ ] Validar formatação ABNT 2025 com `abnt-checker` agent

--- a/tools/scripts/upload_thumbnails.py
+++ b/tools/scripts/upload_thumbnails.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+upload_thumbnails.py — Generate and upload thumbnails for ICONOCRACY corpus items.
+
+Reads from: Other/analytics.html (DATA hardcoded) or data/processed/records.jsonl
+Generates: 300px-wide WebP thumbnails
+Outputs: local thumbnails/ directory + updates thumbnail_url in analytics.html
+
+Usage:
+    python upload_thumbnails.py [--dry-run] [--limit N] [--item ID] [--r2]
+
+R2 upload requires CLOUDFLARE_API_TOKEN + R2_ACCOUNT_ID env vars.
+Without R2 credentials, thumbnails are saved locally only.
+"""
+import base64
+import hashlib
+import json
+import os
+import re
+import ssl
+import sys
+import time
+import urllib.request
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+from typing import Optional
+
+try:
+    from PIL import Image
+    HAS_PIL = True
+except ImportError:
+    HAS_PIL = False
+    print("WARNING: Pillow not installed. Thumbnails will be downloaded but not resized.")
+
+# ── Config ──────────────────────────────────────────────────────────────────
+ANALYTICS_HTML = Path(__file__).resolve().parents[2] / "Other" / "analytics.html"
+THUMBNAILS_DIR = Path(__file__).resolve().parents[2] / "thumbnails"
+THUMBNAILS_DIR.mkdir(exist_ok=True)
+
+TARGET_WIDTH = 300
+THUMBNAIL_QUALITY = 82  # WebP quality
+MAX_DIM = (TARGET_WIDTH, TARGET_WIDTH * 2)  # allow tall images
+
+SSL_CTX = ssl.create_default_context()
+SSL_CTX.check_hostname = False
+SSL_CTX.verify_mode = ssl.CERT_NONE
+
+TIMEOUT = 15
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; ICONOCRACIA-thumbnailer/1.0)"
+}
+
+# ── URL cleanup ──────────────────────────────────────────────────────────────
+def clean_url(url: str) -> str:
+    """Remove query params that cause 302 loops or size limits."""
+    if not url:
+        return ""
+    url = url.split("?")[0]
+    # Wikimedia Commons: prefer original upload URL
+    url = url.replace("/thumb/", "/")
+    # Numista: use the full image URL (strip thumb params)
+    url = re.sub(r'thumbs/\d+_\d+', 'images', url)
+    return url
+
+# ── Image fetch ───────────────────────────────────────────────────────────────
+def fetch_image_bytes(url: str, timeout: int = TIMEOUT) -> bytes | None:
+    """Download image bytes from URL. Returns None on failure."""
+    if not url or not url.startswith(("http://", "https://")):
+        return None
+    req = urllib.request.Request(clean_url(url), headers=HEADERS)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=SSL_CTX) as r:
+            ct = r.headers.get("Content-Type", "")
+            if "image" not in ct and "html" not in ct:
+                return r.read()
+            elif "image" in ct:
+                return r.read()
+    except Exception as e:
+        print(f"  fetch error {url[:60]}: {e}")
+    return None
+
+def make_thumbnail(img_bytes: bytes, max_w: int = TARGET_WIDTH) -> bytes | None:
+    """Resize image to max_w, convert to WebP, return bytes."""
+    if not HAS_PIL:
+        return img_bytes
+    try:
+        img = Image.open(BytesIO(img_bytes))
+        # Convert palette/RGBA
+        if img.mode in ("P", "RGBA", "LA"):
+            img = img.convert("RGB")
+        elif img.mode == "1":
+            img = img.convert("L").convert("RGB")
+        elif img.mode != "RGB":
+            img = img.convert("RGB")
+
+        w, h = img.size
+        if w > max_w:
+            ratio = max_w / w
+            new_h = int(h * ratio)
+            img = img.resize((max_w, new_h), Image.LANCZOS)
+
+        buf = BytesIO()
+        img.save(buf, format="WEBP", quality=THUMBNAIL_QUALITY, method=6)
+        return buf.getvalue()
+    except Exception as e:
+        print(f"  thumbnail error: {e}")
+    return img_bytes if HAS_PIL else None
+
+# ── R2 upload ────────────────────────────────────────────────────────────────
+def upload_to_r2(image_bytes: bytes, key: str) -> str | None:
+    """Upload thumbnail bytes to Cloudflare R2, return public URL or None."""
+    account_id = os.getenv("R2_ACCOUNT_ID")
+    bucket = os.getenv("R2_BUCKET", "iconocracia-images")
+    token = os.getenv("CLOUDFLARE_API_TOKEN")
+
+    if not all([account_id, token]):
+        return None
+
+    url = f"https://{account_id}.r2.cloudflarestorage.com/{bucket}/{key}"
+    req = urllib.request.Request(
+        url,
+        data=image_bytes,
+        method="PUT",
+        headers={
+            "Content-Type": "image/webp",
+            "Authorization": f"Bearer {token}",
+        }
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            if r.status in (200, 201):
+                return f"/images/{key}"
+    except Exception as e:
+        print(f"  R2 upload error: {e}")
+    return None
+
+# ── Item ID → key ─────────────────────────────────────────────────────────────
+def item_key(item_id: str) -> str:
+    """Normalize item ID to safe R2 key."""
+    return f"{item_id}-thumb.webp"
+
+# ── Parse analytics.html DATA ─────────────────────────────────────────────────
+def parse_analytics_data(html_path: Path) -> list[dict]:
+    """Extract DATA array from analytics.html."""
+    content = html_path.read_text(encoding="utf-8")
+    # DATA array ends with }]; followed by \n\nconst CORES
+    m = re.search(r'const DATA = (\[\{.*\}\]);\n\nconst CORES', content, re.DOTALL)
+    if not m:
+        raise ValueError("Could not find DATA array in analytics.html")
+    json_str = m.group(1)
+    return json.loads(json_str)
+
+def write_analytics_data(html_path: Path, data: list[dict]):
+    """Rewrite DATA array in analytics.html, preserving everything else."""
+    content = html_path.read_text(encoding="utf-8")
+    new_json = json.dumps(data, ensure_ascii=False, indent=2)
+    # Reformat to single-line per object (matching original style)
+    new_json_lines = re.sub(r'\[', '[\n', new_json, count=1)
+    # Replace the DATA block
+    pattern = r'const DATA = \[.*?\];'
+    replacement = f'const DATA = {new_json};'
+    new_content = re.sub(pattern, replacement, content, flags=re.DOTALL)
+    html_path.write_text(new_content, encoding="utf-8")
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+def main():
+    dry_run = "--dry-run" in sys.argv
+    limit = 50
+    if "--limit" in sys.argv:
+        idx = sys.argv.index("--limit")
+        limit = int(sys.argv[idx + 1])
+    target_item = None
+    if "--item" in sys.argv:
+        idx = sys.argv.index("--item")
+        target_item = sys.argv[idx + 1]
+
+    use_r2 = "--r2" in sys.argv and os.getenv("CLOUDFLARE_API_TOKEN")
+
+    print(f"Reading {ANALYTICS_HTML}...")
+    data = parse_analytics_data(ANALYTICS_HTML)
+    print(f"  {len(data)} items loaded")
+
+    needs_thumb = [
+        d for d in data
+        if not d.get("thumbnail_url") or d.get("thumbnail_url") == ""
+    ]
+    print(f"  {len(needs_thumb)} need thumbnails")
+
+    if target_item:
+        needs_thumb = [d for d in needs_thumb if d["id"] == target_item]
+
+    processed = 0
+    updated = 0
+
+    for item in needs_thumb[:limit]:
+        item_id = item["id"]
+        src_url = item.get("url") or item.get("source_archive_url") or ""
+        thumb_path = THUMBNAILS_DIR / item_key(item_id)
+
+        # Skip if already exists locally
+        if thumb_path.exists() and not dry_run:
+            local_url = f"thumbnails/{item_key(item_id)}"
+            if item.get("thumbnail_url") != local_url:
+                item["thumbnail_url"] = local_url
+                updated += 1
+            print(f"  [{item_id}] already local: {local_url}")
+            continue
+
+        print(f"  [{item_id}] src: {src_url[:80]}", end="", flush=True)
+
+        if dry_run:
+            print(" [DRY RUN]")
+            processed += 1
+            continue
+
+        img_bytes = fetch_image_bytes(src_url)
+        if not img_bytes:
+            print(" [FAILED - no image]")
+            processed += 1
+            continue
+
+        thumb_bytes = make_thumbnail(img_bytes)
+        if not thumb_bytes:
+            print(" [FAILED - thumbnail]")
+            processed += 1
+            continue
+
+        # Save locally
+        thumb_path.write_bytes(thumb_bytes)
+        print(f" -> {thumb_path.stat().st_size:,} bytes")
+
+        # R2 upload
+        if use_r2:
+            r2_url = upload_to_r2(thumb_bytes, item_key(item_id))
+            if r2_url:
+                item["thumbnail_url"] = r2_url
+            else:
+                item["thumbnail_url"] = f"thumbnails/{item_key(item_id)}"
+        else:
+            item["thumbnail_url"] = f"thumbnails/{item_key(item_id)}"
+
+        updated += 1
+        processed += 1
+        time.sleep(0.5)  # polite rate limiting
+
+    print(f"\nDone: {processed} items processed, {updated} thumbnail_url updated")
+
+    if updated > 0 and not dry_run:
+        # Copy to deploy location
+        deploy_analytics = Path(__file__).resolve().parents[2] / "deploy" / "iconocracia-companion" / "public" / "analytics.html"
+        if deploy_analytics.exists():
+            import shutil
+            src = ANALYTICS_HTML
+            shutil.copy2(src, deploy_analytics)
+            print(f"Copied to {deploy_analytics}")
+        write_analytics_data(ANALYTICS_HTML, data)
+        print(f"Updated {ANALYTICS_HTML} with new thumbnail_url values")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Script to generate 300px WebP thumbnails from corpus images and upload to Cloudflare R2 bucket.

Implements: issue #20 (Populate thumbnail_url for corpus items).

Without R2 credentials: saves thumbnails locally only. With CLOUDFLARE_API_TOKEN + R2_ACCOUNT_ID: uploads to R2 and updates thumbnail_url in analytics.html.

## Summary

Describe the intent of this change in 2-4 lines.

## Surface

- [ ] Corpus/data
- [ ] Coding/analysis
- [ ] Writing/docs
- [ ] Infra/publishing

## Checks

- [ ] `python tools/scripts/validate_schemas.py data/processed/records.jsonl --schema master-record --verbose`
- [ ] `python tools/scripts/code_purification.py --status` if coding-related
- [ ] `python tools/scripts/vault_sync.py status` or `diff` if vault-facing
- [ ] Release/docs updated if GitHub Pages or Hugging Face is affected

## Notes

List any known drift, skipped checks, or external follow-up.
