### PR TITLE
fix: normalize tag prefixes and rebuild tags_str in corpus-data.json

### DIFF
--- a/corpus/corpus-data.json
+++ b/corpus/corpus-data.json
@@ -11,7 +11,8 @@
     "citation_abnt": "S",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://artsandculture.google.com/asset/a-rep%C3%BAblica-manoel-lopes-rodrigues/AQGV9DG4UbJnBg",
@@ -25,7 +26,8 @@
     "citation_abnt": "R",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://artsandculture.google.com/asset/compromisso-constitucional-aur%C3%A9lio-de-figueiredo/jAEuPLgSyN91zA",
@@ -39,7 +41,8 @@
     "citation_abnt": "F",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://collections.vam.ac.uk/item/O762603/the-virtues-engraving-unknown/",
@@ -53,7 +56,8 @@
     "citation_abnt": "D",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://digi.ub.uni-heidelberg.de/diglit/ripa1603",
@@ -67,7 +71,8 @@
     "citation_abnt": "R",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://digi.ub.uni-heidelberg.de/diglit/ripa1603",
@@ -81,7 +86,8 @@
     "citation_abnt": "R",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://digi.ub.uni-heidelberg.de/diglit/ripa1613bd1",
@@ -95,7 +101,8 @@
     "citation_abnt": "R",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://digi.ub.uni-heidelberg.de/diglit/ripa1645",
@@ -109,7 +116,8 @@
     "citation_abnt": "R",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://digi.ub.uni-heidelberg.de/diglit/ripa1669",
@@ -123,7 +131,8 @@
     "citation_abnt": "R",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://eliseuvisconti.com.br/obra/a803/",
@@ -137,7 +146,8 @@
     "citation_abnt": "V",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://eliseuvisconti.com.br/obra/p332/",
@@ -151,7 +161,8 @@
     "citation_abnt": "V",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://mhn.acervos.museus.gov.br/acervo-museologico/pintura-alegorica-14/",
@@ -165,7 +176,8 @@
     "citation_abnt": "V",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://mnba.gov.br/",
@@ -179,7 +191,8 @@
     "citation_abnt": "V",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://museudarepublica.museus.gov.br/a-patria/",
@@ -193,7 +206,8 @@
     "citation_abnt": "B",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://museudarepublica.museus.gov.br/publicacoes/",
@@ -207,7 +221,8 @@
     "citation_abnt": "V",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://museudarepublica.museus.gov.br/wp-content/uploads/2019/05/republica-em-documentos_jardim_web.pdf",
@@ -221,7 +236,8 @@
     "citation_abnt": "K",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://open.smk.dk/artwork/image/KKS2296",
@@ -235,7 +251,8 @@
     "citation_abnt": "H",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://open.smk.dk/artwork/image/KKS6276",
@@ -249,7 +266,8 @@
     "citation_abnt": "F",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://open.smk.dk/artwork/image/KKS7314e",
@@ -263,7 +281,8 @@
     "citation_abnt": "G",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://open.smk.dk/artwork/image/KKSgb4097",
@@ -277,7 +296,8 @@
     "citation_abnt": "A",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://open.smk.dk/artwork/image/KKSgb4255",
@@ -291,7 +311,8 @@
     "citation_abnt": "A",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://open.smk.dk/artwork/image/KKSgb4863",
@@ -305,7 +326,8 @@
     "citation_abnt": "D",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://open.smk.dk/artwork/image/KKSgb5598",
@@ -319,7 +341,8 @@
     "citation_abnt": "C",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://open.smk.dk/artwork/image/KKSgb7580",
@@ -333,7 +356,8 @@
     "citation_abnt": "K",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://sammlungenonline.albertina.at/objects/546636/allegorische-figur-justitia-gerechtigkeit",
@@ -347,7 +371,8 @@
     "citation_abnt": "S",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://smb.museum-digital.de/object/140722",
@@ -361,7 +386,8 @@
     "citation_abnt": "L",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.britishmuseum.org/collection/object/P_1878-0713-2311",
@@ -375,7 +401,8 @@
     "citation_abnt": "G",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.digitale-sammlungen.de/en/details/bsb00028235",
@@ -389,7 +416,8 @@
     "citation_abnt": "C",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.digitale-sammlungen.de/en/details/bsb11216093",
@@ -403,7 +431,8 @@
     "citation_abnt": "R",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.digitale-sammlungen.de/en/details/bsb11255733",
@@ -417,7 +446,8 @@
     "citation_abnt": "A",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.digitale-sammlungen.de/en/details/bsb11255734",
@@ -431,7 +461,8 @@
     "citation_abnt": "A",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.emblems.arts.gla.ac.uk/alciato/books.php?id=A31a",
@@ -445,7 +476,8 @@
     "citation_abnt": "A",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/item/2003689297/",
@@ -459,7 +491,8 @@
     "citation_abnt": "B",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/item/2004665366/",
@@ -473,7 +506,8 @@
     "citation_abnt": "K",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/pictures/item/2003689287/",
@@ -487,7 +521,8 @@
     "citation_abnt": "I",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/pictures/item/2004665350/",
@@ -501,7 +536,8 @@
     "citation_abnt": "T",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.memoriachilena.gob.cl/602/w3-article-10118.html",
@@ -515,7 +551,8 @@
     "citation_abnt": "C",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.museodelprado.es/en/the-collection/art-work/truth-has-died/8c3b0257-606f-4d0b-af9e-73f05de59697",
@@ -529,7 +566,8 @@
     "citation_abnt": "G",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.portinari.org.br/acervo/obras/18112/a-justica-de-salomao",
@@ -543,7 +581,8 @@
     "citation_abnt": "P",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.portinari.org.br/en/archive/artwork/20463/gustavo-capanema-palace-economic-cycles",
@@ -557,7 +596,8 @@
     "citation_abnt": "P",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www.rijksmuseum.nl/en/collection/RP-P-1970-232",
@@ -571,7 +611,8 @@
     "citation_abnt": "L",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www2.senado.leg.br/bdsf/item/id/221763",
@@ -585,7 +626,8 @@
     "citation_abnt": "B",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "url": "https://www2.senado.leg.br/bdsf/item/id/227311",
@@ -599,7 +641,8 @@
     "citation_abnt": "P",
     "audit_flags": [
       "drive-import-2026-06-04"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "id": "AR-001",
@@ -771,20 +814,20 @@
     "citation_abnt": "STALLAERT, Joseph. Allégorie de la Justice. 1885–1888. 1 pintura (teto). Hôtel de Ville, Bruxelles. Disponível em: https://collections.heritage.brussels/fr/objects/36822.",
     "citation_chicago": "Stallaert, Joseph. Allégorie de la Justice. 1885–1888. Ceiling Painting. Hôtel de Ville, Brussels. Brussels Heritage Collections. https://collections.heritage.brussels/fr/objects/36822.",
     "tags": [
-      "Justice",
-      "Stallaert",
-      "Brussels",
-      "city hall",
-      "ceiling painting",
-      "civic virtue",
-      "Belgium"
+      "#Justice",
+      "#Stallaert",
+      "#Brussels",
+      "#city hall",
+      "#ceiling painting",
+      "#civic virtue",
+      "#Belgium"
     ],
     "year": 1885,
     "medium_norm": "Outro",
     "country_pt": "Bélgica",
     "period_norm": "Séc. XIX",
     "motif_str": "Justice, Charity, Foresight, civic virtue",
-    "tags_str": "Justice, Stallaert, Brussels, city hall, ceiling painting, civic virtue, Belgium",
+    "tags_str": "#Justice, #Stallaert, #Brussels, #city hall, #ceiling painting, #civic virtue, #Belgium",
     "regime": "normativo",
     "endurecimento_score": 1.4,
     "indicadores": {
@@ -851,20 +894,20 @@
     "citation_abnt": "POELAERT, Joseph. Palais de Justice de Bruxelles. 1866–1883. Complexo arquitetônico. Bruxelles. Disponível em: https://be-monumen.be/patrimoine-belge/poelaert-joseph/.",
     "citation_chicago": "Poelaert, Joseph. Palais de Justice de Bruxelles. 1866–1883. Architectural Complex. Brussels. https://be-monumen.be/patrimoine-belge/poelaert-joseph/.",
     "tags": [
-      "Justice",
-      "Poelaert",
-      "Brussels",
-      "courthouse",
-      "architecture",
-      "colonialism",
-      "Belgium"
+      "#Justice",
+      "#Poelaert",
+      "#Brussels",
+      "#courthouse",
+      "#architecture",
+      "#colonialism",
+      "#Belgium"
     ],
     "year": 1866,
     "medium_norm": "Outro",
     "country_pt": "Bélgica",
     "period_norm": "Séc. XIX",
     "motif_str": "Justice, classical allegory, civic architecture, colonialism",
-    "tags_str": "Justice, Poelaert, Brussels, courthouse, architecture, colonialism, Belgium",
+    "tags_str": "#Justice, #Poelaert, #Brussels, #courthouse, #architecture, #colonialism, #Belgium",
     "regime": "normativo",
     "endurecimento_score": 3.0,
     "indicadores": {
@@ -941,7 +984,8 @@
     ],
     "id": "BE-003",
     "country": "Belgium",
-    "support": "selo"
+    "support": "selo",
+    "tags_str": ""
   },
   {
     "url": "https://neptun.unamur.be/ark:/83449/0091bdf9fa",
@@ -972,7 +1016,8 @@
     ],
     "id": "BE-004",
     "country": "Belgium",
-    "support": "frontispício"
+    "support": "frontispício",
+    "tags_str": ""
   },
   {
     "id": "BE-5F-LEOPOLD-1832",
@@ -1058,20 +1103,20 @@
     "citation_abnt": "BANQUE DU CONGO BELGE. 100 Francs. 1912-1929. Papel-moeda. Disponível em: https://en.numista.com/258715. Acesso em: 11 abr. 2026.",
     "citation_chicago": "Banque du Congo Belge. 100 Francs. 1912–1929. Banknote. Numista. https://en.numista.com/258715.",
     "tags": [
-      "female allegory",
-      "La Belgique",
-      "colonial",
-      "Congo",
-      "military regime",
-      "racial visual contract",
-      "paternalism"
+      "#female allegory",
+      "#La Belgique",
+      "#colonial",
+      "#Congo",
+      "#military regime",
+      "#racial visual contract",
+      "#paternalism"
     ],
     "year": 1912,
     "medium_norm": "Papel-moeda",
     "country_pt": "Bélgica",
     "period_norm": "Período colonial (1912-1929)",
     "motif_str": "Allegory of Europe, La Belgique, colonial",
-    "tags_str": "female allegory, La Belgique, colonial, Congo, racial visual contract",
+    "tags_str": "#female allegory, #La Belgique, #colonial, #Congo, #military regime, #racial visual contract, #paternalism",
     "regime": "militar",
     "support": "papel-moeda",
     "in_scope": true,
@@ -1122,19 +1167,19 @@
     "citation_abnt": "BANQUE DU CONGO BELGE. 20 Francs. 1912-1937. Papel-moeda. Disponível em: https://en.numista.com/catalogue/note258714.html. Acesso em: 01 abr. 2026.",
     "citation_chicago": "Banque du Congo Belge. 20 Francs. 1912–1937. Banknote. Numista. https://en.numista.com/catalogue/note258714.html.",
     "tags": [
-      "female allegory",
-      "La Belgique",
-      "colonial",
-      "Congo",
-      "military regime",
-      "racial contract"
+      "#female allegory",
+      "#La Belgique",
+      "#colonial",
+      "#Congo",
+      "#military regime",
+      "#racial contract"
     ],
     "year": 1912,
     "medium_norm": "banknote",
     "country_pt": "Bélgica",
     "period_norm": "Congo Belga (1912-1937)",
     "motif_str": "La Belgique, allegory of Europe",
-    "tags_str": "female allegory, La Belgique, colonial, Congo, racial contract",
+    "tags_str": "#female allegory, #La Belgique, #colonial, #Congo, #military regime, #racial contract",
     "regime": "militar",
     "support": "papel-moeda",
     "in_scope": true,
@@ -1209,21 +1254,21 @@
     "citation_abnt": "VINÇOTTE, Thomas. Monument aux Pionniers Belges au Congo. 1911-1921. Escultura em calcário de Euville. Parc du Cinquantenaire, Bruxelles. Disponível em: https://en.wikipedia.org/wiki/Monument_to_the_Belgian_Pioneers_in_Congo. Acesso em: 11 abr. 2026.",
     "citation_chicago": "Vinçotte, Thomas. Monument aux Pionniers Belges au Congo. 1911–1921. Limestone sculpture. Parc du Cinquantenaire, Brussels.",
     "tags": [
-      "female allegory",
-      "La Belgique",
-      "colonial",
-      "Congo",
-      "military regime",
-      "racial visual contract",
-      "sculpture",
-      "Vinçotte"
+      "#female allegory",
+      "#La Belgique",
+      "#colonial",
+      "#Congo",
+      "#military regime",
+      "#racial visual contract",
+      "#sculpture",
+      "#Vinçotte"
     ],
     "year": 1911,
     "medium_norm": "Monumento",
     "country_pt": "Bélgica",
     "period_norm": "Período colonial (1911-1921)",
     "motif_str": "La Belgique, colonial, African woman",
-    "tags_str": "female allegory, La Belgique, colonial, Congo, racial visual contract",
+    "tags_str": "#female allegory, #La Belgique, #colonial, #Congo, #military regime, #racial visual contract, #sculpture, #Vinçotte",
     "regime": "militar",
     "support": "monumento/escultura",
     "in_scope": true,
@@ -1272,18 +1317,18 @@
     "citation_abnt": "MONNAIE ROYALE DE BELGIQUE. 5 Francs — 50 ans de Belgique. 1880. Moeda, prata. Design: Charles Wiener. Disponível em: https://en.numista.com/catalogue/pieces27258.html. Acesso em: 01 abr. 2026.",
     "citation_chicago": "Monnaie Royale de Belgique. 5 Francs — 50 ans de Belgique. 1880. Silver coin. Numista. https://en.numista.com/catalogue/pieces27258.html.",
     "tags": [
-      "female allegory",
-      "La Belgique",
-      "foundational regime",
-      "constitution",
-      "numismatics"
+      "#female allegory",
+      "#La Belgique",
+      "#foundational regime",
+      "#constitution",
+      "#numismatics"
     ],
     "year": 1880,
     "medium_norm": "coin",
     "country_pt": "Bélgica",
     "period_norm": "Reino da Bélgica (1880)",
     "motif_str": "La Belgique",
-    "tags_str": "female allegory, La Belgique, constitution, independence",
+    "tags_str": "#female allegory, #La Belgique, #foundational regime, #constitution, #numismatics",
     "regime": "fundacional",
     "support": "moeda",
     "in_scope": true,
@@ -1351,18 +1396,18 @@
     "citation_abnt": "BOSCAGLI, José. [Estátua feminina na abertura da amostra dos produtos do Rio Grande do Sul]. 1908. 1 fotografia, p&b, 16,5 x 23 cm. Museu Histórico Nacional. Disponível em: https://brasilianafotografica.bn.gov.br/brasiliana/handle/20.500.12156.1/11778.",
     "citation_chicago": "Boscagli, José. Estátua feminina na abertura da amostra dos produtos do Rio Grande do Sul. 1908. Photograph. Museu Histórico Nacional. Brasiliana Fotográfica. https://brasilianafotografica.bn.gov.br/brasiliana/handle/20.500.12156.1/11778.",
     "tags": [
-      "female allegory",
-      "exhibition",
-      "statue",
-      "Republic",
-      "Rio Grande do Sul"
+      "#female allegory",
+      "#exhibition",
+      "#statue",
+      "#Republic",
+      "#Rio Grande do Sul"
     ],
     "year": 1908,
     "medium_norm": "Fotografia",
     "country_pt": "Brasil",
     "period_norm": "República/Império (BR)",
     "motif_str": "Alegoria feminina, Exposição Nacional, Estátua",
-    "tags_str": "female allegory, exhibition, statue, Republic, Rio Grande do Sul",
+    "tags_str": "#female allegory, #exhibition, #statue, #Republic, #Rio Grande do Sul",
     "regime": "fundacional",
     "endurecimento_score": 1.4,
     "indicadores": {
@@ -1425,18 +1470,18 @@
     "citation_abnt": "MONUMENTO à República, Praça da República, Belém. 1940. 1 fotografia, p&b. In: Álbum de fotografias da visita de Getúlio Vargas a Belém. Museu da República/IBRAM. Disponível em: https://brasilianafotografica.bn.gov.br/brasiliana/handle/20.500.12156.1/13609.",
     "citation_chicago": "\"Detalhe do monumento à República, Praça da República, Belém.\" 1940. Photograph. In Álbum de fotografias da visita de Getúlio Vargas a Belém. Museu da República/IBRAM. Brasiliana Fotográfica. https://brasilianafotografica.bn.gov.br/brasiliana/handle/20.500.12156.1/13609.",
     "tags": [
-      "Republic monument",
-      "female allegory",
-      "Belém",
-      "Getúlio Vargas",
-      "Estado Novo"
+      "#Republic monument",
+      "#female allegory",
+      "#Belém",
+      "#Getúlio Vargas",
+      "#Estado Novo"
     ],
     "year": 1940,
     "medium_norm": "Fotografia",
     "country_pt": "Brasil",
     "period_norm": "Estado Novo",
     "motif_str": "República, Alegoria feminina, Monumento, Bandeira",
-    "tags_str": "Republic monument, female allegory, Belém, Getúlio Vargas, Estado Novo",
+    "tags_str": "#Republic monument, #female allegory, #Belém, #Getúlio Vargas, #Estado Novo",
     "regime": "normativo",
     "endurecimento_score": 1.7,
     "indicadores": {
@@ -1500,18 +1545,18 @@
     "citation_abnt": "MONUMENTO à República, Praça da República, Belém. 1940. 1 fotografia, p&b. In: Álbum de fotografias da visita de Getúlio Vargas a Belém. Museu da República/IBRAM. Disponível em: https://brasilianafotografica.bn.gov.br/brasiliana/handle/20.500.12156.1/13611.",
     "citation_chicago": "\"Monumento à República, Praça da República, Belém.\" 1940. Photograph. In Álbum de fotografias da visita de Getúlio Vargas a Belém. Museu da República/IBRAM. Brasiliana Fotográfica. https://brasilianafotografica.bn.gov.br/brasiliana/handle/20.500.12156.1/13611.",
     "tags": [
-      "Republic monument",
-      "female allegory",
-      "Belém",
-      "column",
-      "Estado Novo"
+      "#Republic monument",
+      "#female allegory",
+      "#Belém",
+      "#column",
+      "#Estado Novo"
     ],
     "year": 1940,
     "medium_norm": "Fotografia",
     "country_pt": "Brasil",
     "period_norm": "Estado Novo",
     "motif_str": "República, Alegoria feminina, Monumento, Coluna",
-    "tags_str": "Republic monument, female allegory, Belém, column, Estado Novo",
+    "tags_str": "#Republic monument, #female allegory, #Belém, #column, #Estado Novo",
     "regime": "normativo",
     "endurecimento_score": 2.1,
     "indicadores": {
@@ -1575,18 +1620,18 @@
     "citation_abnt": "SANTOS, Guilherme. Jardim do Campo da Aclamação, atual Campo de Santana; estátuas do Outono e da Primavera. c. 1925. 1 fotografia, gelatina/prata, sépia, 4,5 x 11 cm. Instituto Moreira Salles. Disponível em: https://brasilianafotografica.bn.gov.br/brasiliana/handle/20.500.12156.1/11529.",
     "citation_chicago": "Santos, Guilherme. Jardim do Campo da Aclamação, atual Campo de Santana; estátuas do Outono e da Primavera. c. 1925. Photograph. Instituto Moreira Salles. Brasiliana Fotográfica. https://brasilianafotografica.bn.gov.br/brasiliana/handle/20.500.12156.1/11529.",
     "tags": [
-      "female allegory",
-      "seasons",
-      "sculpture",
-      "Campo de Santana",
-      "Rio de Janeiro"
+      "#female allegory",
+      "#seasons",
+      "#sculpture",
+      "#Campo de Santana",
+      "#Rio de Janeiro"
     ],
     "year": 1925,
     "medium_norm": "Fotografia",
     "country_pt": "Brasil",
     "period_norm": "República/Império (BR)",
     "motif_str": "Alegoria feminina, Estações, Escultura, Jardim público",
-    "tags_str": "female allegory, seasons, sculpture, Campo de Santana, Rio de Janeiro",
+    "tags_str": "#female allegory, #seasons, #sculpture, #Campo de Santana, #Rio de Janeiro",
     "regime": "fundacional",
     "endurecimento_score": 0.7,
     "indicadores": {
@@ -1650,19 +1695,19 @@
     "citation_abnt": "VILLARES, Décio. Alegoria da República. c. 1900. 1 pintura, óleo sobre tela, 97 x 77 cm. Museu Histórico Nacional. Disponível em: https://archive.nyu.edu/handle/2451/61396.",
     "citation_chicago": "Villares, Décio. Alegoria da República. c. 1900. Oil on canvas, 97 × 77 cm. Museu Histórico Nacional. NYU Faculty Digital Archive. https://archive.nyu.edu/handle/2451/61396.",
     "tags": [
-      "Republic",
-      "female allegory",
-      "positivism",
-      "Phrygian cap",
-      "Ordem e Progresso",
-      "painting"
+      "#Republic",
+      "#female allegory",
+      "#positivism",
+      "#Phrygian cap",
+      "#Ordem e Progresso",
+      "#painting"
     ],
     "year": 1900,
     "medium_norm": "Pintura/Desenho",
     "country_pt": "Brasil",
     "period_norm": "República/Império (BR)",
     "motif_str": "República, Alegoria feminina, Positivismo, Barrete frígio",
-    "tags_str": "Republic, female allegory, positivism, Phrygian cap, Ordem e Progresso, painting",
+    "tags_str": "#Republic, #female allegory, #positivism, #Phrygian cap, #Ordem e Progresso, #painting",
     "regime": "fundacional",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -1730,18 +1775,18 @@
     "citation_abnt": "CHAMBELLAND, Carlos. Alegoria da República. 1922. 1 pintura, óleo sobre tela, 202 x 152 cm. Museu Histórico Nacional. Disponível em: https://brasiliana.museus.gov.br/acervos/alegoria-da-republica/.",
     "citation_chicago": "Chambelland, Carlos. Alegoria da República. 1922. Oil on canvas, 202 × 152 cm. Museu Histórico Nacional. Brasiliana Museus. https://brasiliana.museus.gov.br/acervos/alegoria-da-republica/.",
     "tags": [
-      "Republic",
-      "female allegory",
-      "centennial",
-      "painting",
-      "angel"
+      "#Republic",
+      "#female allegory",
+      "#centennial",
+      "#painting",
+      "#angel"
     ],
     "year": 1922,
     "medium_norm": "Pintura/Desenho",
     "country_pt": "Brasil",
     "period_norm": "República/Império (BR)",
     "motif_str": "República, Alegoria feminina, Centenário, Anjo",
-    "tags_str": "Republic, female allegory, centennial, painting, angel",
+    "tags_str": "#Republic, #female allegory, #centennial, #painting, #angel",
     "regime": "fundacional",
     "endurecimento_score": 0.7,
     "indicadores": {
@@ -1808,19 +1853,19 @@
     "citation_abnt": "AS ESTÁTUAS fallando. Brasil, n. 60, 1827. p. [s.n.]. Disponível em: http://memoria.bn.br/pdf/702390/per702390_1827_00060.pdf.",
     "citation_chicago": "\"As Estátuas Fallando.\" Brasil, no. 60 (1827). Hemeroteca Digital Brasileira. http://memoria.bn.br/pdf/702390/per702390_1827_00060.pdf.",
     "tags": [
-      "Justice",
-      "speaking statues",
-      "allegory",
-      "periodical",
-      "Empire",
-      "Truth"
+      "#Justice",
+      "#speaking statues",
+      "#allegory",
+      "#periodical",
+      "#Empire",
+      "#Truth"
     ],
     "year": 1827,
     "medium_norm": "Outro",
     "country_pt": "Brasil",
     "period_norm": "República/Império (BR)",
     "motif_str": "Justiça, Estátua falante, Diálogo alegórico, Verdade",
-    "tags_str": "Justice, speaking statues, allegory, periodical, Empire, Truth",
+    "tags_str": "#Justice, #speaking statues, #allegory, #periodical, #Empire, #Truth",
     "regime": "fundacional",
     "endurecimento_score": 2.3,
     "indicadores": {
@@ -1887,18 +1932,18 @@
     "citation_abnt": "ALMANAK Laemmert. Rio de Janeiro, 1929. ed. A00085, p. 542. Disponível em: http://memoria.bn.br/docreader/webindex/WIPagina/313394/101306.",
     "citation_chicago": "Almanak Laemmert. Rio de Janeiro, 1929, ed. A00085, p. 542. Hemeroteca Digital Brasileira. http://memoria.bn.br/docreader/webindex/WIPagina/313394/101306.",
     "tags": [
-      "Justice",
-      "statue",
-      "French sculptor",
-      "public space",
-      "imported allegory"
+      "#Justice",
+      "#statue",
+      "#French sculptor",
+      "#public space",
+      "#imported allegory"
     ],
     "year": 1872,
     "medium_norm": "Outro",
     "country_pt": "Brasil",
     "period_norm": "República/Império (BR)",
     "motif_str": "Justiça, Estátua, Escultor francês, Praça pública",
-    "tags_str": "Justice, statue, French sculptor, public space, imported allegory",
+    "tags_str": "#Justice, #statue, #French sculptor, #public space, #imported allegory",
     "regime": "fundacional",
     "endurecimento_score": 2.5,
     "indicadores": {
@@ -1967,21 +2012,21 @@
     "citation_abnt": "CESCHIATTI, Alfredo. A Justiça. 1961. 1 escultura em granito. Supremo Tribunal Federal, Praça dos Três Poderes, Brasília. Disponível em: https://acervos.ims.com.br/index.php/Detail/objects/18758.",
     "citation_chicago": "Ceschiatti, Alfredo. A Justiça. 1961. Granite Sculpture. Supremo Tribunal Federal, Brasília. Instituto Moreira Salles. https://acervos.ims.com.br/index.php/Detail/objects/18758.",
     "tags": [
-      "Justiça",
-      "Ceschiatti",
-      "STF",
-      "Brasília",
-      "Niemeyer",
-      "modernism",
-      "granite",
-      "January 8"
+      "#Justiça",
+      "#Ceschiatti",
+      "#STF",
+      "#Brasília",
+      "#Niemeyer",
+      "#modernism",
+      "#granite",
+      "#January 8"
     ],
     "year": 1961,
     "medium_norm": "Outro",
     "country_pt": "Brasil",
     "period_norm": "Séc. XX",
     "motif_str": "Justiça, Justice, Themis, blindfold, sword, modernism",
-    "tags_str": "Justiça, Ceschiatti, STF, Brasília, Niemeyer, modernism, granite, January 8",
+    "tags_str": "#Justiça, #Ceschiatti, #STF, #Brasília, #Niemeyer, #modernism, #granite, #January 8",
     "regime": "militar",
     "endurecimento_score": 2.2,
     "indicadores": {
@@ -2053,19 +2098,19 @@
     "citation_abnt": "VISCONTI, Eliseu. Alegoria (Biblioteca Nacional). 1910. 1 painel decorativo, óleo. Fundação Biblioteca Nacional, Rio de Janeiro. Disponível em: https://eliseuvisconti.com.br/obra/d702/.",
     "citation_chicago": "Visconti, Eliseu. Alegoria (Biblioteca Nacional, Rio de Janeiro). 1910. Decorative Panel. Fundação Biblioteca Nacional, Rio de Janeiro. Eliseu Visconti Project. https://eliseuvisconti.com.br/obra/d702/.",
     "tags": [
-      "allegory",
-      "Visconti",
-      "impressionism",
-      "Biblioteca Nacional",
-      "Rio de Janeiro",
-      "Republic"
+      "#allegory",
+      "#Visconti",
+      "#impressionism",
+      "#Biblioteca Nacional",
+      "#Rio de Janeiro",
+      "#Republic"
     ],
     "year": 1910,
     "medium_norm": "Pintura/Desenho",
     "country_pt": "Brasil",
     "period_norm": "República/Império (BR)",
     "motif_str": "Alegoria feminina, Republic, impressionism",
-    "tags_str": "allegory, Visconti, impressionism, Biblioteca Nacional, Rio de Janeiro, Republic",
+    "tags_str": "#allegory, #Visconti, #impressionism, #Biblioteca Nacional, #Rio de Janeiro, #Republic",
     "regime": "fundacional",
     "endurecimento_score": 0.5,
     "indicadores": {
@@ -2135,20 +2180,20 @@
     "citation_abnt": "LOPES RODRIGUES, Manuel. Alegoria da República (Estados Unidos do Brasil). 1896. 1 pintura, óleo sobre tela. Museu de Arte da Bahia, Salvador.",
     "citation_chicago": "Lopes Rodrigues, Manuel. Alegoria da República (Estados Unidos do Brasil). 1896. Oil on canvas. Museu de Arte da Bahia, Salvador.",
     "tags": [
-      "female allegory",
-      "Republic",
-      "throne",
-      "sword",
-      "Phrygian cap",
-      "national colors",
-      "Brazil"
+      "#female allegory",
+      "#Republic",
+      "#throne",
+      "#sword",
+      "#Phrygian cap",
+      "#national colors",
+      "#Brazil"
     ],
     "year": 1896,
     "medium_norm": "Pintura",
     "country_pt": "Brasil",
     "period_norm": "República/Império (BR)",
     "motif_str": "Alegoria feminina, República, Trono",
-    "tags_str": "female allegory, Republic, throne, sword, Phrygian cap, national colors, Brazil",
+    "tags_str": "#female allegory, #Republic, #throne, #sword, #Phrygian cap, #national colors, #Brazil",
     "regime": "fundacional",
     "endurecimento_score": 1.8,
     "indicadores": {
@@ -2221,7 +2266,8 @@
     ],
     "id": "BR-017",
     "country": "Brazil",
-    "support": "frontispício"
+    "support": "frontispício",
+    "tags_str": ""
   },
   {
     "url": "http://memoria.bn.br/DocReader/116300/4346",
@@ -2252,7 +2298,8 @@
     ],
     "id": "BR-018",
     "country": "Brazil",
-    "support": "texto"
+    "support": "texto",
+    "tags_str": ""
   },
   {
     "url": "http://memoria.bn.br/docreader/116300/4346",
@@ -2283,7 +2330,8 @@
     ],
     "id": "BR-019",
     "country": "Brazil",
-    "support": "texto"
+    "support": "texto",
+    "tags_str": ""
   },
   {
     "url": "https://archive.nyu.edu/handle/2451/61367",
@@ -2314,7 +2362,8 @@
     ],
     "id": "BR-020",
     "country": "Brazil",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://artsandculture.google.com/story/cole%C3%A7%C3%A3o-lopes-rodrigues-museu-de-arte-da-bahia/kAXx2Zki-R24Lw",
@@ -2333,7 +2382,8 @@
     ],
     "id": "BR-021",
     "country": "Brazil",
-    "support": "pintura"
+    "support": "pintura",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/File:Braziliana_ou_Brasiliana(Brazil_National_personification)_by_J_B_Debret.jpg",
@@ -2364,7 +2414,8 @@
     ],
     "id": "BR-022",
     "country": "Brazil",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/File:Capa_da_Revista_Illustrada,_n.%C2%BA_566_(1889).png",
@@ -2383,7 +2434,8 @@
     ],
     "id": "BR-023",
     "country": "Brazil",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/File:EliseuVisconti-A813-A_Lei_%C3%81urea_%E2%80%93_Projeto_para_selo_integrante_da_cole%C3%A7%C3%A3o_vencedora_do_Concurso_dos_Correios_de_1904.jpg",
@@ -2414,7 +2466,8 @@
     ],
     "id": "BR-024",
     "country": "Brazil",
-    "support": "selo"
+    "support": "selo",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/File:EliseuVisconti-A814-A_Mulher_Brasileira_%E2%80%93_Projeto_para_selo_integrante_da_cole%C3%A7%C3%A3o_vencedora_do_Concurso_dos_Correios_de_1904.jpg",
@@ -2445,7 +2498,8 @@
     ],
     "id": "BR-025",
     "country": "Brazil",
-    "support": "selo"
+    "support": "selo",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/File:Pal%C3%A1cio_Anchieta_Escadaria_B%C3%A1rbara_Monteiro_Lindenberg_Vit%C3%B3ria_Esp%C3%ADrito_Santo_2019-4708.jpg",
@@ -2476,7 +2530,8 @@
     ],
     "id": "BR-026",
     "country": "Brazil",
-    "support": "monumento/escultura"
+    "support": "monumento/escultura",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/File:Republica_no_brasil.jpg",
@@ -2495,7 +2550,8 @@
     ],
     "id": "BR-027",
     "country": "Brazil",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/File:Stamp_of_Brazil_-_1891_-_Colnect_811739_-_Liberty_thesouro_nacional.jpeg",
@@ -2526,7 +2582,8 @@
     ],
     "id": "BR-028",
     "country": "Brazil",
-    "support": "selo"
+    "support": "selo",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/note222815.html",
@@ -2557,7 +2614,8 @@
     ],
     "id": "BR-029",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces14481.html",
@@ -2588,7 +2646,8 @@
     ],
     "id": "BR-030",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces36131.html",
@@ -2619,7 +2678,8 @@
     ],
     "id": "BR-031",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces36132.html",
@@ -2650,7 +2710,8 @@
     ],
     "id": "BR-032",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces36319.html",
@@ -2681,7 +2742,8 @@
     ],
     "id": "BR-033",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces4333.html",
@@ -2712,7 +2774,8 @@
     ],
     "id": "BR-034",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces6440.html",
@@ -2743,7 +2806,8 @@
     ],
     "id": "BR-035",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces6773.html",
@@ -2774,7 +2838,8 @@
     ],
     "id": "BR-036",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://hemerotecadigital.bn.br/acervo-digital/o-mequetrefe/702390",
@@ -2805,7 +2870,8 @@
     ],
     "id": "BR-037",
     "country": "Brazil",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://hemerotecadigital.bn.br/acervo-digital/revista-illustrada/332747",
@@ -2836,7 +2902,8 @@
     ],
     "id": "BR-038",
     "country": "Brazil",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://iconocracy.corpus/vault/03075694-0e68-5b33-afb2-3c60687f498b",
@@ -2867,7 +2934,8 @@
     ],
     "id": "BR-039",
     "country": "Brazil",
-    "support": "selo"
+    "support": "selo",
+    "tags_str": ""
   },
   {
     "url": "https://memoria.bn.br/DocReader/Hotpage/HotpageBN.aspx?bib=094078&pagfis=4&url=http://memoria.bn.br/docreader",
@@ -2898,7 +2966,8 @@
     ],
     "id": "BR-040",
     "country": "Brazil",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://mhn.museus.gov.br/estudo-de-decio-villares-volta-ao-circuito-expositivo-do-mhn/",
@@ -2917,7 +2986,8 @@
     ],
     "id": "BR-041",
     "country": "Brazil",
-    "support": "pintura"
+    "support": "pintura",
+    "tags_str": ""
   },
   {
     "url": "https://museudarepublica.museus.gov.br/wp-content/uploads/2013/10/republica-em-documentos_colecao-de-alegorias_web.pdf",
@@ -2949,7 +3019,8 @@
     ],
     "id": "BR-042",
     "country": "Brazil",
-    "support": "monumento/escultura"
+    "support": "monumento/escultura",
+    "tags_str": ""
   },
   {
     "url": "https://www.brasilianaiconografica.art.br/obras/12345/medalha-da-proclamacao-da-republica",
@@ -2980,7 +3051,8 @@
     ],
     "id": "BR-043",
     "country": "Brazil",
-    "support": "medalha"
+    "support": "medalha",
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/item/2020719663/",
@@ -2999,7 +3071,8 @@
     ],
     "id": "BR-044",
     "country": "Brazil",
-    "support": "texto"
+    "support": "texto",
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/item/2024771974/",
@@ -3018,7 +3091,8 @@
     ],
     "id": "BR-045",
     "country": "Brazil",
-    "support": "texto"
+    "support": "texto",
+    "tags_str": ""
   },
   {
     "url": "https://www.worldbanknotescoins.com/2015/02/brazil-50-mil-reis-banknote-1890-banco-do-brazil.html",
@@ -3051,7 +3125,8 @@
     ],
     "id": "BR-046",
     "country": "Brazil",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "id": "BR-1000R-1906",
@@ -3188,19 +3263,19 @@
     "citation_abnt": "CASA DA MOEDA DO BRASIL. 2000 Réis — Efígie da República. 1906-1912. Moeda, prata .900, 20 g. Disponível em: https://en.numista.com/catalogue/pieces14489.html. Acesso em: 01 abr. 2026.",
     "citation_chicago": "Casa da Moeda do Brasil. 2000 Réis — Efígie da República. 1906–1912. Silver coin. Numista. https://en.numista.com/catalogue/pieces14489.html.",
     "tags": [
-      "female allegory",
-      "A República",
-      "Phrygian cap",
-      "normative regime",
-      "numismatics",
-      "positivism"
+      "#female allegory",
+      "#A República",
+      "#Phrygian cap",
+      "#normative regime",
+      "#numismatics",
+      "#positivism"
     ],
     "year": 1907,
     "medium_norm": "coin",
     "country_pt": "Brasil",
     "period_norm": "República Velha (1906-1912)",
     "motif_str": "A República",
-    "tags_str": "female allegory, A República, Phrygian cap, positivism",
+    "tags_str": "#female allegory, #A República, #Phrygian cap, #normative regime, #numismatics, #positivism",
     "regime": "normativo",
     "support": "moeda",
     "in_scope": true,
@@ -3326,20 +3401,20 @@
     "citation_abnt": "GIENG, Hans. Gerechtigkeitsbrunnen mit Plastik der Justitia. 1543. 1 escultura, fonte. Bern, Gerechtigkeitsgasse. Bildarchiv Foto Marburg. Disponível em: https://www.bildindex.de/document/que20183316.",
     "citation_chicago": "Gieng, Hans. Gerechtigkeitsbrunnen mit Plastik der Justitia. 1543. Sculpture. Bern, Gerechtigkeitsgasse. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/que20183316.",
     "tags": [
-      "Justitia",
-      "fountain",
-      "blindfold",
-      "Renaissance",
-      "Bern",
-      "Switzerland",
-      "legal iconography"
+      "#Justitia",
+      "#fountain",
+      "#blindfold",
+      "#Renaissance",
+      "#Bern",
+      "#Switzerland",
+      "#legal iconography"
     ],
     "year": 1543,
     "medium_norm": "Outro",
     "country_pt": "Suíça",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, blindfold, sword, scales",
-    "tags_str": "Justitia, fountain, blindfold, Renaissance, Bern, Switzerland, legal iconography",
+    "tags_str": "#Justitia, #fountain, #blindfold, #Renaissance, #Bern, #Switzerland, #legal iconography",
     "regime": "fundacional",
     "endurecimento_score": 0.7,
     "indicadores": {
@@ -3401,20 +3476,20 @@
     "citation_abnt": "JUSTITIA (cabeça em mármore da Porta di Capua). 1239–1240. 1 escultura em mármore. Museo Provinciale Campano, Capua. Disponível em: https://www.bildindex.de/document/obj08148970.",
     "citation_chicago": "Justitia (Marble Head from Porta di Capua). 1239–1240. Marble Sculpture. Museo Provinciale Campano, Capua. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj08148970.",
     "tags": [
-      "Justitia",
-      "medieval",
-      "Frederick II",
-      "Hohenstaufen",
-      "Capua",
-      "marble",
-      "legal iconography"
+      "#Justitia",
+      "#medieval",
+      "#Frederick II",
+      "#Hohenstaufen",
+      "#Capua",
+      "#marble",
+      "#legal iconography"
     ],
     "year": 1239,
     "medium_norm": "Outro",
     "country_pt": "Itália",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, Frederick II",
-    "tags_str": "Justitia, medieval, Frederick II, Hohenstaufen, Capua, marble, legal iconography",
+    "tags_str": "#Justitia, #medieval, #Frederick II, #Hohenstaufen, #Capua, #marble, #legal iconography",
     "regime": "fundacional",
     "endurecimento_score": 2.4,
     "indicadores": {
@@ -3476,19 +3551,19 @@
     "citation_abnt": "RODE, Bernhard. Die Göttin der Gerechtigkeit nach dem heutigen Geschmacke. Século XVIII. 1 gravura. Kupferstich-Kabinett Dresden. Disponível em: https://www.bildindex.de/document/obj30110594.",
     "citation_chicago": "Rode, Bernhard. Die Göttin der Gerechtigkeit nach dem heutigen Geschmacke. 18th Century. Engraving. Kupferstich-Kabinett Dresden. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj30110594.",
     "tags": [
-      "Justitia",
-      "satire",
-      "Enlightenment",
-      "engraving",
-      "Dresden",
-      "political commentary"
+      "#Justitia",
+      "#satire",
+      "#Enlightenment",
+      "#engraving",
+      "#Dresden",
+      "#political commentary"
     ],
     "year": 1750,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Alemanha",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Justitia, Justice, satire",
-    "tags_str": "Justitia, satire, Enlightenment, engraving, Dresden, political commentary",
+    "tags_str": "#Justitia, #satire, #Enlightenment, #engraving, #Dresden, #political commentary",
     "regime": "fundacional",
     "endurecimento_score": 0.8,
     "indicadores": {
@@ -3546,19 +3621,19 @@
     "citation_abnt": "JUSTITIA an der Rathausuhr, Esslingen am Neckar. 1589. 1 escultura. Altes Rathaus, Esslingen. Disponível em: https://www.bildindex.de/document/obj20553978.",
     "citation_chicago": "Justitia an der Rathausuhr. 1589. Sculpture. Altes Rathaus, Esslingen am Neckar. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj20553978.",
     "tags": [
-      "Justitia",
-      "town hall",
-      "clock",
-      "civic architecture",
-      "Renaissance",
-      "Esslingen"
+      "#Justitia",
+      "#town hall",
+      "#clock",
+      "#civic architecture",
+      "#Renaissance",
+      "#Esslingen"
     ],
     "year": 1589,
     "medium_norm": "Outro",
     "country_pt": "Alemanha",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, civic architecture",
-    "tags_str": "Justitia, town hall, clock, civic architecture, Renaissance, Esslingen",
+    "tags_str": "#Justitia, #town hall, #clock, #civic architecture, #Renaissance, #Esslingen",
     "regime": "fundacional",
     "endurecimento_score": 1.8,
     "indicadores": {
@@ -3616,19 +3691,19 @@
     "citation_abnt": "PERSONIFIKATION der Gerechtigkeit (Barocke Holzdecke). 1660–1780. 1 medalhão em teto de madeira. Lüneburg, Große Bäckerstraße 12. Disponível em: https://www.bildindex.de/document/obj20672587.",
     "citation_chicago": "Personifikation der Gerechtigkeit (Baroque Wooden Ceiling). 1660–1780. Wooden Ceiling Medallion. Lüneburg. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj20672587.",
     "tags": [
-      "Justitia",
-      "Baroque",
-      "ceiling",
-      "domestic space",
-      "Lüneburg",
-      "wooden ceiling"
+      "#Justitia",
+      "#Baroque",
+      "#ceiling",
+      "#domestic space",
+      "#Lüneburg",
+      "#wooden ceiling"
     ],
     "year": 1660,
     "medium_norm": "Outro",
     "country_pt": "Alemanha",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Justitia, Justice, domestic allegory",
-    "tags_str": "Justitia, Baroque, ceiling, domestic space, Lüneburg, wooden ceiling",
+    "tags_str": "#Justitia, #Baroque, #ceiling, #domestic space, #Lüneburg, #wooden ceiling",
     "regime": "fundacional",
     "endurecimento_score": 1.3,
     "indicadores": {
@@ -3685,19 +3760,19 @@
     "citation_abnt": "RAIMONDI, Marcantonio. Allegorie: Justitia. Início do século XVI. 1 gravura. Bibliotheca Hertziana, Roma. Disponível em: https://www.bildindex.de/document/obj08158050.",
     "citation_chicago": "Raimondi, Marcantonio. Allegorie: Justitia. Early 16th Century. Engraving. Bibliotheca Hertziana, Rome. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj08158050.",
     "tags": [
-      "Justitia",
-      "Renaissance",
-      "engraving",
-      "Raphael circle",
-      "Italian",
-      "print"
+      "#Justitia",
+      "#Renaissance",
+      "#engraving",
+      "#Raphael circle",
+      "#Italian",
+      "#print"
     ],
     "year": 1550,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Itália",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice",
-    "tags_str": "Justitia, Renaissance, engraving, Raphael circle, Italian, print",
+    "tags_str": "#Justitia, #Renaissance, #engraving, #Raphael circle, #Italian, #print",
     "regime": "fundacional",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -3760,19 +3835,19 @@
     "citation_abnt": "ALLEGORIE der Justitia und eine weitere weibliche Allegorie. 1501–1550. 1 desenho/gravura. Museo Civico, Bassano del Grappa. Disponível em: https://www.bildindex.de/document/obj08108743.",
     "citation_chicago": "Allegorie der Justitia und eine weitere weibliche Allegorie. 1501–1550. Drawing/Print. Museo Civico, Bassano del Grappa. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj08108743.",
     "tags": [
-      "Justitia",
-      "cardinal virtues",
-      "Renaissance",
-      "Italian",
-      "drawing",
-      "Prudence"
+      "#Justitia",
+      "#cardinal virtues",
+      "#Renaissance",
+      "#Italian",
+      "#drawing",
+      "#Prudence"
     ],
     "year": 1501,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Itália",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, cardinal virtues, Prudence",
-    "tags_str": "Justitia, cardinal virtues, Renaissance, Italian, drawing, Prudence",
+    "tags_str": "#Justitia, #cardinal virtues, #Renaissance, #Italian, #drawing, #Prudence",
     "regime": "fundacional",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -3834,18 +3909,18 @@
     "citation_abnt": "JUSTITIA (Stiftsherrenhaus, Hameln). c. 1558. 1 escultura arquitetônica. Hameln, Osterstraße 8. Disponível em: https://www.bildindex.de/document/obj20608421.",
     "citation_chicago": "Justitia (Stiftsherrenhaus, Hameln). c. 1558. Architectural Sculpture. Hameln. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj20608421.",
     "tags": [
-      "Justitia",
-      "Weser Renaissance",
-      "architectural sculpture",
-      "Hameln",
-      "civic building"
+      "#Justitia",
+      "#Weser Renaissance",
+      "#architectural sculpture",
+      "#Hameln",
+      "#civic building"
     ],
     "year": 1558,
     "medium_norm": "Outro",
     "country_pt": "Alemanha",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, Weser Renaissance",
-    "tags_str": "Justitia, Weser Renaissance, architectural sculpture, Hameln, civic building",
+    "tags_str": "#Justitia, #Weser Renaissance, #architectural sculpture, #Hameln, #civic building",
     "regime": "fundacional",
     "endurecimento_score": 1.7,
     "indicadores": {
@@ -3904,20 +3979,20 @@
     "citation_abnt": "RELIEF: Gerechtigkeit und Eintracht. 1596–1605. 1 relevo. Altes Rathaus, Bremen. Disponível em: https://www.bildindex.de/document/obj20459153.",
     "citation_chicago": "Relief: Gerechtigkeit und Eintracht (Bremen Rathaus). 1596–1605. Relief Sculpture. Bremen Old Town Hall. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj20459153.",
     "tags": [
-      "Justitia",
-      "Concordia",
-      "relief",
-      "civic virtue",
-      "Bremen",
-      "town hall",
-      "Renaissance"
+      "#Justitia",
+      "#Concordia",
+      "#relief",
+      "#civic virtue",
+      "#Bremen",
+      "#town hall",
+      "#Renaissance"
     ],
     "year": 1596,
     "medium_norm": "Outro",
     "country_pt": "Alemanha",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, Concordia, civic virtue",
-    "tags_str": "Justitia, Concordia, relief, civic virtue, Bremen, town hall, Renaissance",
+    "tags_str": "#Justitia, #Concordia, #relief, #civic virtue, #Bremen, #town hall, #Renaissance",
     "regime": "fundacional",
     "endurecimento_score": 1.7,
     "indicadores": {
@@ -3975,19 +4050,19 @@
     "citation_abnt": "WENZINGER, Christian. Allegorie der Jus Civile. 1752. 1 escultura. Sankt Peter, Benedictine Abbey. Disponível em: https://www.bildindex.de/document/obj20677105.",
     "citation_chicago": "Wenzinger, Christian. Allegorie der Jus Civile. 1752. Sculpture. Sankt Peter, Benedictine Abbey. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj20677105.",
     "tags": [
-      "Justitia",
-      "civil law",
-      "Baroque",
-      "Benedictine",
-      "ecclesiastical",
-      "secular law"
+      "#Justitia",
+      "#civil law",
+      "#Baroque",
+      "#Benedictine",
+      "#ecclesiastical",
+      "#secular law"
     ],
     "year": 1752,
     "medium_norm": "Outro",
     "country_pt": "Alemanha",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Justitia, Jus Civile, civil law",
-    "tags_str": "Justitia, civil law, Baroque, Benedictine, ecclesiastical, secular law",
+    "tags_str": "#Justitia, #civil law, #Baroque, #Benedictine, #ecclesiastical, #secular law",
     "regime": "fundacional",
     "endurecimento_score": 1.3,
     "indicadores": {
@@ -4045,19 +4120,19 @@
     "citation_abnt": "KAMIN mit Justitia (Leipzig, Altes Rathaus). c. 1610. 1 decoração de lareira. Altes Rathaus, Leipzig. Disponível em: https://www.bildindex.de/document/obj30143134.",
     "citation_chicago": "Kamin mit Justitia. c. 1610. Fireplace Decoration. Altes Rathaus, Leipzig. Bildindex der Kunst und Architektur. https://www.bildindex.de/document/obj30143134.",
     "tags": [
-      "Justitia",
-      "fireplace",
-      "civic interior",
-      "Leipzig",
-      "town hall",
-      "Early Modern"
+      "#Justitia",
+      "#fireplace",
+      "#civic interior",
+      "#Leipzig",
+      "#town hall",
+      "#Early Modern"
     ],
     "year": 1610,
     "medium_norm": "Outro",
     "country_pt": "Alemanha",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, civic interior",
-    "tags_str": "Justitia, fireplace, civic interior, Leipzig, town hall, Early Modern",
+    "tags_str": "#Justitia, #fireplace, #civic interior, #Leipzig, #town hall, #Early Modern",
     "regime": "fundacional",
     "endurecimento_score": 1.8,
     "indicadores": {
@@ -4114,21 +4189,21 @@
     "citation_abnt": "CRANACH, Lucas, o Velho. Gerechtigkeit. 1537. 1 pintura, óleo sobre painel, 72 × 49,6 cm. Coleção particular. Disponível em: https://lucascranach.org/en/PRIVATE_NONE-P457/.",
     "citation_chicago": "Cranach, Lucas, the Elder. Gerechtigkeit (Allegory of Justice). 1537. Oil on Panel. Private Collection. Cranach Digital Archive. https://lucascranach.org/en/PRIVATE_NONE-P457/.",
     "tags": [
-      "Justitia",
-      "Cranach",
-      "Renaissance",
-      "nude",
-      "painting",
-      "sword",
-      "scales",
-      "Northern Renaissance"
+      "#Justitia",
+      "#Cranach",
+      "#Renaissance",
+      "#nude",
+      "#painting",
+      "#sword",
+      "#scales",
+      "#Northern Renaissance"
     ],
     "year": 1537,
     "medium_norm": "Pintura/Desenho",
     "country_pt": "Alemanha",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, nude allegory, sword, scales",
-    "tags_str": "Justitia, Cranach, Renaissance, nude, painting, sword, scales, Northern Renaissance",
+    "tags_str": "#Justitia, #Cranach, #Renaissance, #nude, #painting, #sword, #scales, #Northern Renaissance",
     "regime": "fundacional",
     "endurecimento_score": 0.3,
     "indicadores": {
@@ -4185,21 +4260,21 @@
     "citation_abnt": "KAULBACH, Friedrich August von. Germania. 1914. 1 pintura (óleo sobre tela). Berlim: Deutsches Historisches Museum. Disponível em: https://www.dhm.de/lemo/bestand/objekt/gemaelde-friedrich-august-von-kaulbach-germania-1914. Acesso em: 28 mar. 2026.",
     "citation_chicago": "Kaulbach, Friedrich August von. Germania. 1914. Oil on canvas. Deutsches Historisches Museum, Berlin. https://www.dhm.de/lemo/bestand/objekt/gemaelde-friedrich-august-von-kaulbach-germania-1914.",
     "tags": [
-      "alegoria nacional",
-      "Germania",
-      "Primeira Guerra Mundial",
-      "pintura",
-      "arte alemã",
-      "feminino",
-      "militarismo",
-      "propaganda"
+      "#alegoria nacional",
+      "#Germania",
+      "#Primeira Guerra Mundial",
+      "#pintura",
+      "#arte alemã",
+      "#feminino",
+      "#militarismo",
+      "#propaganda"
     ],
     "year": 1914,
     "medium_norm": "pintura",
     "country_pt": "Alemanha",
     "period_norm": "Séc. XX",
     "motif_str": "alegoria nacional feminina, Germania, guerra, Primeira Guerra Mundial, identidade nacional",
-    "tags_str": "alegoria nacional, Germania, Primeira Guerra Mundial, pintura, arte alemã, feminino, militarismo, propaganda",
+    "tags_str": "#alegoria nacional, #Germania, #Primeira Guerra Mundial, #pintura, #arte alemã, #feminino, #militarismo, #propaganda",
     "regime": "normativo",
     "endurecimento_score": 1.5,
     "indicadores": {
@@ -4408,7 +4483,8 @@
     ],
     "id": "DE-016",
     "country": "Germany",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/File:DR_1920_141_Germania.jpg",
@@ -4439,7 +4515,8 @@
     ],
     "id": "DE-017",
     "country": "Germany",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces15569.html",
@@ -4470,7 +4547,8 @@
     ],
     "id": "DE-018",
     "country": "Germany",
-    "support": "papel-moeda"
+    "support": "papel-moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/catalogue/pieces40399.html",
@@ -4501,7 +4579,8 @@
     ],
     "id": "DE-019",
     "country": "Germany",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://iconocracy.corpus/vault/f2f019c1-8689-5589-a9c1-2b965269da6e",
@@ -4533,7 +4612,8 @@
     ],
     "id": "DE-020",
     "country": "Germany",
-    "support": "papel-moeda"
+    "support": "papel-moeda",
+    "tags_str": ""
   },
   {
     "url": "https://upload.wikimedia.org/wikipedia/commons/e/e2/Germania5pf1900.jpg",
@@ -4564,7 +4644,8 @@
     ],
     "id": "DE-021",
     "country": "Germany",
-    "support": "selo"
+    "support": "selo",
+    "tags_str": ""
   },
   {
     "id": "DE-1000M-1910",
@@ -4762,19 +4843,19 @@
     "citation_abnt": "DEUTSCHE REICHSPOST. Germania. 1900-1922. Selo postal, série definitiva. Design: Paul Eduard Waldraff. Disponível em: https://en.wikipedia.org/wiki/Germania_(stamp). Acesso em: 01 abr. 2026.",
     "citation_chicago": "Deutsche Reichspost. Germania. 1900–1922. Postage stamp. Wikipedia. https://en.wikipedia.org/wiki/Germania_(stamp).",
     "tags": [
-      "female allegory",
-      "Germania",
-      "military regime",
-      "philately",
-      "Jugendstil",
-      "imperial crown"
+      "#female allegory",
+      "#Germania",
+      "#military regime",
+      "#philately",
+      "#Jugendstil",
+      "#imperial crown"
     ],
     "year": 1900,
     "medium_norm": "stamp",
     "country_pt": "Alemanha",
     "period_norm": "Kaiserreich / Weimar (1900-1922)",
     "motif_str": "Germania",
-    "tags_str": "female allegory, Germania, imperial crown, sword",
+    "tags_str": "#female allegory, #Germania, #military regime, #philately, #Jugendstil, #imperial crown",
     "regime": "militar",
     "support": "selo",
     "in_scope": true,
@@ -4836,20 +4917,20 @@
     "citation_abnt": "DEUTSCHE REICHSPOST. Germania — Overprint \"Belgien\". 1914-1918. Selo postal, overprint de ocupação. Disponível em: https://colnect.com/en/stamps/stamp/320475. Acesso em: 01 abr. 2026.",
     "citation_chicago": "Deutsche Reichspost. Germania — Overprint \"Belgien.\" 1914–1918. Postage stamp. Colnect. https://colnect.com/en/stamps/stamp/320475.",
     "tags": [
-      "female allegory",
-      "Germania",
-      "military regime",
-      "philately",
-      "occupation",
-      "WWI",
-      "Belgium"
+      "#female allegory",
+      "#Germania",
+      "#military regime",
+      "#philately",
+      "#occupation",
+      "#WWI",
+      "#Belgium"
     ],
     "year": 1914,
     "medium_norm": "stamp",
     "country_pt": "Alemanha",
     "period_norm": "Ocupação WWI (1914-1918)",
     "motif_str": "Germania",
-    "tags_str": "female allegory, Germania, occupation, Belgien overprint",
+    "tags_str": "#female allegory, #Germania, #military regime, #philately, #occupation, #WWI, #Belgium",
     "regime": "militar",
     "support": "selo",
     "in_scope": true,
@@ -5010,7 +5091,8 @@
     "citation_abnt": "50 Mark Reichsbanknote — Germania as Young Girl (Weimar 1919)",
     "audit_flags": [
       "sem-thumbnail"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "id": "DE-WR-1924-50PF",
@@ -5067,7 +5149,8 @@
     "citation_abnt": "50 Reichspfennig — Woman Planting Oak Sapling (Weimar 1924)",
     "audit_flags": [
       "sem-thumbnail"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "id": "ES-001",
@@ -5093,20 +5176,20 @@
     "citation_abnt": "ALEGORÍA de la República española y la República francesa. 1931. 1 desenho/gravura. Biblioteca Nacional de España, Madrid. Disponível em: https://bdh.bne.es/bnesearch/detalle/76944.",
     "citation_chicago": "Alegoría de la República española y la República francesa. 1931. Drawing/Print. Biblioteca Nacional de España, Madrid. Biblioteca Digital Hispánica. https://bdh.bne.es/bnesearch/detalle/76944.",
     "tags": [
-      "female allegory",
-      "Spanish Republic",
-      "Marianne",
-      "Second Republic",
-      "España",
-      "Republican iconography",
-      "Spain France"
+      "#female allegory",
+      "#Spanish Republic",
+      "#Marianne",
+      "#Second Republic",
+      "#España",
+      "#Republican iconography",
+      "#Spain France"
     ],
     "year": 1931,
     "medium_norm": "Gravura",
     "country_pt": "Espanha",
     "period_norm": "Séc. XX",
     "motif_str": "República española, Marianne, Alegoria feminina, Espanha, França",
-    "tags_str": "female allegory, Spanish Republic, Marianne, Second Republic, España, Republican iconography, Spain France",
+    "tags_str": "#female allegory, #Spanish Republic, #Marianne, #Second Republic, #España, #Republican iconography, #Spain France",
     "regime": "fundacional",
     "endurecimento_score": 0.7,
     "indicadores": {
@@ -5168,21 +5251,21 @@
     "citation_abnt": "PADRÓ I PEDRET, Tomás. Alegoría de la Primera República española. La Flaca, Barcelona, 1873. 1 litografia. Madri: Biblioteca Nacional de España, Hemeroteca Digital. Disponível em: https://hemerotecadigital.bne.es/hd/es/card?sid=3971781. Acesso em: 28 mar. 2026.",
     "citation_chicago": "Padró i Pedret, Tomás. \"Alegoría de la Primera República española.\" La Flaca (Barcelona), 1873. Lithograph. Biblioteca Nacional de España, Hemeroteca Digital. https://hemerotecadigital.bne.es/hd/es/card?sid=3971781.",
     "tags": [
-      "alegoria nacional",
-      "república",
-      "satira política",
-      "imprensa oitocentista",
-      "barrete frígio",
-      "Espanha",
-      "feminino",
-      "constitucionalismo"
+      "#alegoria nacional",
+      "#república",
+      "#satira política",
+      "#imprensa oitocentista",
+      "#barrete frígio",
+      "#Espanha",
+      "#feminino",
+      "#constitucionalismo"
     ],
     "year": 1873,
     "medium_norm": "gravura/litografia",
     "country_pt": "Espanha",
     "period_norm": "Séc. XIX",
     "motif_str": "alegoria nacional feminina, república, imprensa satírica, Espanha, constitucionalismo",
-    "tags_str": "alegoria nacional, república, satira política, imprensa oitocentista, barrete frígio, Espanha, feminino, constitucionalismo",
+    "tags_str": "#alegoria nacional, #república, #satira política, #imprensa oitocentista, #barrete frígio, #Espanha, #feminino, #constitucionalismo",
     "regime": "fundacional",
     "endurecimento_score": 0.3,
     "indicadores": {
@@ -5389,19 +5472,19 @@
     "citation_abnt": "ZICK, Januarius. Thronende Justitia / Allegorie der strafenden Gerechtigkeit. [séc. XVIII]. Fotografia de Schulze-Marburg, Rudolf, 1943-1944. Zentralinstitut für Kunstgeschichte. Disponível em: https://www.europeana.eu/en/item/201/item_IBA5QWMUFFBZOLE2SPIJO5QD2SPIZS6S.",
     "citation_chicago": "Zick, Januarius. Thronende Justitia / Allegorie der strafenden Gerechtigkeit. 18th century. Ceiling fresco, photographed by Rudolf Schulze-Marburg, 1943–1944. Zentralinstitut für Kunstgeschichte. Europeana. https://www.europeana.eu/en/item/201/item_IBA5QWMUFFBZOLE2SPIJO5QD2SPIZS6S.",
     "tags": [
-      "Justitia",
-      "enthroned",
-      "criminal justice",
-      "ceiling fresco",
-      "Germany",
-      "Koblenz"
+      "#Justitia",
+      "#enthroned",
+      "#criminal justice",
+      "#ceiling fresco",
+      "#Germany",
+      "#Koblenz"
     ],
     "year": 1943,
     "medium_norm": "Fotografia",
     "country_pt": "Alemanha",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Justitia, Trono, Gerechtigkeit, Fresco",
-    "tags_str": "Justitia, enthroned, criminal justice, ceiling fresco, Germany, Koblenz",
+    "tags_str": "#Justitia, #enthroned, #criminal justice, #ceiling fresco, #Germany, #Koblenz",
     "regime": "fundacional",
     "endurecimento_score": 1.4,
     "indicadores": {
@@ -5457,18 +5540,18 @@
     "citation_abnt": "WALKER, Johan. Time and justice reveal the truth. [s.d.]. Royal Institute for Cultural Heritage. Disponível em: https://www.europeana.eu/en/item/2048001/AP_10342206.",
     "citation_chicago": "Walker, Johan. Time and Justice Reveal the Truth. n.d. Royal Institute for Cultural Heritage. Europeana. https://www.europeana.eu/en/item/2048001/AP_10342206.",
     "tags": [
-      "Justice",
-      "Truth",
-      "Time",
-      "allegory",
-      "Belgium"
+      "#Justice",
+      "#Truth",
+      "#Time",
+      "#allegory",
+      "#Belgium"
     ],
     "year": null,
     "medium_norm": "Outro",
     "country_pt": "Bélgica",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justice, Vérité, Temps, Allégorie féminine",
-    "tags_str": "Justice, Truth, Time, allegory, Belgium",
+    "tags_str": "#Justice, #Truth, #Time, #allegory, #Belgium",
     "regime": "fundacional",
     "endurecimento_score": 0.5,
     "indicadores": {
@@ -5536,18 +5619,18 @@
     "citation_abnt": "MATHAM, Jacob. Justitia. c. 1600. 1 gravura. Herzog Anton Ulrich Museum. Disponível em: https://www.europeana.eu/en/item/89/item_ZCR4KC47OMJN7DRRDFTIWRQS33M7PBN2.",
     "citation_chicago": "Matham, Jacob. Justitia. c. 1600. Print. Herzog Anton Ulrich Museum. Europeana. https://www.europeana.eu/en/item/89/item_ZCR4KC47OMJN7DRRDFTIWRQS33M7PBN2.",
     "tags": [
-      "Justitia",
-      "scales",
-      "sword",
-      "print",
-      "Dutch Golden Age"
+      "#Justitia",
+      "#scales",
+      "#sword",
+      "#print",
+      "#Dutch Golden Age"
     ],
     "year": 1600,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Alemanha",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Balança, Espada, Gravura",
-    "tags_str": "Justitia, scales, sword, print, Dutch Golden Age",
+    "tags_str": "#Justitia, #scales, #sword, #print, #Dutch Golden Age",
     "regime": "fundacional",
     "endurecimento_score": 1.2,
     "indicadores": {
@@ -5607,18 +5690,18 @@
     "citation_abnt": "AUDRAN, Charles. Allegory of Justice. [séc. XVII]. 1 gravura. Casanatense Library. Disponível em: https://www.europeana.eu/en/item/446/RML0348941.",
     "citation_chicago": "Audran, Charles, after Pietro da Cortona. Allegory of Justice. 17th century. Print. Casanatense Library. Europeana. https://www.europeana.eu/en/item/446/RML0348941.",
     "tags": [
-      "Justice",
-      "allegory",
-      "Baroque",
-      "Italy",
-      "Cortona"
+      "#Justice",
+      "#allegory",
+      "#Baroque",
+      "#Italy",
+      "#Cortona"
     ],
     "year": 1650,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Itália",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Justice, Allégorie féminine, Baroque",
-    "tags_str": "Justice, allegory, Baroque, Italy, Cortona",
+    "tags_str": "#Justice, #allegory, #Baroque, #Italy, #Cortona",
     "regime": "fundacional",
     "endurecimento_score": 1.1,
     "indicadores": {
@@ -5679,18 +5762,18 @@
     "citation_abnt": "KELS, Hans d. J. Justitia. [séc. XVI]. 1 relevo dourado. Kunsthistorisches Museum Wien. Disponível em: https://www.europeana.eu/en/item/15502/KK_6068.",
     "citation_chicago": "Kels, Hans d. J. Justitia. 16th century. Gilded relief sculpture. Kunsthistorisches Museum Wien. Europeana. https://www.europeana.eu/en/item/15502/KK_6068.",
     "tags": [
-      "Justitia",
-      "relief",
-      "gilded",
-      "Renaissance",
-      "Vienna"
+      "#Justitia",
+      "#relief",
+      "#gilded",
+      "#Renaissance",
+      "#Vienna"
     ],
     "year": 1550,
     "medium_norm": "Outro",
     "country_pt": "Áustria",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Relevo, Dourado, Renascimento",
-    "tags_str": "Justitia, relief, gilded, Renaissance, Vienna",
+    "tags_str": "#Justitia, #relief, #gilded, #Renaissance, #Vienna",
     "regime": "fundacional",
     "endurecimento_score": 1.5,
     "indicadores": {
@@ -5751,19 +5834,19 @@
     "citation_abnt": "HARMS, Johann Oswald. Justitia, allegory of justice. [séc. XVII]. 1 desenho. Herzog Anton Ulrich Museum. Disponível em: https://www.europeana.eu/en/item/89/item_MH6IXNHWTECBQCNPU7IIMCFP2BDFAV76.",
     "citation_chicago": "Harms, Johann Oswald. Justitia, Allegory of Justice. 17th century. Drawing. Herzog Anton Ulrich Museum. Europeana. https://www.europeana.eu/en/item/89/item_MH6IXNHWTECBQCNPU7IIMCFP2BDFAV76.",
     "tags": [
-      "Justitia",
-      "scales",
-      "sword",
-      "drawing",
-      "Baroque",
-      "Germany"
+      "#Justitia",
+      "#scales",
+      "#sword",
+      "#drawing",
+      "#Baroque",
+      "#Germany"
     ],
     "year": 1650,
     "medium_norm": "Pintura/Desenho",
     "country_pt": "Alemanha",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Justitia, Balança, Espada, Desenho",
-    "tags_str": "Justitia, scales, sword, drawing, Baroque, Germany",
+    "tags_str": "#Justitia, #scales, #sword, #drawing, #Baroque, #Germany",
     "regime": "fundacional",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -5821,18 +5904,18 @@
     "citation_abnt": "VOS, Maarten de. Justitia civilis. [séc. XVI]. Royal Institute for Cultural Heritage. Disponível em: https://www.europeana.eu/en/item/2048001/AP_10133590.",
     "citation_chicago": "Vos, Maarten de. Justitia civilis. 16th century. Royal Institute for Cultural Heritage. Europeana. https://www.europeana.eu/en/item/2048001/AP_10133590.",
     "tags": [
-      "civil justice",
-      "Justitia civilis",
-      "Flemish art",
-      "Belgium",
-      "female allegory"
+      "#civil justice",
+      "#Justitia civilis",
+      "#Flemish art",
+      "#Belgium",
+      "#female allegory"
     ],
     "year": 1550,
     "medium_norm": "Outro",
     "country_pt": "Bélgica",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia civilis, Justice civile, Allégorie féminine",
-    "tags_str": "civil justice, Justitia civilis, Flemish art, Belgium, female allegory",
+    "tags_str": "#civil justice, #Justitia civilis, #Flemish art, #Belgium, #female allegory",
     "regime": "fundacional",
     "endurecimento_score": 0.8,
     "indicadores": {
@@ -5900,19 +5983,19 @@
     "citation_abnt": "WALDMANN, Kaspar. Allegory with Justizia, resting on a cloudbank, crowned by a putto. [séc. XVIII]. 1 desenho. Albertina Museum. Disponível em: https://www.europeana.eu/en/item/15508/30435.",
     "citation_chicago": "Waldmann, Kaspar. Allegory with Justizia, Crowned by a Putto. 18th century. Drawing. Albertina Museum. Europeana. https://www.europeana.eu/en/item/15508/30435.",
     "tags": [
-      "Justitia",
-      "crowned",
-      "putto",
-      "celestial",
-      "scales",
-      "Austria"
+      "#Justitia",
+      "#crowned",
+      "#putto",
+      "#celestial",
+      "#scales",
+      "#Austria"
     ],
     "year": 1750,
     "medium_norm": "Pintura/Desenho",
     "country_pt": "Áustria",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Justitia, Putto, Coroa, Nuvem, Balança",
-    "tags_str": "Justitia, crowned, putto, celestial, scales, Austria",
+    "tags_str": "#Justitia, #crowned, #putto, #celestial, #scales, #Austria",
     "regime": "fundacional",
     "endurecimento_score": 0.7,
     "indicadores": {
@@ -5972,18 +6055,18 @@
     "citation_abnt": "PUVIS DE CHAVANNES, Pierre. Female allegory. [séc. XIX]. 1 desenho. Albertina Museum. Disponível em: https://www.europeana.eu/en/item/15508/DG1918_7.",
     "citation_chicago": "Puvis de Chavannes, Pierre. Female Allegory. 19th century. Drawing. Albertina Museum. Europeana. https://www.europeana.eu/en/item/15508/DG1918_7.",
     "tags": [
-      "female allegory",
-      "Symbolism",
-      "muralist",
-      "Third Republic",
-      "Puvis de Chavannes"
+      "#female allegory",
+      "#Symbolism",
+      "#muralist",
+      "#Third Republic",
+      "#Puvis de Chavannes"
     ],
     "year": 1850,
     "medium_norm": "Pintura/Desenho",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "Allégorie féminine, Symbolisme, Murale",
-    "tags_str": "female allegory, Symbolism, muralist, Third Republic, Puvis de Chavannes",
+    "tags_str": "#female allegory, #Symbolism, #muralist, #Third Republic, #Puvis de Chavannes",
     "regime": "normativo",
     "endurecimento_score": 1.6,
     "indicadores": {
@@ -6044,19 +6127,19 @@
     "citation_abnt": "CHIFFLART, François-Nicolas. La Justice, la Vengeance et la Vérité. 1865. 1 gravura. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b531737635.",
     "citation_chicago": "Chifflart, François-Nicolas. La Justice, la Vengeance et la Vérité. 1865. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b531737635.",
     "tags": [
-      "Justice",
-      "Truth",
-      "Vengeance",
-      "female allegory",
-      "engraving",
-      "Second Empire"
+      "#Justice",
+      "#Truth",
+      "#Vengeance",
+      "#female allegory",
+      "#engraving",
+      "#Second Empire"
     ],
     "year": 1865,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "Justice, Vengeance, Vérité, Allégorie féminine",
-    "tags_str": "Justice, Truth, Vengeance, female allegory, engraving, Second Empire",
+    "tags_str": "#Justice, #Truth, #Vengeance, #female allegory, #engraving, #Second Empire",
     "regime": "fundacional",
     "endurecimento_score": 0.7,
     "indicadores": {
@@ -6128,18 +6211,18 @@
     "citation_abnt": "CHIFFLART, François-Nicolas. Le triomphe de la Justice et de la Vérité. 1865. 1 gravura. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b531737529.",
     "citation_chicago": "Chifflart, François-Nicolas. Le triomphe de la Justice et de la Vérité. 1865. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b531737529.",
     "tags": [
-      "Justice",
-      "Truth",
-      "triumph",
-      "female allegory",
-      "engraving"
+      "#Justice",
+      "#Truth",
+      "#triumph",
+      "#female allegory",
+      "#engraving"
     ],
     "year": 1865,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "Justice, Vérité, Triomphe, Allégorie féminine",
-    "tags_str": "Justice, Truth, triumph, female allegory, engraving",
+    "tags_str": "#Justice, #Truth, #triumph, #female allegory, #engraving",
     "regime": "fundacional",
     "endurecimento_score": 0.7,
     "indicadores": {
@@ -6209,17 +6292,17 @@
     "citation_abnt": "CHIFFLART, François-Nicolas. L'envoyé de la Justice. 1859. 1 gravura. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b53173732g.",
     "citation_chicago": "Chifflart, François-Nicolas. L'envoyé de la Justice. 1859. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b53173732g.",
     "tags": [
-      "Justice",
-      "envoy",
-      "female allegory",
-      "engraving"
+      "#Justice",
+      "#envoy",
+      "#female allegory",
+      "#engraving"
     ],
     "year": 1859,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "Justice, Envoyé, Allégorie féminine",
-    "tags_str": "Justice, envoy, female allegory, engraving",
+    "tags_str": "#Justice, #envoy, #female allegory, #engraving",
     "regime": "fundacional",
     "endurecimento_score": 0.9,
     "indicadores": {
@@ -6290,19 +6373,19 @@
     "citation_abnt": "ESTAMPES représentant des naïades et Marianne enseignant l'alphabet à des enfants. [1859-1910]. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b10574064v.",
     "citation_chicago": "\"Estampes représentant des naïades et Marianne enseignant l'alphabet à des enfants.\" 1859–1910. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b10574064v.",
     "tags": [
-      "Marianne",
-      "Republic",
-      "education",
-      "female allegory",
-      "children",
-      "laïcité"
+      "#Marianne",
+      "#Republic",
+      "#education",
+      "#female allegory",
+      "#children",
+      "#laïcité"
     ],
     "year": 1859,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "Marianne, République, Éducation, Allégorie féminine",
-    "tags_str": "Marianne, Republic, education, female allegory, children, laïcité",
+    "tags_str": "#Marianne, #Republic, #education, #female allegory, #children, #laïcité",
     "regime": "normativo",
     "endurecimento_score": 1.1,
     "indicadores": {
@@ -6372,18 +6455,18 @@
     "citation_abnt": "ROPS, Félicien. La République aimable. 1871. 1 gravura. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b531842166.",
     "citation_chicago": "Rops, Félicien. La République aimable. 1871. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b531842166.",
     "tags": [
-      "Republic",
-      "female allegory",
-      "satire",
-      "Félicien Rops",
-      "eroticism"
+      "#Republic",
+      "#female allegory",
+      "#satire",
+      "#Félicien Rops",
+      "#eroticism"
     ],
     "year": 1871,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "République, Allégorie féminine, Satire, Corps féminin",
-    "tags_str": "Republic, female allegory, satire, Félicien Rops, eroticism",
+    "tags_str": "#Republic, #female allegory, #satire, #Félicien Rops, #eroticism",
     "regime": "normativo",
     "endurecimento_score": 0.5,
     "indicadores": {
@@ -6454,18 +6537,18 @@
     "citation_abnt": "THE FRENCH crisis: Madame La République. 1887. 1 gravura. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b8438243t.",
     "citation_chicago": "\"The French Crisis: Madame La République.\" 1887. Political cartoon. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b8438243t.",
     "tags": [
-      "Republic",
-      "political crisis",
-      "female allegory",
-      "cartoon",
-      "Marianne"
+      "#Republic",
+      "#political crisis",
+      "#female allegory",
+      "#cartoon",
+      "#Marianne"
     ],
     "year": 1887,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "République, Crise, Allégorie féminine, Caricature politique",
-    "tags_str": "Republic, political crisis, female allegory, cartoon, Marianne",
+    "tags_str": "#Republic, #political crisis, #female allegory, #cartoon, #Marianne",
     "regime": "normativo",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -6537,19 +6620,19 @@
     "citation_abnt": "LELONG, René. République Française: 3e Emprunt de la Défense nationale. 1917. 1 cartaz. Bibliothèque nationale de France. Disponível em: https://www.europeana.eu/en/item/9200518/ark__12148_btv1b10051217v.",
     "citation_chicago": "Lelong, René. République Française: 3e Emprunt de la Défense nationale. 1917. Propaganda poster. Bibliothèque nationale de France. Europeana. https://www.europeana.eu/en/item/9200518/ark__12148_btv1b10051217v.",
     "tags": [
-      "Marianne",
-      "Republic",
-      "WWI",
-      "propaganda",
-      "defense loan",
-      "female allegory"
+      "#Marianne",
+      "#Republic",
+      "#WWI",
+      "#propaganda",
+      "#defense loan",
+      "#female allegory"
     ],
     "year": 1917,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "Marianne, République, Guerre, Défense nationale, Allégorie féminine",
-    "tags_str": "Marianne, Republic, WWI, propaganda, defense loan, female allegory",
+    "tags_str": "#Marianne, #Republic, #WWI, #propaganda, #defense loan, #female allegory",
     "regime": "militar",
     "endurecimento_score": 1.8,
     "indicadores": {
@@ -6619,19 +6702,19 @@
     "citation_abnt": "STEINLEN, Théophile Alexandre. La République nous appelle. 1915. 1 litografia. Bibliothèque nationale de France. Disponível em: https://www.europeana.eu/en/item/9200518/ark__12148_btv1b10510623s.",
     "citation_chicago": "Steinlen, Théophile Alexandre. La République nous appelle. 1915. Lithograph. Bibliothèque nationale de France. Europeana. https://www.europeana.eu/en/item/9200518/ark__12148_btv1b10510623s.",
     "tags": [
-      "Marianne",
-      "Republic",
-      "WWI",
-      "recruitment",
-      "Steinlen",
-      "female allegory"
+      "#Marianne",
+      "#Republic",
+      "#WWI",
+      "#recruitment",
+      "#Steinlen",
+      "#female allegory"
     ],
     "year": 1915,
     "medium_norm": "Cartaz",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "Marianne, République, Appel, Guerre, Allégorie féminine",
-    "tags_str": "Marianne, Republic, WWI, recruitment, Steinlen, female allegory",
+    "tags_str": "#Marianne, #Republic, #WWI, #recruitment, #Steinlen, #female allegory",
     "regime": "militar",
     "endurecimento_score": 1.2,
     "indicadores": {
@@ -6704,19 +6787,19 @@
     "citation_abnt": "BUSTE de la République. [s.d.]. 1 fotografia de imprensa. Agence Rol. Bibliothèque nationale de France. Disponível em: https://www.europeana.eu/en/item/9200518/ark__12148_btv1b6952880n.",
     "citation_chicago": "\"Buste de la République.\" Early 20th century. Press photograph. Agence Rol. Bibliothèque nationale de France. Europeana. https://www.europeana.eu/en/item/9200518/ark__12148_btv1b6952880n.",
     "tags": [
-      "Marianne",
-      "Republic",
-      "bust",
-      "mairie",
-      "civic space",
-      "press photograph"
+      "#Marianne",
+      "#Republic",
+      "#bust",
+      "#mairie",
+      "#civic space",
+      "#press photograph"
     ],
     "year": 1950,
     "medium_norm": "Fotografia",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "République, Buste, Marianne, Mairie",
-    "tags_str": "Marianne, Republic, bust, mairie, civic space, press photograph",
+    "tags_str": "#Marianne, #Republic, #bust, #mairie, #civic space, #press photograph",
     "regime": "normativo",
     "endurecimento_score": 2.4,
     "indicadores": {
@@ -6790,18 +6873,18 @@
     "citation_abnt": "VEBER, Jean. Le hochet de la République. [s.d.]. 1 gravura. Bibliothèque nationale de France. Disponível em: https://www.europeana.eu/en/item/9200518/ark__12148_btv1b8577646g.",
     "citation_chicago": "Veber, Jean. Le hochet de la République. n.d. Satirical print. Bibliothèque nationale de France. Europeana. https://www.europeana.eu/en/item/9200518/ark__12148_btv1b8577646g.",
     "tags": [
-      "Republic",
-      "satire",
-      "rattle",
-      "trivialization",
-      "female allegory"
+      "#Republic",
+      "#satire",
+      "#rattle",
+      "#trivialization",
+      "#female allegory"
     ],
     "year": 1868,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "République, Satire, Hochet, Allégorie féminine",
-    "tags_str": "Republic, satire, rattle, trivialization, female allegory",
+    "tags_str": "#Republic, #satire, #rattle, #trivialization, #female allegory",
     "regime": "normativo",
     "endurecimento_score": 0.6,
     "indicadores": {
@@ -6872,19 +6955,19 @@
     "citation_abnt": "CALENDRIER et compost des bergiers: La grant danse macabre. 1531. Manuscrito ilustrado. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/.",
     "citation_chicago": "\"Calendrier et compost des bergiers: La grant danse macabre.\" 1531. Illustrated manuscript. Bibliothèque nationale de France. Gallica.",
     "tags": [
-      "Justice",
-      "danse macabre",
-      "death",
-      "female figure",
-      "Renaissance",
-      "manuscript"
+      "#Justice",
+      "#danse macabre",
+      "#death",
+      "#female figure",
+      "#Renaissance",
+      "#manuscript"
     ],
     "year": 1531,
     "medium_norm": "Outro",
     "country_pt": "França",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justice, Danse macabre, Figure féminine, Manuscrit",
-    "tags_str": "Justice, danse macabre, death, female figure, Renaissance, manuscript",
+    "tags_str": "#Justice, #danse macabre, #death, #female figure, #Renaissance, #manuscript",
     "regime": "fundacional",
     "endurecimento_score": 1.1,
     "indicadores": {
@@ -6943,21 +7026,21 @@
     "citation_abnt": "DELACROIX, Eugène. La Liberté guidant le peuple. 1830. 1 pintura, óleo sobre tela, 260 × 325 cm. Musée du Louvre, Paris. Disponível em: https://commons.wikimedia.org/wiki/File:Eug%C3%A8ne_Delacroix_-_Le_28_Juillet._La_Libert%C3%A9_guidant_le_peuple.jpg.",
     "citation_chicago": "Delacroix, Eugène. La Liberté guidant le peuple. 1830. Oil on Canvas. Musée du Louvre, Paris. https://commons.wikimedia.org/wiki/File:Eug%C3%A8ne_Delacroix_-_Le_28_Juillet._La_Libert%C3%A9_guidant_le_peuple.jpg.",
     "tags": [
-      "Liberty",
-      "Marianne",
-      "Delacroix",
-      "Revolution",
-      "July Revolution",
-      "Louvre",
-      "France",
-      "tricolour"
+      "#Liberty",
+      "#Marianne",
+      "#Delacroix",
+      "#Revolution",
+      "#July Revolution",
+      "#Louvre",
+      "#France",
+      "#tricolour"
     ],
     "year": 1830,
     "medium_norm": "Pintura/Desenho",
     "country_pt": "França",
     "period_norm": "Séc. XIX",
     "motif_str": "Liberty, Marianne, Revolution, tricolour",
-    "tags_str": "Liberty, Marianne, Delacroix, Revolution, July Revolution, Louvre, France, tricolour",
+    "tags_str": "#Liberty, #Marianne, #Delacroix, #Revolution, #July Revolution, #Louvre, #France, #tricolour",
     "regime": "fundacional",
     "endurecimento_score": 0.1,
     "indicadores": {
@@ -7014,21 +7097,21 @@
     "citation_abnt": "LE BARBIER L'AÎNÉ (des.); LAURENT, L. (grav.); DIEN (grav.). Déclaration des droits de l'homme et du citoyen. 1789. 1 estampe. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b69480451.",
     "citation_chicago": "Le Barbier l'Aîné (designer), L. Laurent and Dien (engravers). Déclaration des droits de l'homme et du citoyen. 1789. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b69480451.",
     "tags": [
-      "Déclaration des droits",
-      "female allegory",
-      "Liberty",
-      "Justice",
-      "French Revolution",
-      "Marianne",
-      "legal iconography",
-      "broadside"
+      "#Déclaration des droits",
+      "#female allegory",
+      "#Liberty",
+      "#Justice",
+      "#French Revolution",
+      "#Marianne",
+      "#legal iconography",
+      "#broadside"
     ],
     "year": 1789,
     "medium_norm": "Gravura",
     "country_pt": "França",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Declaração dos Direitos, Alegoria feminina, Liberté, Marianne, Révolution française",
-    "tags_str": "Déclaration des droits, female allegory, Liberty, Justice, French Revolution, Marianne, legal iconography, broadside",
+    "tags_str": "#Déclaration des droits, #female allegory, #Liberty, #Justice, #French Revolution, #Marianne, #legal iconography, #broadside",
     "regime": "fundacional",
     "endurecimento_score": 1.8,
     "indicadores": {
@@ -7084,20 +7167,20 @@
     "citation_abnt": "DÉCLARATION des droits de l'homme et du citoyen (variante). 1789. 1 estampe. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b8410817c.",
     "citation_chicago": "Déclaration des droits de l'homme et du citoyen (variant). 1789. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b8410817c.",
     "tags": [
-      "Déclaration des droits",
-      "female allegory",
-      "Liberty",
-      "French Revolution",
-      "anonymous",
-      "broadside",
-      "legal iconography"
+      "#Déclaration des droits",
+      "#female allegory",
+      "#Liberty",
+      "#French Revolution",
+      "#anonymous",
+      "#broadside",
+      "#legal iconography"
     ],
     "year": 1789,
     "medium_norm": "Gravura",
     "country_pt": "França",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Declaração dos Direitos, Alegoria feminina, Liberté, Révolution française",
-    "tags_str": "Déclaration des droits, female allegory, Liberty, French Revolution, anonymous, broadside, legal iconography",
+    "tags_str": "#Déclaration des droits, #female allegory, #Liberty, #French Revolution, #anonymous, #broadside, #legal iconography",
     "regime": "fundacional",
     "endurecimento_score": 1.8,
     "indicadores": {
@@ -7154,20 +7237,20 @@
     "citation_abnt": "ALLÉGORIE pour le frontispice du compte-rendu au Roi par M. Necker. 1781. 1 estampe. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b8410270p.",
     "citation_chicago": "Allégorie pour le frontispice du compte-rendu au Roi par M. Necker. 1781. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b8410270p.",
     "tags": [
-      "female allegory",
-      "Necker",
-      "Ancien Régime",
-      "fiscal governance",
-      "allegorical frontispiece",
-      "Enlightenment",
-      "state finance"
+      "#female allegory",
+      "#Necker",
+      "#Ancien Régime",
+      "#fiscal governance",
+      "#allegorical frontispiece",
+      "#Enlightenment",
+      "#state finance"
     ],
     "year": 1781,
     "medium_norm": "Gravura",
     "country_pt": "França",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Alegoria feminina, Justiça, Abundância, Administração régia, Iluminismo",
-    "tags_str": "female allegory, Necker, Ancien Régime, fiscal governance, allegorical frontispiece, Enlightenment, state finance",
+    "tags_str": "#female allegory, #Necker, #Ancien Régime, #fiscal governance, #allegorical frontispiece, #Enlightenment, #state finance",
     "regime": "fundacional",
     "endurecimento_score": 1.3,
     "indicadores": {
@@ -7224,20 +7307,20 @@
     "citation_abnt": "ALLÉGORIE pour le frontispice du compte rendu au Roi par M. Necker (variante). 1781. 1 estampe. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b6942595s.",
     "citation_chicago": "Allégorie pour le frontispice du compte rendu au Roi par M. Necker (variant). 1781. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b6942595s.",
     "tags": [
-      "female allegory",
-      "Necker",
-      "Ancien Régime",
-      "fiscal governance",
-      "allegorical frontispiece",
-      "Enlightenment",
-      "variant edition"
+      "#female allegory",
+      "#Necker",
+      "#Ancien Régime",
+      "#fiscal governance",
+      "#allegorical frontispiece",
+      "#Enlightenment",
+      "#variant edition"
     ],
     "year": 1781,
     "medium_norm": "Gravura",
     "country_pt": "França",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Alegoria feminina, Justiça, Abundância, Administração régia, Iluminismo",
-    "tags_str": "female allegory, Necker, Ancien Régime, fiscal governance, allegorical frontispiece, Enlightenment, variant edition",
+    "tags_str": "#female allegory, #Necker, #Ancien Régime, #fiscal governance, #allegorical frontispiece, #Enlightenment, #variant edition",
     "regime": "fundacional",
     "endurecimento_score": 1.3,
     "indicadores": {
@@ -7293,20 +7376,20 @@
     "citation_abnt": "ALLÉGORIE pour servir de frontispice au compte-rendu au Roi par M. Necker. 1781. 1 estampe. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b8410268m.",
     "citation_chicago": "Allégorie pour servir de frontispice au compte-rendu au Roi par M. Necker. 1781. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b8410268m.",
     "tags": [
-      "female allegory",
-      "Necker",
-      "Ancien Régime",
-      "fiscal governance",
-      "allegorical frontispiece",
-      "Enlightenment",
-      "transparency"
+      "#female allegory",
+      "#Necker",
+      "#Ancien Régime",
+      "#fiscal governance",
+      "#allegorical frontispiece",
+      "#Enlightenment",
+      "#transparency"
     ],
     "year": 1781,
     "medium_norm": "Gravura",
     "country_pt": "França",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Alegoria feminina, Justiça, Abundância, Administração régia",
-    "tags_str": "female allegory, Necker, Ancien Régime, fiscal governance, allegorical frontispiece, Enlightenment, transparency",
+    "tags_str": "#female allegory, #Necker, #Ancien Régime, #fiscal governance, #allegorical frontispiece, #Enlightenment, #transparency",
     "regime": "fundacional",
     "endurecimento_score": 1.3,
     "indicadores": {
@@ -7364,20 +7447,20 @@
     "citation_abnt": "GARNERAY (des.); QUÉVERDO (grav.). [Liberté, Égalité, Fraternité — portrait allégorique d'Ernouf]. c. 1793–1800. 1 estampe. Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b8412560z.",
     "citation_chicago": "Garneray (designer) and Quéverdo (engraver). [Liberté, Égalité, Fraternité — Portrait allégorique d'Ernouf]. c. 1793–1800. Engraving. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b8412560z.",
     "tags": [
-      "Liberté Égalité Fraternité",
-      "female allegory",
-      "Marianne",
-      "French Revolution",
-      "République française",
-      "Directory period",
-      "Republican iconography"
+      "#Liberté Égalité Fraternité",
+      "#female allegory",
+      "#Marianne",
+      "#French Revolution",
+      "#République française",
+      "#Directory period",
+      "#Republican iconography"
     ],
     "year": 1796,
     "medium_norm": "Gravura",
     "country_pt": "França",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Liberté, Égalité, Fraternité, Alegoria feminina, République française, Marianne",
-    "tags_str": "Liberté Égalité Fraternité, female allegory, Marianne, French Revolution, République française, Directory period, Republican iconography",
+    "tags_str": "#Liberté Égalité Fraternité, #female allegory, #Marianne, #French Revolution, #République française, #Directory period, #Republican iconography",
     "regime": "fundacional",
     "endurecimento_score": 1.5,
     "indicadores": {
@@ -7435,21 +7518,21 @@
     "citation_abnt": "STEINLEN, Théophile Alexandre. Journée du Poilu, 25 et 26 décembre 1915, organisée par le Parlement. 1915. 1 affiche (litografia). Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b9012753r.",
     "citation_chicago": "Steinlen, Théophile Alexandre. Journée du Poilu, 25 et 26 décembre 1915, organisée par le Parlement. 1915. Lithographic Poster. Bibliothèque nationale de France. Gallica. https://gallica.bnf.fr/ark:/12148/btv1b9012753r.",
     "tags": [
-      "Marianne",
-      "female allegory",
-      "WWI",
-      "Steinlen",
-      "propaganda poster",
-      "French Republic",
-      "Journée du Poilu",
-      "Third Republic"
+      "#Marianne",
+      "#female allegory",
+      "#WWI",
+      "#Steinlen",
+      "#propaganda poster",
+      "#French Republic",
+      "#Journée du Poilu",
+      "#Third Republic"
     ],
     "year": 1915,
     "medium_norm": "Gravura",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "Marianne, Alegoria feminina, Soldado, WWI, République française, Propaganda",
-    "tags_str": "Marianne, female allegory, WWI, Steinlen, propaganda poster, French Republic, Journée du Poilu, Third Republic",
+    "tags_str": "#Marianne, #female allegory, #WWI, #Steinlen, #propaganda poster, #French Republic, #Journée du Poilu, #Third Republic",
     "regime": "militar",
     "endurecimento_score": 1.1,
     "indicadores": {
@@ -7506,23 +7589,23 @@
     "citation_abnt": "GRACIANO. Decretum Gratiani (Concordia discordantium canonum). [Bolonha], séc. XIII. 1 manuscrito iluminado, pergaminho. Paris: Bibliothèque nationale de France. Disponível em: https://gallica.bnf.fr/ark:/12148/btv1b10544534k.item. Acesso em: 28 mar. 2026.",
     "citation_chicago": "Gratian. Decretum Gratiani (Concordia discordantium canonum). c. 13th century. Illuminated manuscript on parchment. Bibliothèque nationale de France, Paris. https://gallica.bnf.fr/ark:/12148/btv1b10544534k.item.",
     "tags": [
-      "Justitia",
-      "direito canônico",
-      "manuscrito medieval",
-      "iluminura",
-      "iconografia jurídica",
-      "Graciano",
-      "miniatura",
-      "Bolonha",
-      "BnF",
-      "Gallica"
+      "#Justitia",
+      "#direito canônico",
+      "#manuscrito medieval",
+      "#iluminura",
+      "#iconografia jurídica",
+      "#Graciano",
+      "#miniatura",
+      "#Bolonha",
+      "#BnF",
+      "#Gallica"
     ],
     "year": 1250,
     "medium_norm": "iluminura/manuscrito",
     "country_pt": "França",
     "period_norm": "Idade Média",
     "motif_str": "Justitia, alegoria da justiça, iconografia jurídica medieval, direito canônico, miniatura iluminada",
-    "tags_str": "Justitia, direito canônico, manuscrito medieval, iluminura, iconografia jurídica, Graciano, miniatura, Bolonha, BnF, Gallica",
+    "tags_str": "#Justitia, #direito canônico, #manuscrito medieval, #iluminura, #iconografia jurídica, #Graciano, #miniatura, #Bolonha, #BnF, #Gallica",
     "regime": "fundacional",
     "endurecimento_score": 1.2,
     "indicadores": {
@@ -7625,7 +7708,8 @@
         "analyst_notes": "Obra canônica amplamente documentada. Codificação confiável sem inspeção visual direta."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/pintura, regime/fundacional, motivo/marianne"
   },
   {
     "id": "FR-022",
@@ -7698,7 +7782,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/estampa, regime/contra-alegoria, motivo/marianne, #colonialidade-do-ver"
   },
   {
     "id": "FR-023",
@@ -7769,7 +7854,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/cartaz, regime/militar, motivo/marianne"
   },
   {
     "id": "FR-024",
@@ -7840,7 +7926,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/cartaz, regime/militar, motivo/marianne"
   },
   {
     "id": "FR-025",
@@ -7911,7 +7998,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/cartaz, regime/normativo, motivo/marianne"
   },
   {
     "id": "FR-026",
@@ -7982,7 +8070,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/cartaz, regime/normativo, motivo/marianne"
   },
   {
     "id": "FR-027",
@@ -8053,7 +8142,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/cartaz, regime/militar, motivo/marianne"
   },
   {
     "id": "FR-028",
@@ -8125,7 +8215,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/cartaz, regime/normativo, motivo/marianne"
   },
   {
     "id": "FR-029",
@@ -8196,7 +8287,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/cartaz, regime/normativo, motivo/marianne"
   },
   {
     "id": "FR-030",
@@ -8268,7 +8360,8 @@
         "analyst_notes": "Codificação por metadados — requer verificação visual via IIIF quando Gallica estiver acessível."
       },
       "analyst_notes": ""
-    }
+    },
+    "tags_str": "corpus/candidato, pais/FR, suporte/cartaz, regime/militar, motivo/marianne"
   },
   {
     "id": "FR-031",
@@ -8512,19 +8605,19 @@
     "citation_abnt": "QUÉVÉDO, François-Marie-Isidore. Calendrier républicain (An III). 1794. 1 gravura. Bibliothèque nationale de France. Disponível em: Gallica.",
     "citation_chicago": "Quévédo, François-Marie-Isidore. Calendrier républicain (An III). 1794. Engraving. Bibliothèque nationale de France. Gallica.",
     "tags": [
-      "female allegory",
-      "republican calendar",
-      "Liberty",
-      "Equality",
-      "Revolution",
-      "France"
+      "#female allegory",
+      "#republican calendar",
+      "#Liberty",
+      "#Equality",
+      "#Revolution",
+      "#France"
     ],
     "year": 1794,
     "medium_norm": "Estampa",
     "country_pt": "França",
     "period_norm": "Revolução/República (FR)",
     "motif_str": "Alegoria feminina, Calendrier républicain, Liberté, Égalité",
-    "tags_str": "female allegory, republican calendar, Liberty, Equality, Revolution, France",
+    "tags_str": "#female allegory, #republican calendar, #Liberty, #Equality, #Revolution, #France",
     "regime": "fundacional",
     "endurecimento_score": 1.6,
     "indicadores": {
@@ -8591,19 +8684,19 @@
     "citation_abnt": "MOITTE, Jean-Guillaume. Liberté. 1792. 1 gravura. Bibliothèque nationale de France. Disponível em: Gallica.",
     "citation_chicago": "Moitte, Jean-Guillaume. Liberté. 1792. Engraving. Bibliothèque nationale de France. Gallica.",
     "tags": [
-      "Liberty",
-      "Phrygian cap",
-      "fasces",
-      "serpent",
-      "Revolution",
-      "France"
+      "#Liberty",
+      "#Phrygian cap",
+      "#fasces",
+      "#serpent",
+      "#Revolution",
+      "#France"
     ],
     "year": 1792,
     "medium_norm": "Estampa",
     "country_pt": "França",
     "period_norm": "Revolução/República (FR)",
     "motif_str": "Liberté, Bonnet phrygien, Fasces",
-    "tags_str": "Liberty, Phrygian cap, fasces, serpent, Revolution, France",
+    "tags_str": "#Liberty, #Phrygian cap, #fasces, #serpent, #Revolution, #France",
     "regime": "fundacional",
     "indicadores": {
       "desincorporacao": 1,
@@ -8671,21 +8764,21 @@
     "citation_abnt": "BOIZOT, Louis-Simon. La Liberté, soutenue par la Raison, protège l'Innocence et couronne la Vertu. 1793. 1 gravura. Bibliothèque nationale de France. Disponível em: Gallica.",
     "citation_chicago": "Boizot, Louis-Simon. La Liberté, soutenue par la Raison, protège l'Innocence et couronne la Vertu. 1793. Engraving. Bibliothèque nationale de France. Gallica.",
     "tags": [
-      "Liberty",
-      "Reason",
-      "Virtue",
-      "Innocence",
-      "winged figure",
-      "lion",
-      "Revolution",
-      "France"
+      "#Liberty",
+      "#Reason",
+      "#Virtue",
+      "#Innocence",
+      "#winged figure",
+      "#lion",
+      "#Revolution",
+      "#France"
     ],
     "year": 1793,
     "medium_norm": "Estampa",
     "country_pt": "França",
     "period_norm": "Revolução/República (FR)",
     "motif_str": "Liberté, Raison, Vertu, Innocence",
-    "tags_str": "Liberty, Reason, Virtue, Innocence, winged figure, lion, Revolution, France",
+    "tags_str": "#Liberty, #Reason, #Virtue, #Innocence, #winged figure, #lion, #Revolution, #France",
     "regime": "fundacional",
     "endurecimento_score": 0.9,
     "indicadores": {
@@ -8753,21 +8846,21 @@
     "citation_abnt": "BOIZOT, Louis-Simon. La Liberté armée du Sceptre de la Raison foudroye l'Ignorance et le Fanatisme. 1793. 1 gravura. Bibliothèque nationale de France. Disponível em: Gallica.",
     "citation_chicago": "Boizot, Louis-Simon. La Liberté armée du Sceptre de la Raison foudroye l'Ignorance et le Fanatisme. 1793. Engraving. Bibliothèque nationale de France. Gallica.",
     "tags": [
-      "Liberty",
-      "Reason",
-      "Ignorance",
-      "Fanaticism",
-      "lightning",
-      "lion",
-      "Revolution",
-      "France"
+      "#Liberty",
+      "#Reason",
+      "#Ignorance",
+      "#Fanaticism",
+      "#lightning",
+      "#lion",
+      "#Revolution",
+      "#France"
     ],
     "year": 1793,
     "medium_norm": "Estampa",
     "country_pt": "França",
     "period_norm": "Revolução/República (FR)",
     "motif_str": "Liberté, Raison, Ignorance, Fanatisme",
-    "tags_str": "Liberty, Reason, Ignorance, Fanaticism, lightning, lion, Revolution, France",
+    "tags_str": "#Liberty, #Reason, #Ignorance, #Fanaticism, #lightning, #lion, #Revolution, #France",
     "regime": "fundacional",
     "endurecimento_score": 0.9,
     "indicadores": {
@@ -8834,22 +8927,22 @@
     "citation_abnt": "BRUEGEL, Pieter, o Velho; GALLE, Philips. Iustitia. 1559. 1 gravura. Série: As Sete Virtudes. Bibliothèque nationale de France. Disponível em: Gallica.",
     "citation_chicago": "Bruegel, Pieter, the Elder, and Philips Galle. Iustitia. 1559. Engraving. The Seven Virtues series. Bibliothèque nationale de France. Gallica.",
     "tags": [
-      "Justice",
-      "Justitia",
-      "punishment",
-      "penal law",
-      "Seven Virtues",
-      "Bruegel",
-      "blindfold",
-      "sword",
-      "scales"
+      "#Justice",
+      "#Justitia",
+      "#punishment",
+      "#penal law",
+      "#Seven Virtues",
+      "#Bruegel",
+      "#blindfold",
+      "#sword",
+      "#scales"
     ],
     "year": 1559,
     "medium_norm": "Estampa",
     "country_pt": "França",
     "period_norm": "Antigo Regime",
     "motif_str": "Iustitia, Justitia, Punição, Direito penal",
-    "tags_str": "Justice, Justitia, punishment, penal law, Seven Virtues, Bruegel, blindfold, sword, scales",
+    "tags_str": "#Justice, #Justitia, #punishment, #penal law, #Seven Virtues, #Bruegel, #blindfold, #sword, #scales",
     "regime": "fundacional",
     "endurecimento_score": 0.7,
     "indicadores": {
@@ -8921,14 +9014,14 @@
       "suporte/ceramica",
       "regime/normativo",
       "motivo/justice",
-      "verificar"
+      "#verificar"
     ],
     "year": 1889,
     "medium_norm": "Cerâmica",
     "country_pt": "França",
     "period_norm": "III República / II Império (FR)",
     "motif_str": "La Justice, Allégorie féminine, République",
-    "tags_str": "corpus/candidato, pais/FR, suporte/ceramica, regime/normativo, motivo/justice",
+    "tags_str": "corpus/candidato, pais/FR, suporte/ceramica, regime/normativo, motivo/justice, #verificar",
     "regime": "normativo",
     "endurecimento_score": 0.6,
     "indicadores": {
@@ -8990,7 +9083,8 @@
     ],
     "id": "FR-049",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://balat.kikirpa.be/object/10134533",
@@ -9010,7 +9104,8 @@
     ],
     "id": "FR-050",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://gallica.bnf.fr/ark:/12148/btv1b10051600t",
@@ -9041,7 +9136,8 @@
     ],
     "id": "FR-051",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "http://gallica.bnf.fr/ark:/12148/btv1b531737635",
@@ -9072,7 +9168,8 @@
     ],
     "id": "FR-052",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "http://gallica.bnf.fr/ark:/12148/btv1b8412925w",
@@ -9104,7 +9201,8 @@
     ],
     "id": "FR-053",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=a-duerer-wb3-0130",
@@ -9124,7 +9222,8 @@
     ],
     "id": "FR-054",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=bonnet-l-m-ab3-0035",
@@ -9144,7 +9243,8 @@
     ],
     "id": "FR-055",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=bosche-e-v-d-ab2-0002",
@@ -9164,7 +9264,8 @@
     ],
     "id": "FR-056",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=briot-i-wb3-0005",
@@ -9184,7 +9285,8 @@
     ],
     "id": "FR-057",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=goltzius-h-ab3-0031",
@@ -9204,7 +9306,8 @@
     ],
     "id": "FR-058",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=j-e-nilson-ab3-0029",
@@ -9224,7 +9327,8 @@
     ],
     "id": "FR-059",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=jansz-e-ab2-0001",
@@ -9244,7 +9348,8 @@
     ],
     "id": "FR-060",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=matham-j-kopie-ab3-0004",
@@ -9264,7 +9369,8 @@
     ],
     "id": "FR-061",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=saint-non-j-c-r-d-ab3-0145",
@@ -9284,7 +9390,8 @@
     ],
     "id": "FR-062",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=saint-non-j-c-r-d-ab3-0211",
@@ -9304,7 +9411,8 @@
     ],
     "id": "FR-063",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=visscher-n-exc-ab3-0013",
@@ -9324,7 +9432,8 @@
     ],
     "id": "FR-064",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://kk.haum-bs.de/?id=z-01383",
@@ -9344,7 +9453,8 @@
     ],
     "id": "FR-065",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://www.bildindex.de/document/obj20455031",
@@ -9364,7 +9474,8 @@
     ],
     "id": "FR-066",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "http://www.deutschefotothek.de/documents/obj/72066905",
@@ -9384,7 +9495,8 @@
     ],
     "id": "FR-067",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://colnect.com/en/stamps/list/country/74-France/series/68206-Semeuse_solid_background",
@@ -9416,7 +9528,8 @@
     ],
     "id": "FR-068",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://colnect.com/en/stamps/list/country/74-France/year/1903",
@@ -9447,7 +9560,8 @@
     ],
     "id": "FR-069",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://commons.wikimedia.org/wiki/Category:Semeuse_on_stamps",
@@ -9478,7 +9592,8 @@
     ],
     "id": "FR-070",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://en.numista.com/11287",
@@ -9509,7 +9624,8 @@
     ],
     "id": "FR-071",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b116003372",
@@ -9528,7 +9644,8 @@
     ],
     "id": "FR-072",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b53009905z.item",
@@ -9559,7 +9676,8 @@
     ],
     "id": "FR-073",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b53013992k",
@@ -9590,7 +9708,8 @@
     ],
     "id": "FR-074",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b530172177.item",
@@ -9621,7 +9740,8 @@
     ],
     "id": "FR-075",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b531241805",
@@ -9640,7 +9760,8 @@
     ],
     "id": "FR-076",
     "country": "France",
-    "support": "fotografia"
+    "support": "fotografia",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b531287227",
@@ -9671,7 +9792,8 @@
     ],
     "id": "FR-077",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b53188884v",
@@ -9690,7 +9812,8 @@
     ],
     "id": "FR-078",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b53234029x",
@@ -9709,7 +9832,8 @@
     ],
     "id": "FR-079",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b53240455t",
@@ -9728,7 +9852,8 @@
     ],
     "id": "FR-080",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b53250287h",
@@ -9759,7 +9884,8 @@
     ],
     "id": "FR-081",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b53254750d",
@@ -9790,7 +9916,8 @@
     ],
     "id": "FR-082",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b532646114",
@@ -9809,7 +9936,8 @@
     ],
     "id": "FR-083",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b53269527k",
@@ -9840,7 +9968,8 @@
     ],
     "id": "FR-084",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b55001927d",
@@ -9871,7 +10000,8 @@
     ],
     "id": "FR-085",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b59718546",
@@ -9890,7 +10020,8 @@
     ],
     "id": "FR-086",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b6948145c.item",
@@ -9921,7 +10052,8 @@
     ],
     "id": "FR-087",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b6950386s",
@@ -9940,7 +10072,8 @@
     ],
     "id": "FR-088",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b8402182w",
@@ -9971,7 +10104,8 @@
     ],
     "id": "FR-089",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b84114624",
@@ -10002,7 +10136,8 @@
     ],
     "id": "FR-090",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://gallica.bnf.fr/ark:/12148/btv1b9012156x/f1.item",
@@ -10034,7 +10169,8 @@
     ],
     "id": "FR-091",
     "country": "France",
-    "support": "estampa/gravura"
+    "support": "estampa/gravura",
+    "tags_str": ""
   },
   {
     "url": "https://iconocracy.corpus/vault/7833d92a-6bbe-527f-8893-1d4d12820ffa",
@@ -10065,7 +10201,8 @@
     ],
     "id": "FR-092",
     "country": "France",
-    "support": "selo"
+    "support": "selo",
+    "tags_str": ""
   },
   {
     "url": "https://iconocracy.corpus/vault/a155af76-1c78-502b-b024-b1f0b2ae3f03",
@@ -10096,7 +10233,8 @@
     ],
     "id": "FR-093",
     "country": "France",
-    "support": "cerâmica"
+    "support": "cerâmica",
+    "tags_str": ""
   },
   {
     "url": "https://iconocracy.corpus/vault/deb8221e-bc98-5afb-a0b2-cd3e47a17cff",
@@ -10127,7 +10265,8 @@
     ],
     "id": "FR-094",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://iconocracy.corpus/vault/f502f5cf-ed4e-50d0-8ae0-45c60cd1c6ea",
@@ -10158,7 +10297,8 @@
     ],
     "id": "FR-095",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "url": "https://www.metmuseum.org/art/collection/search/208134",
@@ -10177,7 +10317,8 @@
     ],
     "id": "FR-096",
     "country": "France",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "id": "FR-ASSIGNAT-1792",
@@ -10318,19 +10459,19 @@
     "citation_abnt": "MONNAIE DE PARIS. 5 Francs Hercule. 1870-1878. Moeda, prata .900, 37 mm. Design: Augustin Dupré (1795). Disponível em: https://en.numista.com/catalogue/pieces1187.html. Acesso em: 01 abr. 2026.",
     "citation_chicago": "Monnaie de Paris. 5 Francs Hercule. 1870–1878. Silver coin. Numista. https://en.numista.com/catalogue/pieces1187.html.",
     "tags": [
-      "female allegory",
-      "La République",
-      "La Justice",
-      "Hercule",
-      "foundational regime",
-      "numismatics"
+      "#female allegory",
+      "#La République",
+      "#La Justice",
+      "#Hercule",
+      "#foundational regime",
+      "#numismatics"
     ],
     "year": 1870,
     "medium_norm": "coin",
     "country_pt": "França",
     "period_norm": "Terceira República (1870-1878)",
     "motif_str": "La République, La Justice",
-    "tags_str": "female allegory, La République, La Justice, Hercule",
+    "tags_str": "#female allegory, #La République, #La Justice, #Hercule, #foundational regime, #numismatics",
     "regime": "fundacional",
     "support": "moeda",
     "in_scope": true,
@@ -10392,19 +10533,19 @@
     "citation_abnt": "MONNAIE DE PARIS. Piastre de Commerce. 1885-1928. Moeda, prata .900, 27,215 g. Disponível em: https://en.numista.com/catalogue/pieces4510.html. Acesso em: 01 abr. 2026.",
     "citation_chicago": "Monnaie de Paris. Piastre de Commerce. 1885–1928. Silver coin. Numista. https://en.numista.com/catalogue/pieces4510.html.",
     "tags": [
-      "female allegory",
-      "Marianne",
-      "colonial",
-      "Indochina",
-      "military regime",
-      "numismatics"
+      "#female allegory",
+      "#Marianne",
+      "#colonial",
+      "#Indochina",
+      "#military regime",
+      "#numismatics"
     ],
     "year": 1885,
     "medium_norm": "coin",
     "country_pt": "França",
     "period_norm": "Terceira República (1885-1928)",
     "motif_str": "Marianne",
-    "tags_str": "female allegory, Marianne, colonial, Indochina",
+    "tags_str": "#female allegory, #Marianne, #colonial, #Indochina, #military regime, #numismatics",
     "regime": "militar",
     "support": "moeda",
     "in_scope": true,
@@ -10496,7 +10637,8 @@
     "citation_abnt": "Semeuse 1 Franc silver coin (Oscar Roty)",
     "audit_flags": [
       "sem-thumbnail"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "id": "FR-SEM-SELO-1903",
@@ -10522,20 +10664,20 @@
     "citation_abnt": "LA POSTE. La Semeuse. 1903-1960. Selo postal, série definitiva. Design: Oscar Roty / Louis-Eugène Mouchon. Disponível em: https://en.wikipedia.org/wiki/Sowing_(Oscar_Roty). Acesso em: 01 abr. 2026.",
     "citation_chicago": "La Poste. La Semeuse. 1903–1960. Postage stamp. Wikipedia. https://en.wikipedia.org/wiki/Sowing_(Oscar_Roty).",
     "tags": [
-      "female allegory",
-      "Marianne",
-      "Semeuse",
-      "normative regime",
-      "philately",
-      "Phrygian cap",
-      "peace"
+      "#female allegory",
+      "#Marianne",
+      "#Semeuse",
+      "#normative regime",
+      "#philately",
+      "#Phrygian cap",
+      "#peace"
     ],
     "year": 1903,
     "medium_norm": "stamp",
     "country_pt": "França",
     "period_norm": "Terceira República (1903-1960)",
     "motif_str": "Marianne / La Semeuse",
-    "tags_str": "female allegory, Marianne, Semeuse, peace, sowing",
+    "tags_str": "#female allegory, #Marianne, #Semeuse, #normative regime, #philately, #Phrygian cap, #peace",
     "regime": "normativo",
     "support": "selo",
     "in_scope": true,
@@ -10885,21 +11027,21 @@
     "citation_abnt": "POSADA, José Guadalupe. [Virtudes cardinales: Justica]. La Patria Ilustrada, Cidade do México, 18 fev. 1889. 1 litografia, 23,5 × 16 cm. Washington: Library of Congress. Disponível em: https://www.loc.gov/item/2003656173/. Acesso em: 28 mar. 2026.",
     "citation_chicago": "Posada, José Guadalupe. \"[Virtudes cardinales: Justica].\" La Patria Ilustrada (Mexico City), February 18, 1889. Lithograph, 23.5 × 16 cm. Library of Congress. https://www.loc.gov/item/2003656173/.",
     "tags": [
-      "alegoria da justiça",
-      "Justitia",
-      "virtudes cardinais",
-      "México",
-      "Posada",
-      "litografia",
-      "imprensa porfirista",
-      "feminino"
+      "#alegoria da justiça",
+      "#Justitia",
+      "#virtudes cardinais",
+      "#México",
+      "#Posada",
+      "#litografia",
+      "#imprensa porfirista",
+      "#feminino"
     ],
     "year": 1889,
     "medium_norm": "gravura/litografia",
     "country_pt": "México",
     "period_norm": "Séc. XIX",
     "motif_str": "alegoria da Justiça, virtudes cardinais, Justitia, México, imprensa ilustrada oitocentista",
-    "tags_str": "alegoria da justiça, Justitia, virtudes cardinais, México, Posada, litografia, imprensa porfirista, feminino",
+    "tags_str": "#alegoria da justiça, #Justitia, #virtudes cardinais, #México, #Posada, #litografia, #imprensa porfirista, #feminino",
     "regime": "normativo",
     "endurecimento_score": 1.5,
     "indicadores": {
@@ -11034,20 +11176,20 @@
     "citation_abnt": "VROUWE Justitia (nua, com espada e balança). 1500–1600. 1 gravura. Rijksmuseum, Amsterdam. Disponível em: https://www.rijksmuseum.nl/en/collection/object/Vrouwe-Justitia--13997b5b276f9bbbb36a847da4c3022a.",
     "citation_chicago": "Vrouwe Justitia (Nude, with Sword and Scales). 1500–1600. Engraving. Rijksmuseum, Amsterdam. https://www.rijksmuseum.nl/en/collection/object/Vrouwe-Justitia--13997b5b276f9bbbb36a847da4c3022a.",
     "tags": [
-      "Justitia",
-      "nude",
-      "sword",
-      "scales",
-      "Renaissance",
-      "Dutch",
-      "engraving"
+      "#Justitia",
+      "#nude",
+      "#sword",
+      "#scales",
+      "#Renaissance",
+      "#Dutch",
+      "#engraving"
     ],
     "year": 1500,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Países Baixos",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, nude allegory, sword, scales",
-    "tags_str": "Justitia, nude, sword, scales, Renaissance, Dutch, engraving",
+    "tags_str": "#Justitia, #nude, #sword, #scales, #Renaissance, #Dutch, #engraving",
     "regime": "fundacional",
     "endurecimento_score": 0.9,
     "indicadores": {
@@ -11108,19 +11250,19 @@
     "citation_abnt": "JUSTITIA (busto com coroa e olho pendente). [s.d.]. 1 escultura (busto). Rijksmuseum, Amsterdam. Disponível em: https://www.rijksmuseum.nl/en/collection/object/Justitia--314f580f935ba978fb199ce7abeb0db1.",
     "citation_chicago": "Justitia (Bust with Crown and Eye Pendant). n.d. Bust Sculpture. Rijksmuseum, Amsterdam. https://www.rijksmuseum.nl/en/collection/object/Justitia--314f580f935ba978fb199ce7abeb0db1.",
     "tags": [
-      "Justitia",
-      "bust",
-      "crown",
-      "all-seeing eye",
-      "Dutch",
-      "surveillance"
+      "#Justitia",
+      "#bust",
+      "#crown",
+      "#all-seeing eye",
+      "#Dutch",
+      "#surveillance"
     ],
     "year": null,
     "medium_norm": "Outro",
     "country_pt": "Países Baixos",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, all-seeing eye, crown",
-    "tags_str": "Justitia, bust, crown, all-seeing eye, Dutch, surveillance",
+    "tags_str": "#Justitia, #bust, #crown, #all-seeing eye, #Dutch, #surveillance",
     "regime": "normativo",
     "endurecimento_score": 1.9,
     "indicadores": {
@@ -11181,19 +11323,19 @@
     "citation_abnt": "ALLEGORIE op de rechtvaardigheid. Século XVII. 1 gravura (página de título). Rijksmuseum, Amsterdam. Disponível em: https://www.rijksmuseum.nl/en/collection/object/Allegorie-op-de-rechtvaardigheid--a26144337b14ab57eb5ca23025308032.",
     "citation_chicago": "Allegorie op de rechtvaardigheid (Allegory of Justice, Enthroned). 17th Century. Print. Rijksmuseum, Amsterdam. https://www.rijksmuseum.nl/en/collection/object/Allegorie-op-de-rechtvaardigheid--a26144337b14ab57eb5ca23025308032.",
     "tags": [
-      "Justitia",
-      "enthroned",
-      "Baroque",
-      "Dutch",
-      "title page",
-      "sovereignty"
+      "#Justitia",
+      "#enthroned",
+      "#Baroque",
+      "#Dutch",
+      "#title page",
+      "#sovereignty"
     ],
     "year": 1650,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Países Baixos",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Justitia, Justice, enthroned, sovereignty of law",
-    "tags_str": "Justitia, enthroned, Baroque, Dutch, title page, sovereignty",
+    "tags_str": "#Justitia, #enthroned, #Baroque, #Dutch, #title page, #sovereignty",
     "regime": "normativo",
     "endurecimento_score": 2.0,
     "indicadores": {
@@ -11254,19 +11396,19 @@
     "citation_abnt": "MATHAM, Jacob (attr.). Rechtvaardigheid (Justitia). 1585–1589. 1 gravura. Rijksmuseum, Amsterdam. Disponível em: https://www.rijksmuseum.nl/en/collection/RP-P-OB-27.296.",
     "citation_chicago": "Matham, Jacob (attr.). Rechtvaardigheid (Justitia). 1585–1589. Engraving. Rijksmuseum, Amsterdam. https://www.rijksmuseum.nl/en/collection/RP-P-OB-27.296.",
     "tags": [
-      "Justitia",
-      "female allegory",
-      "Justice",
-      "Dutch Golden Age",
-      "Goltzius",
-      "virtue series"
+      "#Justitia",
+      "#female allegory",
+      "#Justice",
+      "#Dutch Golden Age",
+      "#Goltzius",
+      "#virtue series"
     ],
     "year": 1587,
     "medium_norm": "Gravura",
     "country_pt": "Países Baixos",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Alegoria feminina, Espada, Balança",
-    "tags_str": "Justitia, female allegory, Justice, Dutch Golden Age, Goltzius, virtue series",
+    "tags_str": "#Justitia, #female allegory, #Justice, #Dutch Golden Age, #Goltzius, #virtue series",
     "regime": "fundacional",
     "endurecimento_score": 1.1,
     "indicadores": {
@@ -11328,20 +11470,20 @@
     "citation_abnt": "DELFF, Willem Jacobsz. Vrouwe Justitia voor het oordeel van Zaleucus en het oordeel van Cambyses. 1590–1638. 1 gravura. Rijksmuseum, Amsterdam. Disponível em: https://www.rijksmuseum.nl/en/collection/RP-P-1883-A-6992.",
     "citation_chicago": "Delff, Willem Jacobsz. Vrouwe Justitia voor het oordeel van Zaleucus en het oordeel van Cambyses. 1590–1638. Engraving. Rijksmuseum, Amsterdam. https://www.rijksmuseum.nl/en/collection/RP-P-1883-A-6992.",
     "tags": [
-      "Justitia",
-      "female allegory",
-      "Justice",
-      "exempla iustitiae",
-      "Cambyses",
-      "Zaleucus",
-      "Dutch Golden Age"
+      "#Justitia",
+      "#female allegory",
+      "#Justice",
+      "#exempla iustitiae",
+      "#Cambyses",
+      "#Zaleucus",
+      "#Dutch Golden Age"
     ],
     "year": 1614,
     "medium_norm": "Gravura",
     "country_pt": "Países Baixos",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Alegoria feminina, Julgamento, Espada, Balança",
-    "tags_str": "Justitia, female allegory, Justice, exempla iustitiae, Cambyses, Zaleucus, Dutch Golden Age",
+    "tags_str": "#Justitia, #female allegory, #Justice, #exempla iustitiae, #Cambyses, #Zaleucus, #Dutch Golden Age",
     "regime": "fundacional",
     "endurecimento_score": 0.6,
     "indicadores": {
@@ -11402,19 +11544,19 @@
     "citation_abnt": "MATHAM, Jacob. Rechtvaardigheid (Justitia). 1597. 1 gravura. Rijksmuseum, Amsterdam. Disponível em: https://www.rijksmuseum.nl/en/collection/RP-P-OB-27.124.",
     "citation_chicago": "Matham, Jacob. Rechtvaardigheid (Justitia). 1597. Engraving. Rijksmuseum, Amsterdam. https://www.rijksmuseum.nl/en/collection/RP-P-OB-27.124.",
     "tags": [
-      "Justitia",
-      "female allegory",
-      "Justice",
-      "Dutch Golden Age",
-      "Goltzius",
-      "cardinal virtues"
+      "#Justitia",
+      "#female allegory",
+      "#Justice",
+      "#Dutch Golden Age",
+      "#Goltzius",
+      "#cardinal virtues"
     ],
     "year": 1597,
     "medium_norm": "Gravura",
     "country_pt": "Países Baixos",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Alegoria feminina, Espada, Balança",
-    "tags_str": "Justitia, female allegory, Justice, Dutch Golden Age, Goltzius, cardinal virtues",
+    "tags_str": "#Justitia, #female allegory, #Justice, #Dutch Golden Age, #Goltzius, #cardinal virtues",
     "regime": "fundacional",
     "endurecimento_score": 0.9,
     "indicadores": {
@@ -11475,19 +11617,19 @@
     "citation_abnt": "ANONIEM. Rechtvaardigheid (Justitia) / Iustitia. 1585–1637. 1 gravura. Rijksmuseum, Amsterdam. Disponível em: https://www.rijksmuseum.nl/en/collection/RP-P-1882-A-6499.",
     "citation_chicago": "Anonymous. Rechtvaardigheid (Justitia) / Iustitia. 1585–1637. Engraving. Rijksmuseum, Amsterdam. https://www.rijksmuseum.nl/en/collection/RP-P-1882-A-6499.",
     "tags": [
-      "Justitia",
-      "female allegory",
-      "Justice",
-      "Dutch Golden Age",
-      "Goltzius tradition",
-      "anonymous"
+      "#Justitia",
+      "#female allegory",
+      "#Justice",
+      "#Dutch Golden Age",
+      "#Goltzius tradition",
+      "#anonymous"
     ],
     "year": 1610,
     "medium_norm": "Gravura",
     "country_pt": "Países Baixos",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Alegoria feminina, Espada, Balança",
-    "tags_str": "Justitia, female allegory, Justice, Dutch Golden Age, Goltzius tradition, anonymous",
+    "tags_str": "#Justitia, #female allegory, #Justice, #Dutch Golden Age, #Goltzius tradition, #anonymous",
     "regime": "fundacional",
     "endurecimento_score": 0.9,
     "indicadores": {
@@ -11548,18 +11690,18 @@
     "citation_abnt": "MATHAM, Jacob. Rechtvaardigheid (Justitia). 1593. 1 gravura. Rijksmuseum, Amsterdam. Disponível em: https://www.rijksmuseum.nl/en/collection/RP-P-1887-A-12280.",
     "citation_chicago": "Matham, Jacob. Rechtvaardigheid (Justitia). 1593. Engraving. Rijksmuseum, Amsterdam. https://www.rijksmuseum.nl/en/collection/RP-P-1887-A-12280.",
     "tags": [
-      "Justitia",
-      "female allegory",
-      "Justice",
-      "Dutch Golden Age",
-      "Matham"
+      "#Justitia",
+      "#female allegory",
+      "#Justice",
+      "#Dutch Golden Age",
+      "#Matham"
     ],
     "year": 1593,
     "medium_norm": "Gravura",
     "country_pt": "Países Baixos",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Alegoria feminina, Espada, Balança",
-    "tags_str": "Justitia, female allegory, Justice, Dutch Golden Age, Matham",
+    "tags_str": "#Justitia, #female allegory, #Justice, #Dutch Golden Age, #Matham",
     "regime": "fundacional",
     "endurecimento_score": 0.9,
     "indicadores": {
@@ -11619,18 +11761,18 @@
     "citation_abnt": "UNIÃO DEMOCRÁTICA POPULAR. Justiça popular: o Pide que assassinou Dias Coelho vai ser julgado nas costas do povo! [1975?]. 1 cartaz. Biblioteca Nacional de Portugal. Disponível em: https://bndigital.bnportugal.gov.pt/records/item/17148-justica-popular.",
     "citation_chicago": "União Democrática Popular. Justiça popular. c. 1975. Political poster. Biblioteca Nacional de Portugal. BND Portugal. https://bndigital.bnportugal.gov.pt/records/item/17148-justica-popular.",
     "tags": [
-      "popular justice",
-      "Carnation Revolution",
-      "political poster",
-      "Portugal",
-      "UDP"
+      "#popular justice",
+      "#Carnation Revolution",
+      "#political poster",
+      "#Portugal",
+      "#UDP"
     ],
     "year": 1975,
     "medium_norm": "Cartaz",
     "country_pt": "Portugal",
     "period_norm": "Séc. XX",
     "motif_str": "Justiça popular, Revolução, Cartaz político",
-    "tags_str": "popular justice, Carnation Revolution, political poster, Portugal, UDP",
+    "tags_str": "#popular justice, #Carnation Revolution, #political poster, #Portugal, #UDP",
     "regime": "militar",
     "endurecimento_score": 1.9,
     "indicadores": {
@@ -11690,18 +11832,18 @@
     "citation_abnt": "[ALEGORIA à História]. c. 1600. 1 gravura, água-forte, p&b. Biblioteca Nacional de Portugal. Disponível em: https://bndigital.bnportugal.gov.pt/records/item/39213-alegoria-a-historia.",
     "citation_chicago": "\"Alegoria à História.\" c. 1600. Engraving. Biblioteca Nacional de Portugal. BND Portugal. https://bndigital.bnportugal.gov.pt/records/item/39213-alegoria-a-historia.",
     "tags": [
-      "History allegory",
-      "female figure",
-      "engraving",
-      "early modern",
-      "Portugal"
+      "#History allegory",
+      "#female figure",
+      "#engraving",
+      "#early modern",
+      "#Portugal"
     ],
     "year": 1600,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Portugal",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Alegoria, História, Figura feminina, Gravura",
-    "tags_str": "History allegory, female figure, engraving, early modern, Portugal",
+    "tags_str": "#History allegory, #female figure, #engraving, #early modern, #Portugal",
     "regime": "fundacional",
     "endurecimento_score": 0.8,
     "indicadores": {
@@ -11760,18 +11902,18 @@
     "citation_abnt": "QUILLARD, Pierre Antoine. Alegoria à Morte. 1730. 1 gravura. Biblioteca Nacional de Portugal. Disponível em: https://bndigital.bnportugal.gov.pt/records/item/37491-alegoria-a-morte.",
     "citation_chicago": "Quillard, Pierre Antoine. Alegoria à Morte. 1730. Engraving. Biblioteca Nacional de Portugal. BND Portugal. https://bndigital.bnportugal.gov.pt/records/item/37491-alegoria-a-morte.",
     "tags": [
-      "Death allegory",
-      "Baroque",
-      "French-Portuguese",
-      "engraving",
-      "Quillard"
+      "#Death allegory",
+      "#Baroque",
+      "#French-Portuguese",
+      "#engraving",
+      "#Quillard"
     ],
     "year": 1730,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Portugal",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Alegoria, Morte, Gravura barroca",
-    "tags_str": "Death allegory, Baroque, French-Portuguese, engraving, Quillard",
+    "tags_str": "#Death allegory, #Baroque, #French-Portuguese, #engraving, #Quillard",
     "regime": "fundacional",
     "endurecimento_score": 0.8,
     "indicadores": {
@@ -11830,18 +11972,18 @@
     "citation_abnt": "QUILLARD, Pierre Antoine. Alegoria ao Tempo. 1730. 1 gravura. Biblioteca Nacional de Portugal. Disponível em: https://bndigital.bnportugal.gov.pt/records/item/37507-alegoria-ao-tempo.",
     "citation_chicago": "Quillard, Pierre Antoine. Alegoria ao Tempo. 1730. Engraving. Biblioteca Nacional de Portugal. BND Portugal. https://bndigital.bnportugal.gov.pt/records/item/37507-alegoria-ao-tempo.",
     "tags": [
-      "Time allegory",
-      "Baroque",
-      "French-Portuguese",
-      "engraving",
-      "Quillard"
+      "#Time allegory",
+      "#Baroque",
+      "#French-Portuguese",
+      "#engraving",
+      "#Quillard"
     ],
     "year": 1730,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Portugal",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Alegoria, Tempo, Gravura barroca",
-    "tags_str": "Time allegory, Baroque, French-Portuguese, engraving, Quillard",
+    "tags_str": "#Time allegory, #Baroque, #French-Portuguese, #engraving, #Quillard",
     "regime": "fundacional",
     "endurecimento_score": 0.8,
     "indicadores": {
@@ -11901,19 +12043,19 @@
     "citation_abnt": "A REPUBLICA precisa de ti: vota em Norton de Matos. 1949. 1 cartaz. Comissão Distrital do Porto. Biblioteca Nacional de Portugal. Disponível em: https://bndigital.bnportugal.gov.pt/.",
     "citation_chicago": "\"A Republica precisa de ti: vota em Norton de Matos.\" 1949. Political poster. Comissão Distrital do Porto. Biblioteca Nacional de Portugal. BND Portugal.",
     "tags": [
-      "Republic",
-      "female allegory",
-      "election",
-      "Norton de Matos",
-      "anti-dictatorship",
-      "Portugal"
+      "#Republic",
+      "#female allegory",
+      "#election",
+      "#Norton de Matos",
+      "#anti-dictatorship",
+      "#Portugal"
     ],
     "year": 1949,
     "medium_norm": "Cartaz",
     "country_pt": "Portugal",
     "period_norm": "Estado Novo",
     "motif_str": "República, Alegoria feminina, Eleição, Cartaz político",
-    "tags_str": "Republic, female allegory, election, Norton de Matos, anti-dictatorship, Portugal",
+    "tags_str": "#Republic, #female allegory, #election, #Norton de Matos, #anti-dictatorship, #Portugal",
     "regime": "normativo",
     "endurecimento_score": 1.7,
     "indicadores": {
@@ -12122,19 +12264,19 @@
     "citation_abnt": "JUSTITIA enthroned, with sword and scales. Século XVII. 1 gravura. British Museum, London. Disponível em: https://www.britishmuseum.org/collection/object/P_1870-0625-185.",
     "citation_chicago": "Justitia Enthroned, with Sword and Scales. 17th Century. Print. British Museum, London. https://www.britishmuseum.org/collection/object/P_1870-0625-185.",
     "tags": [
-      "Justitia",
-      "enthroned",
-      "Baroque",
-      "British Museum",
-      "print",
-      "putti"
+      "#Justitia",
+      "#enthroned",
+      "#Baroque",
+      "#British Museum",
+      "#print",
+      "#putti"
     ],
     "year": 1650,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Reino Unido",
     "period_norm": "Barroco/Rococó",
     "motif_str": "Justitia, Justice, enthroned, sword, scales, putti",
-    "tags_str": "Justitia, enthroned, Baroque, British Museum, print, putti",
+    "tags_str": "#Justitia, #enthroned, #Baroque, #British Museum, #print, #putti",
     "regime": "normativo",
     "endurecimento_score": 1.8,
     "indicadores": {
@@ -12202,19 +12344,19 @@
     "citation_abnt": "PROVIDENCE and Justice (personificações femininas em nichos). [s.d.]. 1 gravura. British Museum, London. Disponível em: https://www.britishmuseum.org/collection/object/P_1862-0712-304.",
     "citation_chicago": "Providence and Justice (Female Personifications in Niches). n.d. Print. British Museum, London. https://www.britishmuseum.org/collection/object/P_1862-0712-304.",
     "tags": [
-      "Justitia",
-      "Providence",
-      "niches",
-      "architectural",
-      "British Museum",
-      "personification"
+      "#Justitia",
+      "#Providence",
+      "#niches",
+      "#architectural",
+      "#British Museum",
+      "#personification"
     ],
     "year": null,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Reino Unido",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, Providence, scales, snake",
-    "tags_str": "Justitia, Providence, niches, architectural, British Museum, personification",
+    "tags_str": "#Justitia, #Providence, #niches, #architectural, #British Museum, #personification",
     "regime": "normativo",
     "endurecimento_score": 2.3,
     "indicadores": {
@@ -12283,19 +12425,19 @@
     "citation_abnt": "JUSTITIA and Prudentia (personificações femininas). [s.d.]. 1 gravura. British Museum, London. Disponível em: https://www.britishmuseum.org/collection/object/P_1862-0712-305.",
     "citation_chicago": "Justitia and Prudentia (Female Personifications). n.d. Print. British Museum, London. https://www.britishmuseum.org/collection/object/P_1862-0712-305.",
     "tags": [
-      "Justitia",
-      "Prudentia",
-      "cardinal virtues",
-      "British Museum",
-      "sword",
-      "mirror"
+      "#Justitia",
+      "#Prudentia",
+      "#cardinal virtues",
+      "#British Museum",
+      "#sword",
+      "#mirror"
     ],
     "year": null,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "Reino Unido",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Justice, Prudentia, sword, mirror, cardinal virtues",
-    "tags_str": "Justitia, Prudentia, cardinal virtues, British Museum, sword, mirror",
+    "tags_str": "#Justitia, #Prudentia, #cardinal virtues, #British Museum, #sword, #mirror",
     "regime": "normativo",
     "endurecimento_score": 2.3,
     "indicadores": {
@@ -12363,20 +12505,20 @@
     "citation_abnt": "POMEROY, Frederick William. Lady Justice. 1907. 1 escultura em bronze dourado. Central Criminal Court (Old Bailey), London. Disponível em: http://www.speel.me.uk/sculptlondon/oldbaileyjustice.htm.",
     "citation_chicago": "Pomeroy, Frederick William. Lady Justice. 1907. Bronze and Gilt Sculpture. Central Criminal Court (Old Bailey), London. http://www.speel.me.uk/sculptlondon/oldbaileyjustice.htm.",
     "tags": [
-      "Lady Justice",
-      "Old Bailey",
-      "London",
-      "unblindfolded",
-      "bronze",
-      "courthouse",
-      "Pomeroy"
+      "#Lady Justice",
+      "#Old Bailey",
+      "#London",
+      "#unblindfolded",
+      "#bronze",
+      "#courthouse",
+      "#Pomeroy"
     ],
     "year": 1907,
     "medium_norm": "Outro",
     "country_pt": "Reino Unido",
     "period_norm": "Séc. XIX",
     "motif_str": "Justice, Lady Justice, sword, scales, unblindfolded",
-    "tags_str": "Lady Justice, Old Bailey, London, unblindfolded, bronze, courthouse, Pomeroy",
+    "tags_str": "#Lady Justice, #Old Bailey, #London, #unblindfolded, #bronze, #courthouse, #Pomeroy",
     "regime": "normativo",
     "endurecimento_score": 2.4,
     "indicadores": {
@@ -12442,20 +12584,20 @@
     "citation_abnt": "DELAUNE, Étienne. Woman holding sword and scales of justice (Jurisprudentia). c. 1560. 1 gravura. Wellcome Collection, London. Disponível em: https://wellcomecollection.org/works/rkvhanzr.",
     "citation_chicago": "Delaune, Étienne. Woman Holding Sword and Scales of Justice (Jurisprudentia). c. 1560. Engraving. Wellcome Collection, London. https://wellcomecollection.org/works/rkvhanzr.",
     "tags": [
-      "Justitia",
-      "Jurisprudentia",
-      "female allegory",
-      "Renaissance",
-      "Justice",
-      "Delaune",
-      "sword and scales"
+      "#Justitia",
+      "#Jurisprudentia",
+      "#female allegory",
+      "#Renaissance",
+      "#Justice",
+      "#Delaune",
+      "#sword and scales"
     ],
     "year": 1560,
     "medium_norm": "Gravura",
     "country_pt": "Reino Unido",
     "period_norm": "Renascimento/Moderno Inicial",
     "motif_str": "Justitia, Jurisprudência, Alegoria feminina, Espada, Balança",
-    "tags_str": "Justitia, Jurisprudentia, female allegory, Renaissance, Justice, Delaune, sword and scales",
+    "tags_str": "#Justitia, #Jurisprudentia, #female allegory, #Renaissance, #Justice, #Delaune, #sword and scales",
     "regime": "fundacional",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -12523,20 +12665,20 @@
     "citation_abnt": "KEALEY, Ernest James. Women of Britain say 'Go!'. 1915. 1 litografia colorida (cartaz). Imperial War Museum, London. Disponível em: https://www.iwm.org.uk/collections/item/object/14592.",
     "citation_chicago": "Kealey, Ernest James. Women of Britain Say 'Go!' 1915. Color Lithograph. Imperial War Museum, London. https://www.iwm.org.uk/collections/item/object/14592.",
     "tags": [
-      "female allegory",
-      "WWI",
-      "propaganda poster",
-      "Britain",
-      "recruitment",
-      "Parliamentary Recruiting Committee",
-      "gender and war"
+      "#female allegory",
+      "#WWI",
+      "#propaganda poster",
+      "#Britain",
+      "#recruitment",
+      "#Parliamentary Recruiting Committee",
+      "#gender and war"
     ],
     "year": 1915,
     "medium_norm": "Gravura",
     "country_pt": "Reino Unido",
     "period_norm": "Séc. XX",
     "motif_str": "Mulher, Alegoria feminina, Britânia, WWI, Propaganda, Recrutamento",
-    "tags_str": "female allegory, WWI, propaganda poster, Britain, recruitment, Parliamentary Recruiting Committee, gender and war",
+    "tags_str": "#female allegory, #WWI, #propaganda poster, #Britain, #recruitment, #Parliamentary Recruiting Committee, #gender and war",
     "regime": "militar",
     "endurecimento_score": 1.7,
     "indicadores": {
@@ -12742,7 +12884,8 @@
     ],
     "id": "UK-011",
     "country": "United Kingdom",
-    "support": "medalha"
+    "support": "medalha",
+    "tags_str": ""
   },
   {
     "url": "https://collections.vam.ac.uk/item/O102163",
@@ -12761,7 +12904,8 @@
     ],
     "id": "UK-012",
     "country": "United Kingdom",
-    "support": "monumento/escultura"
+    "support": "monumento/escultura",
+    "tags_str": ""
   },
   {
     "url": "https://collections.vam.ac.uk/item/O1242380",
@@ -12780,7 +12924,8 @@
     ],
     "id": "UK-013",
     "country": "United Kingdom",
-    "support": "monumento/escultura"
+    "support": "monumento/escultura",
+    "tags_str": ""
   },
   {
     "url": "https://collections.vam.ac.uk/item/O1261189",
@@ -12799,7 +12944,8 @@
     ],
     "id": "UK-014",
     "country": "United Kingdom",
-    "support": "monumento/escultura"
+    "support": "monumento/escultura",
+    "tags_str": ""
   },
   {
     "url": "https://collections.vam.ac.uk/item/O126326",
@@ -12818,7 +12964,8 @@
     ],
     "id": "UK-015",
     "country": "United Kingdom",
-    "support": "monumento/escultura"
+    "support": "monumento/escultura",
+    "tags_str": ""
   },
   {
     "url": "https://collections.vam.ac.uk/item/O190041",
@@ -12837,7 +12984,8 @@
     ],
     "id": "UK-016",
     "country": "United Kingdom",
-    "support": "pintura"
+    "support": "pintura",
+    "tags_str": ""
   },
   {
     "url": "https://collections.vam.ac.uk/item/O77466",
@@ -12856,7 +13004,8 @@
     ],
     "id": "UK-017",
     "country": "United Kingdom",
-    "support": "medalha"
+    "support": "medalha",
+    "tags_str": ""
   },
   {
     "url": "https://iconocracy.corpus/vault/d6f71fb1-437c-5e18-85d1-4395f54f6306",
@@ -12887,7 +13036,8 @@
     ],
     "id": "UK-018",
     "country": "United Kingdom",
-    "support": "moeda"
+    "support": "moeda",
+    "tags_str": ""
   },
   {
     "id": "UK-FLORIN-1902",
@@ -13029,18 +13179,18 @@
     "citation_abnt": "ROYAL MINT. Penny — Britannia. 1860-1894. Moeda, bronze. Design: Leonard Charles Wyon. Disponível em: https://en.numista.com/catalogue/pieces3377.html. Acesso em: 01 abr. 2026.",
     "citation_chicago": "Royal Mint. Penny — Britannia. 1860–1894. Bronze coin. Numista. https://en.numista.com/catalogue/pieces3377.html.",
     "tags": [
-      "female allegory",
-      "Britannia",
-      "normative regime",
-      "numismatics",
-      "mass circulation"
+      "#female allegory",
+      "#Britannia",
+      "#normative regime",
+      "#numismatics",
+      "#mass circulation"
     ],
     "year": 1860,
     "medium_norm": "coin",
     "country_pt": "Reino Unido",
     "period_norm": "Vitoriano (1860-1894)",
     "motif_str": "Britannia",
-    "tags_str": "female allegory, Britannia, mass circulation",
+    "tags_str": "#female allegory, #Britannia, #normative regime, #numismatics, #mass circulation",
     "regime": "normativo",
     "support": "moeda",
     "in_scope": true,
@@ -13224,19 +13374,19 @@
     "citation_abnt": "ROYAL MINT. British Trade Dollar. 1895-1935. Moeda, prata .900, 39 mm. Disponível em: https://en.numista.com/catalogue/pieces8472.html. Acesso em: 01 abr. 2026.",
     "citation_chicago": "Royal Mint. British Trade Dollar. 1895–1935. Silver coin. Numista. https://en.numista.com/catalogue/pieces8472.html.",
     "tags": [
-      "female allegory",
-      "Britannia",
-      "colonial",
-      "trade dollar",
-      "military regime",
-      "numismatics"
+      "#female allegory",
+      "#Britannia",
+      "#colonial",
+      "#trade dollar",
+      "#military regime",
+      "#numismatics"
     ],
     "year": 1895,
     "medium_norm": "coin",
     "country_pt": "Reino Unido",
     "period_norm": "Imperial (1895-1935)",
     "motif_str": "Britannia",
-    "tags_str": "female allegory, Britannia, colonial, trade dollar",
+    "tags_str": "#female allegory, #Britannia, #colonial, #trade dollar, #military regime, #numismatics",
     "regime": "militar",
     "support": "moeda",
     "in_scope": true,
@@ -13305,20 +13455,20 @@
     "citation_abnt": "AMERICA pois'd in the balance of justice. 1776. 1 gravura. Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/2004673327/.",
     "citation_chicago": "America Pois'd in the Balance of Justice. 1776. Etching and Engraving. Library of Congress, Washington, D.C. https://www.loc.gov/item/2004673327/.",
     "tags": [
-      "Justice",
-      "Britannia",
-      "America",
-      "Revolution",
-      "scales",
-      "geopolitics",
-      "1776"
+      "#Justice",
+      "#Britannia",
+      "#America",
+      "#Revolution",
+      "#scales",
+      "#geopolitics",
+      "#1776"
     ],
     "year": 1776,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "EUA",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Justice, Britannia, America, scales, Revolution",
-    "tags_str": "Justice, Britannia, America, Revolution, scales, geopolitics, 1776",
+    "tags_str": "#Justice, #Britannia, #America, #Revolution, #scales, #geopolitics, #1776",
     "regime": "fundacional",
     "endurecimento_score": 0.6,
     "indicadores": {
@@ -13384,19 +13534,19 @@
     "citation_abnt": "CRAWFORD, Thomas. Justice and History (modelo para o Capitólio dos EUA). c. 1860. 1 fotografia (salt print). Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/2009631377/.",
     "citation_chicago": "Crawford, Thomas. Justice and History (Plaster Model for US Capitol). c. 1860. Salted Paper Print. Library of Congress, Washington, D.C. https://www.loc.gov/item/2009631377/.",
     "tags": [
-      "Justice",
-      "History",
-      "Capitol",
-      "sculpture",
-      "Crawford",
-      "Senate doors"
+      "#Justice",
+      "#History",
+      "#Capitol",
+      "#sculpture",
+      "#Crawford",
+      "#Senate doors"
     ],
     "year": 1860,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "EUA",
     "period_norm": "Séc. XIX",
     "motif_str": "Justice, History, Capitol, Columbia",
-    "tags_str": "Justice, History, Capitol, sculpture, Crawford, Senate doors",
+    "tags_str": "#Justice, #History, #Capitol, #sculpture, #Crawford, #Senate doors",
     "regime": "normativo",
     "endurecimento_score": 2.1,
     "indicadores": {
@@ -13460,20 +13610,20 @@
     "citation_abnt": "JUSTICE (mulher vendada com espada e balança). [s.d.]. 1 gravura em aço. US Bureau of Printing & Engraving. Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/2007675578/.",
     "citation_chicago": "Justice (Blindfolded Woman with Sword and Scales). n.d. Steel Engraving. US Bureau of Printing & Engraving. Library of Congress, Washington, D.C. https://www.loc.gov/item/2007675578/.",
     "tags": [
-      "Justice",
-      "blindfold",
-      "sword",
-      "scales",
-      "government",
-      "official",
-      "steel engraving"
+      "#Justice",
+      "#blindfold",
+      "#sword",
+      "#scales",
+      "#government",
+      "#official",
+      "#steel engraving"
     ],
     "year": null,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "EUA",
     "period_norm": "Séc. XIX",
     "motif_str": "Justice, blindfold, sword, scales",
-    "tags_str": "Justice, blindfold, sword, scales, government, official, steel engraving",
+    "tags_str": "#Justice, #blindfold, #sword, #scales, #government, #official, #steel engraving",
     "regime": "normativo",
     "endurecimento_score": 2.2,
     "indicadores": {
@@ -13538,20 +13688,20 @@
     "citation_abnt": "ROMBERG, Maurice. Foire France-Américaine: Justice, Liberty, Demeter, Athena. 1917. 1 litogravura colorida. Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/99613542/.",
     "citation_chicago": "Romberg, Maurice. Foire France-Américaine: Justice, Liberty, Demeter, Athena. 1917. Color Lithograph Poster. Library of Congress, Washington, D.C. https://www.loc.gov/item/99613542/.",
     "tags": [
-      "Justice",
-      "Liberty",
-      "WWI",
-      "Franco-American",
-      "poster",
-      "Athena",
-      "allegory"
+      "#Justice",
+      "#Liberty",
+      "#WWI",
+      "#Franco-American",
+      "#poster",
+      "#Athena",
+      "#allegory"
     ],
     "year": 1917,
     "medium_norm": "Cartaz",
     "country_pt": "EUA",
     "period_norm": "Séc. XX",
     "motif_str": "Justice, Liberty, Athena, Demeter, Marianne, Columbia",
-    "tags_str": "Justice, Liberty, WWI, Franco-American, poster, Athena, allegory",
+    "tags_str": "#Justice, #Liberty, #WWI, #Franco-American, #poster, #Athena, #allegory",
     "regime": "militar",
     "endurecimento_score": 1.2,
     "indicadores": {
@@ -13618,20 +13768,20 @@
     "citation_abnt": "TRENCHARD, James. Behold! a fabric now to freedom rear'd. 1788. 1 gravura. Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/2004676797/.",
     "citation_chicago": "Trenchard, James. Behold! A Fabric Now to Freedom Rear'd (Constitutional Allegory). 1788. Etching. Library of Congress, Washington, D.C. https://www.loc.gov/item/2004676797/.",
     "tags": [
-      "Justice",
-      "Liberty",
-      "Constitution",
-      "Concord",
-      "Clio",
-      "founding",
-      "allegory"
+      "#Justice",
+      "#Liberty",
+      "#Constitution",
+      "#Concord",
+      "#Clio",
+      "#founding",
+      "#allegory"
     ],
     "year": 1788,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "EUA",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Justice, Liberty, Concord, Constitution, Columbia",
-    "tags_str": "Justice, Liberty, Constitution, Concord, Clio, founding, allegory",
+    "tags_str": "#Justice, #Liberty, #Constitution, #Concord, #Clio, #founding, #allegory",
     "regime": "fundacional",
     "endurecimento_score": 0.8,
     "indicadores": {
@@ -13699,19 +13849,19 @@
     "citation_abnt": "WILL, Johann Martin. Die Wage der Macht / La balance de la puissance. 1780. 1 gravura. Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/2004673370/.",
     "citation_chicago": "Will, Johann Martin. Die Wage der Macht / La Balance de la Puissance. 1780. Etching and Engraving. Library of Congress, Washington, D.C. https://www.loc.gov/item/2004673370/.",
     "tags": [
-      "Justice",
-      "Britannia",
-      "scales",
-      "geopolitics",
-      "bilingual",
-      "power balance"
+      "#Justice",
+      "#Britannia",
+      "#scales",
+      "#geopolitics",
+      "#bilingual",
+      "#power balance"
     ],
     "year": 1780,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "EUA",
     "period_norm": "Iluminismo (Séc. XVIII)",
     "motif_str": "Justice, Britannia, scales, geopolitics",
-    "tags_str": "Justice, Britannia, scales, geopolitics, bilingual, power balance",
+    "tags_str": "#Justice, #Britannia, #scales, #geopolitics, #bilingual, #power balance",
     "regime": "fundacional",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -13778,19 +13928,19 @@
     "citation_abnt": "COLUMBIA presenting sword to Admiral Dewey. 1899. 1 cromolitogravura. Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/2018697020/.",
     "citation_chicago": "Columbia Presenting Sword to Admiral Dewey. 1899. Chromolithograph. Library of Congress, Washington, D.C. https://www.loc.gov/item/2018697020/.",
     "tags": [
-      "Columbia",
-      "martial",
-      "Spanish-American War",
-      "Dewey",
-      "chromolithograph",
-      "imperialism"
+      "#Columbia",
+      "#martial",
+      "#Spanish-American War",
+      "#Dewey",
+      "#chromolithograph",
+      "#imperialism"
     ],
     "year": 1899,
     "medium_norm": "Outro",
     "country_pt": "EUA",
     "period_norm": "Séc. XIX",
     "motif_str": "Columbia, Liberty, martial allegory",
-    "tags_str": "Columbia, martial, Spanish-American War, Dewey, chromolithograph, imperialism",
+    "tags_str": "#Columbia, #martial, #Spanish-American War, #Dewey, #chromolithograph, #imperialism",
     "regime": "militar",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -13856,19 +14006,19 @@
     "citation_abnt": "HEDWIG Reicher as Columbia in suffrage pageant. 1913. 1 fotografia. Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/97510759/.",
     "citation_chicago": "Hedwig Reicher as Columbia in Suffrage Pageant. 1913. Photograph. Library of Congress, Washington, D.C. https://www.loc.gov/item/97510759/.",
     "tags": [
-      "Columbia",
-      "suffrage",
-      "feminism",
-      "pageant",
-      "photograph",
-      "women's rights"
+      "#Columbia",
+      "#suffrage",
+      "#feminism",
+      "#pageant",
+      "#photograph",
+      "#women's rights"
     ],
     "year": 1913,
     "medium_norm": "Fotografia",
     "country_pt": "EUA",
     "period_norm": "Séc. XIX",
     "motif_str": "Columbia, Justice, Liberty, suffrage, feminism",
-    "tags_str": "Columbia, suffrage, feminism, pageant, photograph, women's rights",
+    "tags_str": "#Columbia, #suffrage, #feminism, #pageant, #photograph, #women's rights",
     "regime": "normativo",
     "endurecimento_score": 1.3,
     "indicadores": {
@@ -13935,19 +14085,19 @@
     "citation_abnt": "THE GODDESS of Liberty (mulher com capa estrelada). 1861. 1 fotografia (carte de visite). Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/2018664118/.",
     "citation_chicago": "The Goddess of Liberty (Woman in Star-Spangled Cape). 1861. Albumen Print. Library of Congress, Washington, D.C. https://www.loc.gov/item/2018664118/.",
     "tags": [
-      "Liberty",
-      "Columbia",
-      "Civil War",
-      "carte de visite",
-      "photograph",
-      "living allegory"
+      "#Liberty",
+      "#Columbia",
+      "#Civil War",
+      "#carte de visite",
+      "#photograph",
+      "#living allegory"
     ],
     "year": 1861,
     "medium_norm": "Gravura/Estampe",
     "country_pt": "EUA",
     "period_norm": "Séc. XIX",
     "motif_str": "Liberty, Columbia, Civil War",
-    "tags_str": "Liberty, Columbia, Civil War, carte de visite, photograph, living allegory",
+    "tags_str": "#Liberty, #Columbia, #Civil War, #carte de visite, #photograph, #living allegory",
     "regime": "normativo",
     "endurecimento_score": 1.5,
     "indicadores": {
@@ -14014,20 +14164,20 @@
     "citation_abnt": "BELL, Jared W. Temple of liberty. 1834. 1 xilogravura. Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/2008661765/.",
     "citation_chicago": "Bell, Jared W. Temple of Liberty. 1834. Woodcut. Library of Congress, Washington, D.C. https://www.loc.gov/item/2008661765/.",
     "tags": [
-      "Liberty",
-      "female allegory",
-      "Goddess of Liberty",
-      "antebellum",
-      "republican values",
-      "American iconography",
-      "broadside"
+      "#Liberty",
+      "#female allegory",
+      "#Goddess of Liberty",
+      "#antebellum",
+      "#republican values",
+      "#American iconography",
+      "#broadside"
     ],
     "year": 1834,
     "medium_norm": "Gravura",
     "country_pt": "EUA",
     "period_norm": "Séc. XIX",
     "motif_str": "Liberdade, Alegoria feminina, Templo da Liberdade, Goddess of Liberty, Estados Unidos",
-    "tags_str": "Liberty, female allegory, Goddess of Liberty, antebellum, republican values, American iconography, broadside",
+    "tags_str": "#Liberty, #female allegory, #Goddess of Liberty, #antebellum, #republican values, #American iconography, #broadside",
     "regime": "fundacional",
     "endurecimento_score": 2.3,
     "indicadores": {
@@ -14095,20 +14245,20 @@
     "citation_abnt": "FLAGG, James Montgomery. Wake up America! Civilization calls every man, woman and child! 1917. 1 litografia colorida (cartaz). Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/91726511/.",
     "citation_chicago": "Flagg, James Montgomery. Wake Up America! Civilization Calls Every Man, Woman and Child! 1917. Color Lithograph. Library of Congress, Washington, D.C. https://www.loc.gov/item/91726511/.",
     "tags": [
-      "Columbia",
-      "female allegory",
-      "WWI",
-      "propaganda poster",
-      "James Montgomery Flagg",
-      "Phrygian cap",
-      "American iconography"
+      "#Columbia",
+      "#female allegory",
+      "#WWI",
+      "#propaganda poster",
+      "#James Montgomery Flagg",
+      "#Phrygian cap",
+      "#American iconography"
     ],
     "year": 1917,
     "medium_norm": "Gravura",
     "country_pt": "EUA",
     "period_norm": "Séc. XX",
     "motif_str": "Columbia, Alegoria feminina, Estados Unidos, WWI, Goddess of Liberty, Propaganda",
-    "tags_str": "Columbia, female allegory, WWI, propaganda poster, James Montgomery Flagg, Phrygian cap, American iconography",
+    "tags_str": "#Columbia, #female allegory, #WWI, #propaganda poster, #James Montgomery Flagg, #Phrygian cap, #American iconography",
     "regime": "militar",
     "endurecimento_score": 1.5,
     "indicadores": {
@@ -14176,20 +14326,20 @@
     "citation_abnt": "HALSTED, Frances Adams (des.); ADERENTE, Vincente (paint.). Columbia calls—Enlist now for U.S. Army. 1917. 1 litografia colorida (cartaz). Library of Congress, Washington, D.C. Disponível em: https://www.loc.gov/item/95506508/.",
     "citation_chicago": "Halsted, Frances Adams (designer) and Vincente Aderente (painter). Columbia Calls—Enlist Now for U.S. Army. 1917. Color Lithograph. Library of Congress, Washington, D.C. https://www.loc.gov/item/95506508/.",
     "tags": [
-      "Columbia",
-      "female allegory",
-      "WWI",
-      "propaganda poster",
-      "globe",
-      "American iconography",
-      "sword"
+      "#Columbia",
+      "#female allegory",
+      "#WWI",
+      "#propaganda poster",
+      "#globe",
+      "#American iconography",
+      "#sword"
     ],
     "year": 1917,
     "medium_norm": "Gravura",
     "country_pt": "EUA",
     "period_norm": "Séc. XX",
     "motif_str": "Columbia, Alegoria feminina, Estados Unidos, WWI, Propaganda",
-    "tags_str": "Columbia, female allegory, WWI, propaganda poster, globe, American iconography, sword",
+    "tags_str": "#Columbia, #female allegory, #WWI, #propaganda poster, #globe, #American iconography, #sword",
     "regime": "militar",
     "endurecimento_score": 1.7,
     "indicadores": {
@@ -14625,7 +14775,8 @@
     ],
     "id": "US-021",
     "country": "United States",
-    "support": "selo"
+    "support": "selo",
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/item/08030546/",
@@ -14644,7 +14795,8 @@
     ],
     "id": "US-022",
     "country": "United States",
-    "support": "frontispício"
+    "support": "frontispício",
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/item/12018646/",
@@ -14663,7 +14815,8 @@
     ],
     "id": "US-023",
     "country": "United States",
-    "support": "frontispício"
+    "support": "frontispício",
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/item/13016362/",
@@ -14682,7 +14835,8 @@
     ],
     "id": "US-024",
     "country": "United States",
-    "support": "frontispício"
+    "support": "frontispício",
+    "tags_str": ""
   },
   {
     "url": "https://www.loc.gov/item/2011630457",
@@ -14714,7 +14868,8 @@
     ],
     "id": "US-025",
     "country": "United States",
-    "support": "monumento/escultura"
+    "support": "monumento/escultura",
+    "tags_str": ""
   },
   {
     "id": "US-BANNER-1861",
@@ -14740,20 +14895,20 @@
     "citation_abnt": "HAIL! Glorious banner of our land. 1861. 1 litografia colorida. Library of Congress. Disponível em: https://www.loc.gov/item/91721286/. Acesso em: 11 abr. 2026.",
     "citation_chicago": "Hail! Glorious Banner of Our Land. 1861. Color lithograph. Library of Congress. https://www.loc.gov/item/91721286/.",
     "tags": [
-      "female allegory",
-      "Columbia",
-      "Civil War",
-      "military regime",
-      "flag",
-      "eagle",
-      "music cover"
+      "#female allegory",
+      "#Columbia",
+      "#Civil War",
+      "#military regime",
+      "#flag",
+      "#eagle",
+      "#music cover"
     ],
     "year": 1861,
     "medium_norm": "Estampa",
     "country_pt": "EUA",
     "period_norm": "Guerra Civil (1861)",
     "motif_str": "Columbia, flag, eagle",
-    "tags_str": "female allegory, Columbia, Civil War, military regime",
+    "tags_str": "#female allegory, #Columbia, #Civil War, #military regime, #flag, #eagle, #music cover",
     "regime": "militar",
     "support": "estampa/gravura",
     "in_scope": true,
@@ -14895,7 +15050,8 @@
     "citation_abnt": "Science Presenting Steam and Electricity to Commerce and Manufacture ($2 Silver Certificate)",
     "audit_flags": [
       "sem-thumbnail"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "id": "US-EDUC-1896-05",
@@ -14958,7 +15114,8 @@
     "citation_abnt": "Electricity Presenting Light to the World ($5 Silver Certificate)",
     "audit_flags": [
       "sem-thumbnail"
-    ]
+    ],
+    "tags_str": ""
   },
   {
     "id": "US-NAST-1864",
@@ -14986,21 +15143,21 @@
     "citation_abnt": "NAST, Thomas. The blessings of victory. 1864. 1 fotografia de gravura em madeira (carte de visite). Library of Congress. Disponível em: https://www.loc.gov/item/2022631575/. Acesso em: 11 abr. 2026.",
     "citation_chicago": "Nast, Thomas. The Blessings of Victory. 1864. Photograph of wood engraving. Library of Congress. https://www.loc.gov/item/2022631575/.",
     "tags": [
-      "female allegory",
-      "Liberty",
-      "Columbia",
-      "Civil War",
-      "military regime",
-      "Thomas Nast",
-      "Harper's Weekly",
-      "sword"
+      "#female allegory",
+      "#Liberty",
+      "#Columbia",
+      "#Civil War",
+      "#military regime",
+      "#Thomas Nast",
+      "#Harper's Weekly",
+      "#sword"
     ],
     "year": 1864,
     "medium_norm": "Estampa",
     "country_pt": "EUA",
     "period_norm": "Guerra Civil (1864)",
     "motif_str": "Liberty, Columbia, sword, palm branch",
-    "tags_str": "female allegory, Liberty, Columbia, Civil War, Thomas Nast",
+    "tags_str": "#female allegory, #Liberty, #Columbia, #Civil War, #military regime, #Thomas Nast, #Harper's Weekly, #sword",
     "regime": "militar",
     "support": "estampa/gravura",
     "in_scope": true,
@@ -15103,19 +15260,19 @@
     "citation_abnt": "US MINT. Standing Liberty Quarter. 1916-1930. Moeda, prata .900, 24,3 mm. Design: Hermon Atkins MacNeil. Disponível em: https://en.numista.com/catalogue/pieces15965.html. Acesso em: 01 abr. 2026.",
     "citation_chicago": "US Mint. Standing Liberty Quarter. 1916–1930. Silver coin. Numista. https://en.numista.com/catalogue/pieces15965.html.",
     "tags": [
-      "female allegory",
-      "Liberty",
-      "military regime",
-      "numismatics",
-      "nudity controversy",
-      "dessexualizacao"
+      "#female allegory",
+      "#Liberty",
+      "#military regime",
+      "#numismatics",
+      "#nudity controversy",
+      "#dessexualizacao"
     ],
     "year": 1916,
     "medium_norm": "coin",
     "country_pt": "EUA",
     "period_norm": "Era Progressista / WWI (1916-1930)",
     "motif_str": "Liberty",
-    "tags_str": "female allegory, Liberty, nudity controversy",
+    "tags_str": "#female allegory, #Liberty, #military regime, #numismatics, #nudity controversy, #dessexualizacao",
     "regime": "militar",
     "support": "moeda",
     "in_scope": true,
@@ -15183,21 +15340,21 @@
     "citation_abnt": "BLANES, Juan Manuel. El Altar de la Patria. 1896. 1 pintura (óleo sobre tela). Montevidéu: Museo Departamental de Bellas Artes Juan Manuel Blanes. Disponível em: https://www.museos.gub.uy/index.php/component/k2/item/1550-juan-manuel-blanes-1830-1901. Acesso em: 28 mar. 2026.",
     "citation_chicago": "Blanes, Juan Manuel. El Altar de la Patria. 1896. Oil on canvas. Museo Departamental de Bellas Artes Juan Manuel Blanes, Montevideo. https://www.museos.gub.uy/index.php/component/k2/item/1550-juan-manuel-blanes-1830-1901.",
     "tags": [
-      "alegoria nacional",
-      "pátria",
-      "Uruguai",
-      "altar cívico",
-      "pintura",
-      "república",
-      "feminino",
-      "Blanes"
+      "#alegoria nacional",
+      "#pátria",
+      "#Uruguai",
+      "#altar cívico",
+      "#pintura",
+      "#república",
+      "#feminino",
+      "#Blanes"
     ],
     "year": 1896,
     "medium_norm": "pintura",
     "country_pt": "Uruguai",
     "period_norm": "Séc. XIX",
     "motif_str": "alegoria nacional feminina, pátria, Uruguai, altar cívico, nação",
-    "tags_str": "alegoria nacional, pátria, Uruguai, altar cívico, pintura, república, feminino, Blanes",
+    "tags_str": "#alegoria nacional, #pátria, #Uruguai, #altar cívico, #pintura, #república, #feminino, #Blanes",
     "regime": "fundacional",
     "endurecimento_score": 1.0,
     "indicadores": {
@@ -15262,14 +15419,14 @@
     "citation_abnt": "BAKER & GODWIN (grav. e ed.). Abraham Lincoln, Republican candidate for president of the United States. [New York : Baker & Godwin, c1860]. Xilografia com tipografia, imagem 39,3 × 55 cm. LC-DIG-ppmsca-19254. Library of Congress Prints and Photographs Division, Washington, D.C. Disponível em: https://www.loc.gov/item/2003689297/. Acesso em: 23 maio 2026.",
     "citation_chicago": "Baker & Godwin. \"Abraham Lincoln, Republican Candidate for President of the United States.\" ca. 1860. Woodcut with letterpress, image 39.3 × 55 cm. LC-DIG-ppmsca-19254. Library of Congress, Washington, D.C. https://www.loc.gov/item/2003689297/.",
     "tags": [
-      "Justitia",
-      "Justice",
-      "Lincoln",
-      "political allegory",
-      "woodcut",
-      "United States",
-      "1860",
-      "election"
+      "#Justitia",
+      "#Justice",
+      "#Lincoln",
+      "#political allegory",
+      "#woodcut",
+      "#United States",
+      "#1860",
+      "#election"
     ],
     "url_iiif": "",
     "url_image_download": "https://tile.loc.gov/storage-services/service/pnp/ppmsca/19200/19254v.jpg",
@@ -15294,7 +15451,8 @@
       "#verificar",
       "iconocode-pendente",
       "provenance:iconocracia-2026-05-19"
-    ]
+    ],
+    "tags_str": "#Justitia, #Justice, #Lincoln, #political allegory, #woodcut, #United States, #1860, #election"
   },
   {
     "id": "sq1-2026-05-19-gusman-justice-vengeance-003",
@@ -15321,15 +15479,15 @@
     "citation_abnt": "GUSMAN, Adolphe (grav.); PRUD'HON, Pierre Paul (des.); HADAMARD, Auguste (des. intm.). La Justice et la Vengeance Divine poursuivant le Crime. [1840–1878]. Xilogravura em papel China sobre papel grosso, 129 × 168 mm. Inv. 1878,0713.2311. British Museum, London. Disponível em: https://www.britishmuseum.org/collection/object/P_1878-0713-2311. Acesso em: 23 maio 2026.",
     "citation_chicago": "Gusman, Adolphe (block cutter), after Pierre Paul Prud'hon and Auguste Hadamard. \"La Justice et la Vengeance Divine poursuivant le Crime.\" ca. 1840–1878. Wood-engraving on China paper. 1878,0713.2311. British Museum, London. https://www.britishmuseum.org/collection/object/P_1878-0713-2311.",
     "tags": [
-      "Justitia",
-      "Vengeance divine",
-      "Crime",
-      "Prud'hon",
-      "wood-engraving",
-      "allegory",
-      "France",
-      "United Kingdom",
-      "19th century"
+      "#Justitia",
+      "#Vengeance divine",
+      "#Crime",
+      "#Prud'hon",
+      "#wood-engraving",
+      "#allegory",
+      "#France",
+      "#United Kingdom",
+      "#19th century"
     ],
     "url_iiif": "",
     "url_image_download": "",
@@ -15354,7 +15512,8 @@
       "#verificar",
       "iconocode-pendente",
       "provenance:iconocracia-2026-05-19"
-    ]
+    ],
+    "tags_str": "#Justitia, #Vengeance divine, #Crime, #Prud'hon, #wood-engraving, #allegory, #France, #United Kingdom, #19th century"
   },
   {
     "id": "sq1-2026-05-19-inger-liberty-004",
@@ -15383,15 +15542,15 @@
     "citation_abnt": "INGER, Christian (litógrafo). Liberty: Liberty brings to the earth justice and peace. [Philadelphia : s.n., 1863 ou 1864]. Litografia com aquarela, imagem 56,5 × 41,6 cm. LC-DIG-pga-03861. Library of Congress Prints and Photographs Division, Washington, D.C. Disponível em: https://www.loc.gov/pictures/item/2003689287/. Acesso em: 23 maio 2026.",
     "citation_chicago": "Inger, Christian. \"Liberty. 'Liberty Brings to the Earth Justice and Peace.'\" ca. 1863–1864. Lithograph with watercolor, image 56.5 × 41.6 cm. LC-DIG-pga-03861. Library of Congress, Washington, D.C. https://www.loc.gov/pictures/item/2003689287/.",
     "tags": [
-      "Justitia",
-      "Liberty",
-      "Peace",
-      "Civil War",
-      "Union allegory",
-      "Philadelphia Inquirer",
-      "lithograph",
-      "United States",
-      "1863"
+      "#Justitia",
+      "#Liberty",
+      "#Peace",
+      "#Civil War",
+      "#Union allegory",
+      "#Philadelphia Inquirer",
+      "#lithograph",
+      "#United States",
+      "#1863"
     ],
     "url_iiif": "",
     "url_image_download": "https://cdn.loc.gov/service/pnp/pga/03800/03861v.jpg",
@@ -15416,7 +15575,8 @@
       "#verificar",
       "iconocode-pendente",
       "provenance:iconocracia-2026-05-19"
-    ]
+    ],
+    "tags_str": "#Justitia, #Liberty, #Peace, #Civil War, #Union allegory, #Philadelphia Inquirer, #lithograph, #United States, #1863"
   },
   {
     "id": "sq1-2026-05-19-kimmel-outbreak-007",
@@ -15447,16 +15607,16 @@
     "citation_abnt": "KIMMEL & FORSTER (litógrafo e ed.); KIMMEL, Christopher (des.). The outbreak of the rebellion in the United States 1861. [New York : Kimmel & Forster, c1865]. Litografia em preto e cinza-oliva, imagem 48 × 62,5 cm. LC-DIG-pga-01777. Library of Congress Prints and Photographs Division, Washington, D.C. Disponível em: https://www.loc.gov/item/2004665366/. Acesso em: 23 maio 2026.",
     "citation_chicago": "Kimmel & Forster. \"The Outbreak of the Rebellion in the United States 1861.\" ca. 1865. Lithograph, image 48 × 62.5 cm. LC-DIG-pga-01777. Library of Congress, Washington, D.C. https://www.loc.gov/item/2004665366/.",
     "tags": [
-      "Justitia",
-      "Justice",
-      "Lincoln",
-      "Civil War",
-      "Union",
-      "lithograph",
-      "United States",
-      "1865",
-      "Buchanan",
-      "Columbia"
+      "#Justitia",
+      "#Justice",
+      "#Lincoln",
+      "#Civil War",
+      "#Union",
+      "#lithograph",
+      "#United States",
+      "#1865",
+      "#Buchanan",
+      "#Columbia"
     ],
     "url_iiif": "",
     "url_image_download": "https://cdn.loc.gov/service/pnp/pga/01700/01777v.jpg",
@@ -15481,7 +15641,8 @@
       "#verificar",
       "iconocode-pendente",
       "provenance:iconocracia-2026-05-19"
-    ]
+    ],
+    "tags_str": "#Justitia, #Justice, #Lincoln, #Civil War, #Union, #lithograph, #United States, #1865, #Buchanan, #Columbia"
   },
   {
     "id": "sq1-2026-05-19-traubel-triumph-006",
@@ -15511,16 +15672,16 @@
     "citation_abnt": "TRAUBEL, M. H. (litógrafo e ed.). Triumph. [Philadelphia : M. H. Traubel, c1861]. Litografia em verde-claro, buff e preto, imagem 54 × 41,1 cm. LC-DIG-pga-02893. Library of Congress Prints and Photographs Division, Washington, D.C. Disponível em: https://www.loc.gov/pictures/item/2004665350/. Acesso em: 23 maio 2026.",
     "citation_chicago": "Traubel, M. H. \"Triumph.\" ca. 1861. Lithograph, image 54 × 41.1 cm. LC-DIG-pga-02893. Library of Congress, Washington, D.C. https://www.loc.gov/pictures/item/2004665350/.",
     "tags": [
-      "Justitia",
-      "Justice",
-      "Freedom",
-      "Union",
-      "Civil War",
-      "lithograph",
-      "United States",
-      "1861",
-      "allegorical print",
-      "Confederacy"
+      "#Justitia",
+      "#Justice",
+      "#Freedom",
+      "#Union",
+      "#Civil War",
+      "#lithograph",
+      "#United States",
+      "#1861",
+      "#allegorical print",
+      "#Confederacy"
     ],
     "url_iiif": "",
     "url_image_download": "https://cdn.loc.gov/service/pnp/pga/02800/02893v.jpg",
@@ -15545,7 +15706,8 @@
       "#verificar",
       "iconocode-pendente",
       "provenance:iconocracia-2026-05-19"
-    ]
+    ],
+    "tags_str": "#Justitia, #Justice, #Freedom, #Union, #Civil War, #lithograph, #United States, #1861, #allegorical print, #Confederacy"
   },
   {
     "id": "sq2-2026-05-19-alegoria-lei-aurea-villares-004",
@@ -15572,15 +15734,15 @@
     "citation_abnt": "VILLARES, Décio Rodrigues. Alegoria à Lei de 13 de Maio de 1888 (estudo). [188-]. Óleo sobre tela. Museu Histórico Nacional, Rio de Janeiro. Disponível em: https://mhn.museus.gov.br/estudo-de-decio-villares-volta-ao-circuito-expositivo-do-mhn/. Acesso em: 19 maio 2026.",
     "citation_chicago": "Décio Rodrigues Villares. Alegoria à Lei de 13 de Maio de 1888 (estudo). ca. 1888. Oil on canvas. Museu Histórico Nacional, Rio de Janeiro. https://mhn.museus.gov.br/estudo-de-decio-villares-volta-ao-circuito-expositivo-do-mhn/.",
     "tags": [
-      "alegoria",
-      "Lei Áurea",
-      "abolição",
-      "Décio Villares",
-      "MHN",
-      "positivismo",
-      "republic",
-      "Brazil",
-      "século XIX"
+      "#alegoria",
+      "#Lei Áurea",
+      "#abolição",
+      "#Décio Villares",
+      "#MHN",
+      "#positivismo",
+      "#republic",
+      "#Brazil",
+      "#século XIX"
     ],
     "url_iiif": "",
     "url_image_download": "",
@@ -15603,7 +15765,8 @@
       "#verificar",
       "iconocode-pendente",
       "provenance:iconocracia-2026-05-19"
-    ]
+    ],
+    "tags_str": "#alegoria, #Lei Áurea, #abolição, #Décio Villares, #MHN, #positivismo, #republic, #Brazil, #século XIX"
   },
   {
     "id": "sq2-2026-05-19-republica-manoel-lopes-rodrigues-003",
@@ -15630,15 +15793,15 @@
     "citation_abnt": "RODRIGUES, Manoel Lopes. A República. 1896. Óleo sobre tela, 228 × 118,5 cm. Museu de Arte da Bahia, Salvador. Disponível em: https://artsandculture.google.com/asset/a-rep%C3%BAblica-manoel-lopes-rodrigues/AQGV9DG4UbJnBg. Acesso em: 19 maio 2026.",
     "citation_chicago": "Manoel Lopes Rodrigues. A República. 1896. Oil on canvas, 228 × 118.5 cm. Museu de Arte da Bahia, Salvador. https://artsandculture.google.com/asset/a-rep%C3%BAblica-manoel-lopes-rodrigues/AQGV9DG4UbJnBg.",
     "tags": [
-      "alegoria",
-      "república",
-      "feminina",
-      "barrete frígio",
-      "espada",
-      "Bahia",
-      "Manoel Lopes Rodrigues",
-      "MAB",
-      "Brazil"
+      "#alegoria",
+      "#república",
+      "#feminina",
+      "#barrete frígio",
+      "#espada",
+      "#Bahia",
+      "#Manoel Lopes Rodrigues",
+      "#MAB",
+      "#Brazil"
     ],
     "url_iiif": "",
     "url_image_download": "",
@@ -15662,6 +15825,7 @@
       "#verificar",
       "iconocode-pendente",
       "provenance:iconocracia-2026-05-19"
-    ]
+    ],
+    "tags_str": "#alegoria, #república, #feminina, #barrete frígio, #espada, #Bahia, #Manoel Lopes Rodrigues, #MAB, #Brazil"
   }
 ]


### PR DESCRIPTION
FR-048 had "verificar" without the # prefix, and FR-022's #colonialidade-do-ver was missing from tags_str. Fixed both by normalizing bare flag tags to #-prefixed form and rebuilding tags_str from the full tags list for all items.

https://claude.ai/code/session_017EyMbURjhyEKMB2f5VwJ8Y

## Summary

Describe the intent of this change in 2-4 lines.

## Surface

- [ ] Corpus/data
- [ ] Coding/analysis
- [ ] Writing/docs
- [ ] Infra/publishing

## Checks

- [ ] `python tools/scripts/validate_schemas.py data/processed/records.jsonl --schema master-record --verbose`
- [ ] `python tools/scripts/code_purification.py --status` if coding-related
- [ ] `python tools/scripts/vault_sync.py status` or `diff` if vault-facing
- [ ] Release/docs updated if GitHub Pages or Hugging Face is affected

## Notes

List any known drift, skipped checks, or external follow-up.
