### PR TITLE
data: re-acquire batch 2 source images — 33 items diagnosis (Fase A.1-alt)

### DIFF
--- a/binaries/Images-reacquired-2026-06-08/_batch2-report-2026-06-09.md
+++ b/binaries/Images-reacquired-2026-06-08/_batch2-report-2026-06-09.md
@@ -1,0 +1,112 @@
+# Re-aquisição Batch 2 — Relatório — 2026-06-09
+
+**Escopo:** 33 itens restantes do set de 51 com HTML/PDF salvo como `.jpg` (docs/decisions/nao-imagens-store-2026-05-30.json), excluindo os 18 do Batch 1 (Numista + Rijksmuseum).
+
+---
+
+## Resumo
+
+| Resultado | Count |
+|-----------|-------|
+| OK (imagem válida adquirida) | 0/33 |
+| Institutional Access | 4/33 |
+| NEEDS_MANUAL | 1/33 |
+| HTTP 403 (cloud IP block) | 27/33 |
+| Bot-protected | 1/33 |
+
+**Causa raiz:** O container cloud desta sessão tem IP bloqueado por Cloudflare e CDNs de museus/arquivos em TODOS os 33 domínios. Requisições diretas (`urllib`) retornam HTTP 403. O Exa conseguiu buscar HTML de alguns sites (BildIndex, IMS, Brasiliana, LucasCranach, DHM, BNE, museos.gub.uy) mas não retorna conteúdo binário. Este é um bloqueio de IP de provedor cloud — a aquisição precisa ser feita do laptop da Ana.
+
+---
+
+## Tabela por item
+
+| ID | Domain | Status | Notes |
+|----|--------|--------|-------|
+| BE-001 | collections.heritage.brussels | HTTP_403 | Cloudflare block; page not fetched via Exa |
+| BE-002 | be-monumen.be | HTTP_403 | HTTP 403 from container |
+| BR-005 | archive.nyu.edu | HTTP_403 | TIFF: `/bitstream/2451/61396/2/Rj12-03.tiff`; thumbnail JPG: `/retrieve/124973/Rj12-03.tiff.jpg` |
+| BR-006 | brasiliana.museus.gov.br | HTTP_403 | Alegoria da República, Chambelland 1922; Brasiliana code `f9686ffb4f947dbec319d3d63abefccf` |
+| BR-007 | memoria.bn.br | HTTP_403 | PDF per702390; download manual + pdftoppm -f 60 -l 60 -jpeg -r 200 |
+| BR-009 | acervos.ims.com.br | HTTP_403 | "A Justiça" Ceschiatti, id 010ACDF27248.jpg; requer liberação IMS |
+| BR-010 | eliseuvisconti.com.br | HTTP_403 | D702 O Progresso c.1910 pastel; Fundação Biblioteca Nacional RJ |
+| DE-001 | bildindex.de | HTTP_403 | que20183316 — Exa timeout; tente diretamente do laptop |
+| DE-002 | bildindex.de | HTTP_403 | obj08148970 — Justitia 1239-40 Capua; Datengeber: `http://foto.biblhertz.it/obj08148970` |
+| DE-003 | bildindex.de | HTTP_403 | obj30110594 — Göttin der Gerechtigkeit, Bernhard Rode; Deutsche Fotothek FD 253 077 |
+| DE-004 | bildindex.de | HTTP_403 | obj20553978 — Justitia an der Rathausuhr 1589 Esslingen; Bildarchiv Foto Marburg mi05228a07 |
+| DE-005 | bildindex.de | HTTP_403 | obj20672587 — Personifikation Gerechtigkeit 1660/1780 Lüneburg; Bildarchiv mi07014d04 |
+| DE-006 | bildindex.de | HTTP_403 | obj08158050 — Allegorie Justitia, Raimondi; Datengeber: `http://foto.biblhertz.it/obj08158050` |
+| DE-007 | bildindex.de | HTTP_403 | obj08108743 — Exa timeout; tente do laptop |
+| DE-008 | bildindex.de | HTTP_403 | obj20608421 — Justitia um 1558 Hameln; Deutsche Fotothek FD 351 316 |
+| DE-009 | bildindex.de | HTTP_403 | obj20459153 — Exa timeout; tente do laptop |
+| DE-010 | bildindex.de | HTTP_403 | obj20677105 — Jus Civile, Wenzinger 1752, Sankt Peter; Bildarchiv mi08920i01 |
+| DE-011 | bildindex.de | HTTP_403 | obj30143134 — Kamin mit Justitia um 1610 Leipzig; Deutsche Fotothek FD 115 733 |
+| DE-012 | lucascranach.org | HTTP_403 | Justice 1537 PRIVATE_NONE-P457; colecção privada; CDA page load OK via Exa |
+| DE-013 | dhm.de | HTTP_403 | Kaulbach Germania 1914, DHM Inv. 1988/82; solicitar via fotoservice@dhm.de |
+| DE-GERM-1900 | en.wikipedia.org | HTTP_403 | **Wikimedia Commons:** `File:DR_1900_56_Germania_Reichspost.jpg` (570×670, domínio público) |
+| DE-GERM-BELG-1914 | colnect.com | BOT_PROTECTED | Anubis Proof-of-Work; necessita browser real |
+| ES-001 | bdh.bne.es | HTTP_403 | BNE item 76944; IIIF: `bdh.bne.es/bnesearch/rest/imagen/iiif/manifest?id=76944` |
+| ES-002 | hemerotecadigital.bne.es | HTTP_403 | Hemeroteca card sid=3971781; jornal 1637; IIIF disponível via BNE API |
+| PT-001 | bndigital.bnportugal.gov.pt | INSTITUTIONAL_ACCESS | Item 17148 Justiça popular; **"acessível apenas na rede interna da BNP"** |
+| PT-002 | bndigital.bnportugal.gov.pt | INSTITUTIONAL_ACCESS | Item 39213 Alegoria à História; institucional BNP only |
+| PT-003 | bndigital.bnportugal.gov.pt | INSTITUTIONAL_ACCESS | Item 37491 Alegoria à Morte; institucional BNP only |
+| PT-004 | bndigital.bnportugal.gov.pt | INSTITUTIONAL_ACCESS | Item 37507 Alegoria ao Tempo; institucional BNP only |
+| UK-001 | britishmuseum.org | HTTP_403 | BM P_1870-0625-185; Exa timeout; tentar BM IIIF: `https://www.britishmuseum.org/collection/image/...` |
+| UK-002 | britishmuseum.org | HTTP_403 | BM P_1862-0712-304; Exa timeout |
+| UK-003 | britishmuseum.org | HTTP_403 | BM P_1862-0712-305; Exa timeout |
+| UK-004 | speel.me.uk | HTTP_403 | Site estático; Exa timeout; tente `curl` do laptop |
+| UY-001 | museos.gub.uy | NEEDS_MANUAL | Página de biografia de Blanes — sem imagem específica da obra na URL; identificar imagem correta manualmente |
+
+---
+
+## Diagnóstico por grupo
+
+### BildIndex.de (11 itens: DE-001–DE-011)
+
+O BildIndex funciona como agregador de imagens de partner portals com direitos reservados. Os 11 itens pertencem a três instituições:
+
+- **Bibliotheca Hertziana (Roma):** DE-002 e DE-006 → `http://foto.biblhertz.it/obj08148970` e `obj08158050`
+- **Deutsche Fotothek:** DE-003, DE-008, DE-011 → buscar via `https://www.deutschefotothek.de/`
+- **Bildarchiv Foto Marburg:** DE-004, DE-005, DE-010 e mais → `https://www.fotomarburg.de/`
+- DE-001, DE-007, DE-009 → Exa timeout; tentar do laptop diretamente
+
+**Estratégia laptop:** abrir cada URL no browser, esperar o viewer carregar, clicar "Download" ou fazer screenshot do viewer.
+
+### BNPortugal (4 itens: PT-001–PT-004)
+
+Acesso restrito à rede interna da BNP. Opções:
+1. Solicitar cópia via `bndigital@bnportugal.pt` com referência aos persistent IDs (`purl.pt/22074` para PT-001)
+2. Visitar a BNP presencialmente (Lisboa)
+3. Verificar se as obras têm acesso via IIIF público: `https://iiif.bnportugal.gov.pt/iiif/...`
+
+### British Museum (3 itens: UK-001–UK-003)
+
+BM tem IIIF. URLs padrão:
+- `https://iiif.thebritishmuseum.org/image/api/v3/iiif/P_1870-0625-185/full/full/0/default.jpg` (adaptar por item)
+- Alternativamente: `https://media.britishmuseum.org/media/Repository/...` — verificar do laptop
+
+### Wikimedia Commons (1 item: DE-GERM-1900)
+
+**Download imediato do laptop:**
+```
+wget "https://upload.wikimedia.org/wikipedia/commons/a/a7/DR_1900_56_Germania_Reichspost.jpg" -O DE-GERM-1900.jpg
+```
+(ou qualquer outro arquivo da série: `DR_1900_55_Germania_Reichspost.jpg` para o 5Pf)
+
+### Misc (BR-005, BR-006, BR-007, BR-009, BR-010, DE-012, DE-013, DE-GERM-BELG-1914, ES-001, ES-002, UK-004, UY-001)
+
+Ver tabela acima para URLs e estratégias por item.
+
+---
+
+## Próximos passos recomendados (para Ana, do laptop)
+
+1. **DE-GERM-1900**: Download imediato do Wikimedia (link acima) — 1 min
+2. **BildIndex 11 itens**: Abrir no browser, screenshots ou download via viewer — ~30 min
+3. **BM 3 itens**: Testar IIIF URLs diretamente do laptop
+4. **PT 4 itens**: Solicitar à BNP via email com persistent IDs
+5. **BR-007**: `wget http://memoria.bn.br/pdf/702390/per702390_1827_00060.pdf && pdftoppm -f 60 -l 60 -jpeg -r 200 BR-007.pdf BR-007`
+6. **Demais**: Ver notas na tabela por item
+
+---
+
+*Relatório gerado em 2026-06-09 por sessão remota Claude Code (reacquire-images-batch2). O script de aquisição está em `tools/scripts/_batch2_acquire.py` para reutilização do laptop.*

--- a/binaries/Images-reacquired-2026-06-08/_batch2-results.json
+++ b/binaries/Images-reacquired-2026-06-08/_batch2-results.json
@@ -1,0 +1,266 @@
+[
+  {
+    "id": "BE-001",
+    "domain": "collections.heritage.brussels",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "Cloudflare block on cloud IP; page content not verified via Exa"
+  },
+  {
+    "id": "BE-002",
+    "domain": "be-monumen.be",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "HTTP 403 from container; Exa not tried"
+  },
+  {
+    "id": "BR-005",
+    "domain": "archive.nyu.edu",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "NYU DSpace: TIFF at /bitstream/2451/61396/2/Rj12-03.tiff; thumbnail at /retrieve/124973/Rj12-03.tiff.jpg — blocked from cloud IP"
+  },
+  {
+    "id": "BR-006",
+    "domain": "brasiliana.museus.gov.br",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "Alegoria da República by Carlos Chambelland 1922; Brasiliana code f9686ffb4f947dbec319d3d63abefccf; image at wp-content/uploads/2024/05/... — 403 from cloud"
+  },
+  {
+    "id": "BR-007",
+    "domain": "memoria.bn.br",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "PDF http://memoria.bn.br/pdf/702390/per702390_1827_00060.pdf — 403 from cloud IP; download manually, page 60"
+  },
+  {
+    "id": "BR-009",
+    "domain": "acervos.ims.com.br",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "IMS record 18758; identifier 010ACDF27248.jpg; 'A Justiça' por Marcel Gautherot c.1968; requer liberação de direitos IMS"
+  },
+  {
+    "id": "BR-010",
+    "domain": "eliseuvisconti.com.br",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "D702 O Progresso; pastel, c.1910; Fundação Biblioteca Nacional RJ; 403 from cloud"
+  },
+  {
+    "id": "DE-001",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "que20183316 — Exa timeout; Bildarchiv partner portal; try bildindex.de directly from laptop"
+  },
+  {
+    "id": "DE-002",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj08148970 — Justitia 1239-40, Capua; Datengeber: http://foto.biblhertz.it/obj08148970; Rechte vorbehalten"
+  },
+  {
+    "id": "DE-003",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj30110594 — Göttin der Gerechtigkeit, Bernhard Rode; Deutsche Fotothek FD 253 077; Rechte vorbehalten"
+  },
+  {
+    "id": "DE-004",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj20553978 — Justitia an der Rathausuhr 1589, Esslingen; Bildarchiv Foto Marburg mi05228a07; Rechte vorbehalten"
+  },
+  {
+    "id": "DE-005",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj20672587 — Personifikation Gerechtigkeit 1660/1780, Lüneburg; Bildarchiv Foto Marburg mi07014d04; Rechte vorbehalten"
+  },
+  {
+    "id": "DE-006",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj08158050 — Allegorie Justitia, Marcantonio Raimondi; Datengeber: http://foto.biblhertz.it/obj08158050; Rechte vorbehalten"
+  },
+  {
+    "id": "DE-007",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj08108743 — Exa timeout; Bildindex partner portal; try from laptop"
+  },
+  {
+    "id": "DE-008",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj20608421 — Justitia um 1558, Hameln; Deutsche Fotothek FD 351 316; Rechte vorbehalten"
+  },
+  {
+    "id": "DE-009",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj20459153 — Exa timeout; Bildindex partner portal; try from laptop"
+  },
+  {
+    "id": "DE-010",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj20677105 — Jus Civile, Christian Wenzinger 1752, Sankt Peter; Bildarchiv Foto Marburg mi08920i01; Rechte vorbehalten"
+  },
+  {
+    "id": "DE-011",
+    "domain": "www.bildindex.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "obj30143134 — Kamin mit Justitia um 1610, Leipzig Altes Rathaus; Deutsche Fotothek FD 115 733; Rechte vorbehalten"
+  },
+  {
+    "id": "DE-012",
+    "domain": "lucascranach.org",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "Cranach Justice 1537, PRIVATE_NONE-P457; CDA page loads via Exa; private collection — 403 for direct image"
+  },
+  {
+    "id": "DE-013",
+    "domain": "www.dhm.de",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "Kaulbach Germania 1914, DHM Inv. 1988/82; page loads via Exa; image requires request to fotoservice@dhm.de"
+  },
+  {
+    "id": "DE-GERM-1900",
+    "domain": "en.wikipedia.org",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "Wikimedia Commons: File:DR_1900_56_Germania_Reichspost.jpg (570x670, public domain); download from https://commons.wikimedia.org/wiki/File:DR_1900_56_Germania_Reichspost.jpg"
+  },
+  {
+    "id": "DE-GERM-BELG-1914",
+    "domain": "colnect.com",
+    "status": "BOT_PROTECTED",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "Colnect protected by Anubis PoW anti-bot; needs browser/laptop download"
+  },
+  {
+    "id": "ES-001",
+    "domain": "bdh.bne.es",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BNE Digital Library item 76944; IIIF likely at bdh.bne.es/rest/imagen/iiif/manifest?id=76944 — blocked from cloud"
+  },
+  {
+    "id": "ES-002",
+    "domain": "hemerotecadigital.bne.es",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BNE Hemeroteca card sid=3971781; 1637 newspaper; IIIF or download from laptop"
+  },
+  {
+    "id": "PT-001",
+    "domain": "bndigital.bnportugal.gov.pt",
+    "status": "INSTITUTIONAL_ACCESS",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BNP item 17148 Justiça popular UDP poster; 'acessível apenas na rede interna da BNP' — needs BNP institutional network or request to bndigital@bnportugal.pt"
+  },
+  {
+    "id": "PT-002",
+    "domain": "bndigital.bnportugal.gov.pt",
+    "status": "INSTITUTIONAL_ACCESS",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BNP item 39213 Alegoria à História; institucional only"
+  },
+  {
+    "id": "PT-003",
+    "domain": "bndigital.bnportugal.gov.pt",
+    "status": "INSTITUTIONAL_ACCESS",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BNP item 37491 Alegoria à Morte; institucional only"
+  },
+  {
+    "id": "PT-004",
+    "domain": "bndigital.bnportugal.gov.pt",
+    "status": "INSTITUTIONAL_ACCESS",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BNP item 37507 Alegoria ao Tempo; institucional only"
+  },
+  {
+    "id": "UK-001",
+    "domain": "www.britishmuseum.org",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BM P_1870-0625-185; Exa timeout; try BM IIIF API: https://iiif.thebritishmuseum.org/iiif/..."
+  },
+  {
+    "id": "UK-002",
+    "domain": "www.britishmuseum.org",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BM P_1862-0712-304; Exa timeout; try BM IIIF API"
+  },
+  {
+    "id": "UK-003",
+    "domain": "www.britishmuseum.org",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "BM P_1862-0712-305; Exa timeout; try BM IIIF API"
+  },
+  {
+    "id": "UK-004",
+    "domain": "www.speel.me.uk",
+    "status": "HTTP_403",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "speel.me.uk sculpture London; Exa timeout; small personal site, try curl from laptop"
+  },
+  {
+    "id": "UY-001",
+    "domain": "www.museos.gub.uy",
+    "status": "NEEDS_MANUAL",
+    "magic": "-",
+    "size_kb": 0,
+    "notes": "Blanes biography page — no specific artwork image at this URL; identify correct Blanes artwork image manually"
+  }
+]

--- a/tools/scripts/_batch2_acquire.py
+++ b/tools/scripts/_batch2_acquire.py
@@ -312,14 +312,14 @@ def process_item(item_id, url):
     print(f"  Processing {item_id} [{domain}] ...", end=" ", flush=True)
 
     try:
-        if 'bildindex.de' in domain:
+        if domain.endswith('bildindex.de') or domain == 'bildindex.de':
             data, ext, magic, img_url = handle_bildindex(item_id, url)
-        elif 'britishmuseum.org' in domain:
+        elif domain.endswith('.britishmuseum.org') or domain == 'britishmuseum.org':
             data, ext, magic, img_url = handle_britishmuseum(item_id, url)
             time.sleep(1.5)  # extra delay for BM
-        elif 'bnportugal.gov.pt' in domain:
+        elif domain.endswith('.bnportugal.gov.pt') or domain == 'bnportugal.gov.pt':
             data, ext, magic, img_url = handle_bnportugal(item_id, url)
-        elif 'memoria.bn.br' in domain:
+        elif domain.endswith('.memoria.bn.br') or domain == 'memoria.bn.br':
             data, ext, magic, img_url = handle_br007_pdf(item_id, url)
             if magic == "MANUAL_RENDER" or (magic and magic.startswith("PDF_SAVED")):
                 size_kb = os.path.getsize(os.path.join(OUTPUT_DIR, f"{item_id}.pdf")) // 1024 if os.path.exists(os.path.join(OUTPUT_DIR, f"{item_id}.pdf")) else 0
@@ -362,7 +362,7 @@ def main():
     for i, (item_id, url) in enumerate(BATCH2_ITEMS):
         from urllib.parse import urlparse
         domain = urlparse(url).netloc
-        delay = 3.0 if 'britishmuseum' in domain else 1.5
+        delay = 3.0 if (domain.endswith('.britishmuseum.org') or domain == 'britishmuseum.org') else 1.5
         if i > 0:
             time.sleep(delay)
         result = process_item(item_id, url)

--- a/tools/scripts/_batch2_acquire.py
+++ b/tools/scripts/_batch2_acquire.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""
+Batch 2 re-acquisition script: 33 items from bildindex.de, britishmuseum.org,
+bndigital.bnportugal.gov.pt, memoria.bn.br (BR-007 PDF), and misc domains.
+"""
+import urllib.request
+import urllib.error
+import json
+import re
+import time
+import os
+import sys
+
+OUTPUT_DIR = "/home/user/iconocracy-corpus/binaries/Images-reacquired-2026-06-08"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+
+BATCH2_ITEMS = [
+    ("BE-001", "https://collections.heritage.brussels/fr/objects/36822"),
+    ("BE-002", "https://be-monumen.be/patrimoine-belge/poelaert-joseph/"),
+    ("BR-005", "https://archive.nyu.edu/handle/2451/61396"),
+    ("BR-006", "https://brasiliana.museus.gov.br/acervos/alegoria-da-republica/"),
+    ("BR-007", "http://memoria.bn.br/pdf/702390/per702390_1827_00060.pdf"),
+    ("BR-009", "https://acervos.ims.com.br/index.php/Detail/objects/18758"),
+    ("BR-010", "https://eliseuvisconti.com.br/obra/d702/"),
+    ("DE-001", "https://www.bildindex.de/document/que20183316"),
+    ("DE-002", "https://www.bildindex.de/document/obj08148970"),
+    ("DE-003", "https://www.bildindex.de/document/obj30110594"),
+    ("DE-004", "https://www.bildindex.de/document/obj20553978"),
+    ("DE-005", "https://www.bildindex.de/document/obj20672587"),
+    ("DE-006", "https://www.bildindex.de/document/obj08158050"),
+    ("DE-007", "https://www.bildindex.de/document/obj08108743"),
+    ("DE-008", "https://www.bildindex.de/document/obj20608421"),
+    ("DE-009", "https://www.bildindex.de/document/obj20459153"),
+    ("DE-010", "https://www.bildindex.de/document/obj20677105"),
+    ("DE-011", "https://www.bildindex.de/document/obj30143134"),
+    ("DE-012", "https://lucascranach.org/en/PRIVATE_NONE-P457/"),
+    ("DE-013", "https://www.dhm.de/lemo/bestand/objekt/gemaelde-friedrich-august-von-kaulbach-germania-1914"),
+    ("DE-GERM-1900", "https://en.wikipedia.org/wiki/Germania_(stamp)"),
+    ("DE-GERM-BELG-1914", "https://colnect.com/en/stamps/stamp/320475-overprint_on_Germania-Belgium-Belgium_German_Occupation_i"),
+    ("ES-001", "https://bdh.bne.es/bnesearch/detalle/76944"),
+    ("ES-002", "https://hemerotecadigital.bne.es/hd/es/card?sid=3971781"),
+    ("PT-001", "https://bndigital.bnportugal.gov.pt/records/item/17148-justica-popular"),
+    ("PT-002", "https://bndigital.bnportugal.gov.pt/records/item/39213-alegoria-a-historia"),
+    ("PT-003", "https://bndigital.bnportugal.gov.pt/records/item/37491-alegoria-a-morte"),
+    ("PT-004", "https://bndigital.bnportugal.gov.pt/records/item/37507-alegoria-ao-tempo"),
+    ("UK-001", "https://www.britishmuseum.org/collection/object/P_1870-0625-185"),
+    ("UK-002", "https://www.britishmuseum.org/collection/object/P_1862-0712-304"),
+    ("UK-003", "https://www.britishmuseum.org/collection/object/P_1862-0712-305"),
+    ("UK-004", "http://www.speel.me.uk/sculptlondon/oldbaileyjustice.htm"),
+    ("UY-001", "https://www.museos.gub.uy/index.php/component/k2/item/1550-juan-manuel-blanes-1830-1901"),
+]
+
+def fetch_url(url, extra_headers=None, timeout=20):
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    if extra_headers:
+        for k, v in extra_headers.items():
+            req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read(), resp.geturl()
+
+def detect_magic(data):
+    if len(data) < 12:
+        return None, "TOO_SHORT"
+    if data[:3] == b'\xff\xd8\xff':
+        return "jpg", "JPEG"
+    if data[:8] == b'\x89PNG\r\n\x1a\n':
+        return "png", "PNG"
+    if data[:4] == b'RIFF' and data[8:12] == b'WEBP':
+        return "webp", "WEBP"
+    if data[:4] == b'%PDF':
+        return "pdf", "PDF"
+    sniff = data[:50].lower()
+    if b'<html' in sniff or b'<!doc' in sniff:
+        return None, "HTML"
+    return None, "UNKNOWN"
+
+def extract_og_image(html_bytes):
+    try:
+        html = html_bytes.decode('utf-8', errors='replace')
+    except:
+        return None
+    # og:image
+    m = re.search(r'<meta[^>]+property=["\']og:image["\'][^>]+content=["\']([^"\']+)["\']', html, re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    m = re.search(r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+property=["\']og:image["\']', html, re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    # twitter:image
+    m = re.search(r'<meta[^>]+(?:name|property)=["\']twitter:image["\'][^>]+content=["\']([^"\']+)["\']', html, re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    m = re.search(r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+(?:name|property)=["\']twitter:image["\']', html, re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    return None
+
+def extract_first_large_img(html_bytes, base_url=""):
+    try:
+        html = html_bytes.decode('utf-8', errors='replace')
+    except:
+        return None
+    imgs = re.findall(r'<img[^>]+src=["\']([^"\']+)["\'][^>]*>', html, re.IGNORECASE)
+    for src in imgs:
+        if any(ext in src.lower() for ext in ['.jpg', '.jpeg', '.png', '.webp', '.gif']):
+            if not src.startswith('http'):
+                from urllib.parse import urljoin
+                src = urljoin(base_url, src)
+            return src
+    return None
+
+def fetch_image_from_url(img_url):
+    data, _ = fetch_url(img_url)
+    ext, magic_name = detect_magic(data)
+    if ext:
+        return data, ext, magic_name
+    return None, None, magic_name
+
+def handle_bildindex(item_id, url):
+    html, final_url = fetch_url(url, extra_headers={"Accept": "text/html,application/xhtml+xml"})
+    html_str = html.decode('utf-8', errors='replace')
+
+    # Try og:image first
+    img_url = extract_og_image(html)
+
+    # Try bildanzeige img
+    if not img_url:
+        m = re.search(r'<img[^>]+id=["\']bildanzeige["\'][^>]+src=["\']([^"\']+)["\']', html_str, re.IGNORECASE)
+        if m:
+            img_url = m.group(1)
+
+    # Try bildindex.de/bilder/ pattern
+    if not img_url:
+        m = re.search(r'(https://(?:www\.)?bildindex\.de/bilder/[^\s"\'<>]+)', html_str)
+        if m:
+            img_url = m.group(1)
+
+    # Try data-src or large image patterns
+    if not img_url:
+        m = re.search(r'data-src=["\']([^"\']+(?:jpg|jpeg|png|webp)[^"\']*)["\']', html_str, re.IGNORECASE)
+        if m:
+            img_url = m.group(1)
+
+    if not img_url:
+        # Try any image with typical art pattern
+        m = re.search(r'src=["\']([^"\']*(?:obj|que|bild)[^"\']*\.(?:jpg|jpeg|png|webp))["\']', html_str, re.IGNORECASE)
+        if m:
+            img_url = m.group(1)
+
+    if not img_url:
+        return None, None, "NO_OG_IMAGE", None
+
+    if not img_url.startswith('http'):
+        from urllib.parse import urljoin
+        img_url = urljoin(final_url, img_url)
+
+    data, final_img_url = fetch_url(img_url)
+    ext, magic_name = detect_magic(data)
+    if ext:
+        return data, ext, magic_name, img_url
+    return None, None, f"BAD_MAGIC:{magic_name}", img_url
+
+def handle_britishmuseum(item_id, url):
+    html, final_url = fetch_url(url, extra_headers={"Accept": "text/html,application/xhtml+xml"})
+    img_url = extract_og_image(html)
+    if not img_url:
+        return None, None, "NO_OG_IMAGE", None
+    if not img_url.startswith('http'):
+        from urllib.parse import urljoin
+        img_url = urljoin(final_url, img_url)
+    data, final_img_url = fetch_url(img_url)
+    ext, magic_name = detect_magic(data)
+    if ext:
+        return data, ext, magic_name, img_url
+    return None, None, f"BAD_MAGIC:{magic_name}", img_url
+
+def handle_bnportugal(item_id, url):
+    html, final_url = fetch_url(url)
+    html_str = html.decode('utf-8', errors='replace')
+    img_url = extract_og_image(html)
+
+    # Try IIIF manifest
+    if not img_url:
+        m = re.search(r'(https://[^\s"\'<>]+/manifest[^\s"\'<>]*)', html_str)
+        if m:
+            manifest_url = m.group(1)
+            try:
+                manifest_data, _ = fetch_url(manifest_url, extra_headers={"Accept": "application/json"})
+                manifest = json.loads(manifest_data)
+                # IIIF v3
+                try:
+                    img_url = manifest['items'][0]['items'][0]['items'][0]['body']['id']
+                except (KeyError, IndexError, TypeError):
+                    pass
+                # IIIF v2
+                if not img_url:
+                    try:
+                        img_url = manifest['sequences'][0]['canvases'][0]['images'][0]['resource']['@id']
+                    except (KeyError, IndexError, TypeError):
+                        pass
+            except:
+                pass
+
+    if not img_url:
+        # Look for IIIF image service URL pattern
+        m = re.search(r'(https://[^\s"\'<>]+/iiif/[^\s"\'<>]+/full/[^\s"\'<>]+)', html_str)
+        if m:
+            img_url = m.group(1)
+
+    if not img_url:
+        img_url = extract_first_large_img(html, final_url)
+
+    if not img_url:
+        return None, None, "NO_OG_IMAGE", None
+
+    if not img_url.startswith('http'):
+        from urllib.parse import urljoin
+        img_url = urljoin(final_url, img_url)
+
+    data, _ = fetch_url(img_url)
+    ext, magic_name = detect_magic(data)
+    if ext:
+        return data, ext, magic_name, img_url
+    return None, None, f"BAD_MAGIC:{magic_name}", img_url
+
+def handle_br007_pdf(item_id, url):
+    # Download the PDF
+    data, _ = fetch_url(url)
+    ext, magic_name = detect_magic(data)
+    if ext != "pdf":
+        return None, None, f"BAD_MAGIC:{magic_name}", None
+
+    pdf_path = os.path.join(OUTPUT_DIR, f"{item_id}.pdf")
+    with open(pdf_path, 'wb') as f:
+        f.write(data)
+
+    # Try pdftoppm
+    import subprocess
+    out_prefix = os.path.join(OUTPUT_DIR, f"{item_id}_p060")
+    try:
+        result = subprocess.run(
+            ["pdftoppm", "-f", "60", "-l", "60", "-jpeg", "-r", "200", pdf_path, out_prefix],
+            capture_output=True, timeout=60
+        )
+        # pdftoppm creates {prefix}-060.ppm or {prefix}-060.jpg
+        candidates = [f for f in os.listdir(OUTPUT_DIR) if f.startswith(f"{item_id}_p060") and f.endswith('.jpg')]
+        if candidates:
+            img_path = os.path.join(OUTPUT_DIR, candidates[0])
+            with open(img_path, 'rb') as f:
+                img_data = f.read()
+            ext2, magic2 = detect_magic(img_data)
+            if ext2:
+                return img_data, ext2, f"PDF+RENDER:{magic2}", url
+        # Check ppm output
+        candidates_ppm = [f for f in os.listdir(OUTPUT_DIR) if f.startswith(f"{item_id}_p060")]
+        if candidates_ppm:
+            return None, None, f"PDF_SAVED+PPM_RENDER:check_{candidates_ppm[0]}", url
+    except FileNotFoundError:
+        # pdftoppm not installed — try apt-get
+        try:
+            subprocess.run(["apt-get", "install", "-y", "poppler-utils"], capture_output=True, timeout=120)
+            result = subprocess.run(
+                ["pdftoppm", "-f", "60", "-l", "60", "-jpeg", "-r", "200", pdf_path, out_prefix],
+                capture_output=True, timeout=60
+            )
+            candidates = [f for f in os.listdir(OUTPUT_DIR) if f.startswith(f"{item_id}_p060") and f.endswith('.jpg')]
+            if candidates:
+                img_path = os.path.join(OUTPUT_DIR, candidates[0])
+                with open(img_path, 'rb') as f:
+                    img_data = f.read()
+                ext2, magic2 = detect_magic(img_data)
+                if ext2:
+                    return img_data, ext2, f"PDF+RENDER:{magic2}", url
+        except:
+            pass
+        return None, "pdf", "MANUAL_RENDER", url
+    except Exception as e:
+        return None, "pdf", f"MANUAL_RENDER:{e}", url
+
+    return None, "pdf", "MANUAL_RENDER", url
+
+def handle_generic(item_id, url, extra_sleep=0):
+    if extra_sleep:
+        time.sleep(extra_sleep)
+    html, final_url = fetch_url(url, extra_headers={"Accept": "text/html,application/xhtml+xml"})
+    # Check if what we got is already an image
+    ext, magic_name = detect_magic(html)
+    if ext:
+        return html, ext, magic_name, url
+
+    img_url = extract_og_image(html)
+    if not img_url:
+        img_url = extract_first_large_img(html, final_url)
+    if not img_url:
+        return None, None, "NO_OG_IMAGE", None
+
+    if not img_url.startswith('http'):
+        from urllib.parse import urljoin
+        img_url = urljoin(final_url, img_url)
+
+    data, _ = fetch_url(img_url)
+    ext, magic_name = detect_magic(data)
+    if ext:
+        return data, ext, magic_name, img_url
+    return None, None, f"BAD_MAGIC:{magic_name}", img_url
+
+
+def process_item(item_id, url):
+    from urllib.parse import urlparse
+    domain = urlparse(url).netloc
+
+    print(f"  Processing {item_id} [{domain}] ...", end=" ", flush=True)
+
+    try:
+        if 'bildindex.de' in domain:
+            data, ext, magic, img_url = handle_bildindex(item_id, url)
+        elif 'britishmuseum.org' in domain:
+            data, ext, magic, img_url = handle_britishmuseum(item_id, url)
+            time.sleep(1.5)  # extra delay for BM
+        elif 'bnportugal.gov.pt' in domain:
+            data, ext, magic, img_url = handle_bnportugal(item_id, url)
+        elif 'memoria.bn.br' in domain:
+            data, ext, magic, img_url = handle_br007_pdf(item_id, url)
+            if magic == "MANUAL_RENDER" or (magic and magic.startswith("PDF_SAVED")):
+                size_kb = os.path.getsize(os.path.join(OUTPUT_DIR, f"{item_id}.pdf")) // 1024 if os.path.exists(os.path.join(OUTPUT_DIR, f"{item_id}.pdf")) else 0
+                print(f"PDF_SAVED ({size_kb}KB) → {magic}")
+                return {"id": item_id, "domain": domain, "status": "MANUAL_RENDER", "magic": "PDF", "size_kb": size_kb, "notes": f"PDF saved; {magic}"}
+        else:
+            data, ext, magic, img_url = handle_generic(item_id, url)
+
+        if data and ext:
+            out_path = os.path.join(OUTPUT_DIR, f"{item_id}.{ext}")
+            with open(out_path, 'wb') as f:
+                f.write(data)
+            size_kb = len(data) // 1024
+            print(f"OK {magic} ({size_kb}KB)")
+            return {"id": item_id, "domain": domain, "status": "OK", "magic": magic, "size_kb": size_kb, "notes": img_url or url}
+        else:
+            # If BR-007 pdf was saved but no render
+            if item_id == "BR-007" and os.path.exists(os.path.join(OUTPUT_DIR, f"{item_id}.pdf")):
+                size_kb = os.path.getsize(os.path.join(OUTPUT_DIR, f"{item_id}.pdf")) // 1024
+                print(f"PDF_ONLY ({size_kb}KB) → {magic}")
+                return {"id": item_id, "domain": domain, "status": "MANUAL_RENDER", "magic": "PDF", "size_kb": size_kb, "notes": f"PDF saved; render failed: {magic}"}
+            print(f"FAIL → {magic}")
+            return {"id": item_id, "domain": domain, "status": "FAIL", "magic": magic or "UNKNOWN", "size_kb": 0, "notes": url}
+
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}")
+        return {"id": item_id, "domain": domain, "status": f"HTTP_{e.code}", "magic": "-", "size_kb": 0, "notes": str(e)}
+    except urllib.error.URLError as e:
+        print(f"URL_ERR: {e.reason}")
+        return {"id": item_id, "domain": domain, "status": "URL_ERROR", "magic": "-", "size_kb": 0, "notes": str(e.reason)}
+    except Exception as e:
+        print(f"ERR: {e}")
+        return {"id": item_id, "domain": domain, "status": "ERROR", "magic": "-", "size_kb": 0, "notes": str(e)[:120]}
+
+
+def main():
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    results = []
+
+    for i, (item_id, url) in enumerate(BATCH2_ITEMS):
+        from urllib.parse import urlparse
+        domain = urlparse(url).netloc
+        delay = 3.0 if 'britishmuseum' in domain else 1.5
+        if i > 0:
+            time.sleep(delay)
+        result = process_item(item_id, url)
+        results.append(result)
+
+    return results
+
+
+if __name__ == "__main__":
+    print("=== Batch 2 Re-acquisition ===\n")
+    results = main()
+
+    ok = [r for r in results if r['status'] == 'OK']
+    manual = [r for r in results if 'MANUAL' in r['status']]
+    fail = [r for r in results if r['status'] not in ('OK',) and 'MANUAL' not in r['status']]
+
+    print(f"\n=== Summary ===")
+    print(f"OK:     {len(ok)}/33")
+    print(f"Manual: {len(manual)}/33")
+    print(f"Fail:   {len(fail)}/33")
+
+    # Save JSON results for report generation
+    with open(os.path.join(OUTPUT_DIR, "_batch2-results.json"), 'w') as f:
+        json.dump(results, f, indent=2)
+    print(f"\nResults saved to {OUTPUT_DIR}/_batch2-results.json")


### PR DESCRIPTION
## Contexto

Continuação do PR #69 (batch 1: 18 itens Numista + Rijksmuseum, já mergeado).

Este PR cobre os **33 itens restantes** do set de 51 com HTML/PDF salvo indevidamente como `.jpg` (ver `docs/decisions/nao-imagens-store-2026-05-30.json`).

## Resultado: 0/33 imagens adquiridas

**Causa raiz:** O container cloud desta sessão tem IP bloqueado por Cloudflare e CDNs de museus/arquivos em todos os 33 domínios. HTTP 403 universal para requisições diretas. Este bloqueio é de nível de provedor cloud (AWS/GCP range) e não pode ser contornado sem proxy residencial ou download local.

## Contagens por domínio

| Domínio | Itens | Status |
|---------|-------|--------|
| bildindex.de | 11 | HTTP_403 — partner portals Hertziana/Fotothek/Marburg |
| bndigital.bnportugal.gov.pt | 4 | INSTITUTIONAL_ACCESS — "acessível apenas na rede interna da BNP" |
| britishmuseum.org | 3 | HTTP_403 — IIIF acessível do laptop |
| memoria.bn.br | 1 | HTTP_403 — PDF + pdftoppm do laptop |
| en.wikipedia.org (Wikimedia) | 1 | HTTP_403 — **download imediato**: `File:DR_1900_56_Germania_Reichspost.jpg` (público) |
| colnect.com | 1 | BOT_PROTECTED (Anubis PoW) |
| misc 1 domínio cada | 13 | HTTP_403 / NEEDS_MANUAL |

## O que está neste PR

- `binaries/Images-reacquired-2026-06-08/_batch2-report-2026-06-09.md` — diagnóstico completo por item, causa raiz, estratégia de aquisição manual por grupo de domínio
- `binaries/Images-reacquired-2026-06-08/_batch2-results.json` — resultados estruturados (33 entradas)
- `tools/scripts/_batch2_acquire.py` — script de aquisição para reutilização do laptop

## Próximos passos (para Ana, do laptop)

1. **DE-GERM-1900** (1 min): `wget "https://upload.wikimedia.org/wikipedia/commons/a/a7/DR_1900_56_Germania_Reichspost.jpg" -O DE-GERM-1900.jpg`
2. **BildIndex 11 itens** (~30 min): abrir no browser, download via viewer; Datengeber conhecidos em `_batch2-report-2026-06-09.md`
3. **BM 3 itens**: testar IIIF endpoints do laptop
4. **PT 4 itens**: solicitar à BNP via `bndigital@bnportugal.pt` com persistent IDs
5. **BR-007**: `wget http://memoria.bn.br/pdf/... && pdftoppm -f 60 -l 60 -jpeg -r 200`

## Checklist de verificação humana

- [ ] Revisar `_batch2-report-2026-06-09.md` — diagnóstico e estratégias por item
- [ ] Decidir quais dos 33 serão re-adquiridos manualmente vs. marcados `sem-imagem`
- [ ] Download DE-GERM-1900 do Wikimedia (público, 0 obstáculos)
- [ ] Para BildIndex: verificar se imagens do Bildarchiv Foto Marburg podem ser acessadas via https://www.fotomarburg.de/ com credenciais ou download livre
- [ ] Para PT: enviar request à BNP
- [ ] Batch 3 (se necessário): adicionar imagens adquiridas do laptop neste mesmo diretório e commitar

---

Relacionado a: #69 (batch 1 — Numista + Rijksmuseum, mergeado)

---
_Generated by [Claude Code](https://claude.ai/code/session_01USXeFjbG48cnP2aRDDe5im)_