### PR TITLE
docs(skill): corrige ecc-iconocracy-guide com host macOS-primário e estado real de comandos/MCPs

### DIFF
--- a/.claude/skills/ecc-iconocracy-guide/SKILL.md
+++ b/.claude/skills/ecc-iconocracy-guide/SKILL.md
@@ -11,11 +11,11 @@ user-invocable: true
 # Guia de Ferramentas — Tese ICONOCRACIA
 
 Mapeia tarefas do projeto para o que está **de fato instalado e acionável** neste repositório.
-Três camadas:
+Três camadas de escolha (priorizadas) + duas seções transversais (modos do agente, descoberta):
 
 1. **Skills sob medida da tese** — vivem em `.claude/skills/` (projeto). São a primeira escolha.
-2. **Plugin ECC** (`ecc` v2.0.0-rc.1) — comandos de engenharia em `.claude/commands/` e catálogo de skills em `.claude/skills/ecc/`.
-3. **Ferramentas MCP** — scite (literatura), Context7 (docs de bibliotecas), Exa (busca web).
+2. **Plugin ECC** — `everything-claude-code` v1.10.0, instalado em escopo **usuário** (`~/.claude/plugins/cache/everything-claude-code/everything-claude-code/1.10.0/`). Os comandos do plugin não vivem em `.claude/commands/` deste repo (essa pasta está vazia). Audite com `cat ~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/plugin.json`.
+3. **Ferramentas MCP** — Context7 (docs de bibliotecas), Exa (busca web), Firecrawl (busca web ativa, recomendada pelo CLAUDE.md global), scite (literatura — em setup).
 
 > O agente também despacha por **palavras-gatilho** (modo routing do `CLAUDE.md`), que muitas vezes
 > é o caminho mais direto — não precisa nomear a skill.
@@ -27,12 +27,14 @@ Três camadas:
 | Compilar a tese (DOCX/PDF) | `compilar-tese` | "compilar", "make tese", "gerar PDF" |
 | Sincronizar corpus / validar schema | `sync-corpus` | "sync vault", "validar corpus", drift entre `records.jsonl` ↔ `corpus-data.json` |
 | Deduplicar candidatos novos | `scout-dedupe` | "dedupe", "possível duplicata", após uma campanha SCOUT |
-| Checar SSD / symlinks / ingest | `ssd-health` | "ssd", "mount check", "ingest drive", "backup iconocracia" |
+| Checar SSD / symlinks / ingest **(Linux-only)** | `ssd-health` | "ssd", "mount check", "ingest drive", "backup iconocracia" |
 | Citações ABNT (pré-commit) | `abnt-precommit` | "checar ABNT", antes de fechar capítulo |
 | Gestão de referências Zotero | `zotero-cite` | "citar", "zotero", inserir referência |
 | Gate de release público | `release-gate` | "release", "publicar corpus", antes de exportar para HF |
 | Fallback de download de arquivos | `archive-fallback` | invocada pelo modo SCOUT quando uma fonte falha |
 | Conserto de pipeline Pandoc | `pandoc-fix` | erro de compilação Pandoc/LaTeX |
+
+> Para o **umbrella** user-level que orquestra estes branches em modo agente, ver `iconocracy-agent` em `~/.claude/skills/` — descrita no `CLAUDE.md` do hub como "default umbrella" e não duplicada aqui porque vive fora do projeto.
 
 ## 2. Modos do agente (CLAUDE.md mode routing)
 
@@ -50,14 +52,14 @@ São o despacho primário da tese. Basta usar o gatilho:
 | `revisar`, `peer review` | REVISAR | Revisão multi-perspectiva |
 | `zwischenraum`, `painel comparativo` | ZWISCHENRAUM | Painéis comparativos warburguianos |
 
-## 3. Comandos ECC de engenharia (para os ~69 scripts em `tools/scripts/`)
+## 3. Comandos ECC de engenharia
 
-Acionáveis como slash-commands do plugin `ecc`:
+Slash-commands genéricos do plugin `everything-claude-code`. **Não** são wrappers dos ~69 scripts em `tools/scripts/` — para esses, rode `python tools/scripts/<nome>.py` direto.
 
 | Tarefa | Comando |
 |---|---|
 | Revisão de código Python | `/python-review`, `/code-review` |
-| Varredura de segurança | `/security-scan` |
+| Varredura da config Claude (`.claude/`, settings, hooks, MCP) | `/security-scan` |
 | Cobertura / qualidade de testes | `/test-coverage`, `/quality-gate` |
 | Limpeza de código morto | `/refactor-clean` |
 | Conserto de build | `/build-fix` |
@@ -67,20 +69,19 @@ Acionáveis como slash-commands do plugin `ecc`:
 
 ## 4. Ferramentas MCP de pesquisa
 
-| Tarefa | Ferramenta MCP |
-|---|---|
-| Verificar afirmações, achar artigos com Smart Citations | **scite** (`search_literature`, `search_grants`) |
-| Docs atualizadas de bibliotecas (pandas, jsonschema, etc.) | **Context7** (`resolve-library-id` → `query-docs`) |
-| Busca web ampla / descoberta | **Exa** (`web_search_exa`, `web_fetch_exa`) |
+| Tarefa | Ferramenta MCP | Estado |
+|---|---|---|
+| Busca web primária (extração de página, search com filtros) | **Firecrawl** (`mcp__firecrawl__firecrawl_search`, `_scrape`, `_extract`) | ativo |
+| Docs atualizadas de bibliotecas (pandas, jsonschema, etc.) | **Context7** (`resolve-library-id` → `query-docs`) | ativo |
+| Busca web acadêmica complementar | **Exa** (`web_search_exa`, `web_fetch_exa`) | ativo |
+| Verificar afirmações, Smart Citations | **scite** | **em setup** — falta configurar MCP (`grep scite ~/.claude/settings.json` → 0 hits) |
 
 ## 5. Descoberta
 
-- `/find-skills` — procurar uma skill por funcionalidade.
-- `/ecc-guide` — navegar agentes, skills, comandos e hooks do plugin ECC ao vivo.
-- O catálogo completo `.claude/skills/ecc/` (`deep-research`, `article-writing`, `eval-harness`,
-  `verification-loop`, `strategic-compact`, `market-research`, `scientific-thinking-literature-review`…)
-  existe no disco; nem toda entrada aparece como slash-command. Confirme a disponibilidade real
-  com `/find-skills` ou `/ecc-guide` antes de depender de uma delas.
+- `/find-skill` — procurar uma skill por funcionalidade.
+- `ls ~/.claude/plugins/cache/everything-claude-code/everything-claude-code/1.10.0/commands/` — lista os slash-commands do plugin instalados hoje.
+- `cat ~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/plugin.json` — audita versão atual do plugin antes de seguir este guia.
+- O catálogo de skills do plugin (`deep-research`, `article-writing`, `eval-harness`,
+  `verification-loop`, `strategic-compact`, `market-research`, …) é maior que o conjunto de slash-commands; muitas só são invocáveis via o tool `Skill`. Confirme com `/find-skill` antes de depender de uma delas.
 
-> **Host:** Linux (`/home/ana`, SSD em `/media/ana/SSD_DATA`). Caminhos `/Users/...` e `/Volumes/...`
-> em docs antigas são da era Mac e estão obsoletos.
+> **Host:** macOS primário (`/Users/ana/...`, conda env `iconocracy` em `/opt/homebrew/Caskroom/miniforge/base/envs/`). Linux secundário em outra máquina via SSD (`/home/ana`, `/media/ana/SSD_DATA`) — usado para ingest e operações de SSD. Skills marcadas **Linux-only** (ex.: `ssd-health`) não rodam em sessões macOS.


### PR DESCRIPTION
## Summary

Audit do `.claude/skills/ecc-iconocracy-guide/SKILL.md` (87 linhas) encontrou contradições verificáveis. Esta correção alinha o guia ao estado real do host e do plugin instalado.

## Mudanças

- **Host**: Linux único → macOS primário + Linux secundário (SSD/ingest). A nota anterior negava a sessão atual macOS apesar do conda env macOS-canônico em `/opt/homebrew/...` estar ativo.
- **Plugin**: `ecc v2.0.0-rc.1` (fictício) → `everything-claude-code v1.10.0` (versão instalada de fato em `~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/plugin.json`); esclarece que comandos vivem no cache do plugin, não em `.claude/commands/` deste repo (vazio).
- **MCPs**: adiciona Firecrawl (recomendada pelo `~/.claude/CLAUDE.md` global como busca web primária) e Exa; scite mantida com nota "**em setup**" pois `grep scite ~/.claude/settings.json` → 0 hits; nova coluna "Estado".
- **Comandos**:
  - `/security-scan` mantido (existe como skill em `~/.claude/plugins/cache/.../skills/security-scan/`), refraseado para refletir o que faz (scaneia config Claude, não código Python)
  - `/find-skills` (plural — typo) → `/find-skill` (singular — existe)
  - `/ecc-guide` removido (não existe)
  - Removido parêntese "(~69 scripts em tools/scripts/)" — comandos ECC não são wrappers desses scripts
- **Skills**: aviso `(Linux-only)` em `ssd-health` (a própria SKILL.md dela diz "Host: Linux Debian"); nota de rodapé sobre `iconocracy-agent` user-level como umbrella.
- **Descoberta**: troca slash-commands inexistentes por comandos shell de auditoria (`ls .../commands/`, `cat .../plugin.json`).

## Test plan

- [x] `cat ~/.claude/plugins/marketplaces/everything-claude-code/.claude-plugin/plugin.json` → confirma v1.10.0
- [x] `find ~/.claude/plugins/cache/everything-claude-code -name "<cmd>.md" -path "*/commands/*"` → confirma 11 slash-commands citados
- [x] `find ~/.claude/plugins/cache/.../skills/security-scan/SKILL.md` → existe
- [x] `find ~/.claude/skills/find-skill/SKILL.md` → existe
- [x] `uname -a` → Darwin (macOS confirmado)
- [x] Conda env `/opt/homebrew/Caskroom/miniforge/base/envs/iconocracy/bin/python3.12` → existe
- [x] Tabelas markdown coerentes; numeração das seções consistente
- [x] `description:` da frontmatter permanece (escopo da skill não mudou)

## Notas

- Diff: 21 add / 20 del / 41 linhas alteradas.
- Trabalho feito num worktree dedicado (`.claude/worktrees/fix-ecc-iconocracy-guide`) para não misturar com a reconciliação SSD em curso no branch `reconcile/ssd-scripts-2026-06-04`.
- Os arquivos `.planning/` ficaram untracked propositadamente (working notes da skill `planning-with-files`).