### PR TITLE
rescue: E1/E3 pathosformel + decision docs IRR/coded_by + scaffold Cap. 1 (pós-squash #76)

### DIFF
--- a/tese/compilacao-2026-06-09/README.md
+++ b/tese/compilacao-2026-06-09/README.md
@@ -1,0 +1,142 @@
+# Compilação 2026-06-09 — Cap 1 com Pivot Atlas
+
+**Núcleo argumentativo (mosaico A+B+C, brainstorm 2026-06-09):**
+Pateman + Goodrich + Mondzain + Warburg articulam o **Contrato Sexual Visual** como dispositivo
+materializado em alegoria feminina oficial. O **Atlas Iconocrático** com **Pathosformel/Zwischenraum/Nachleben**
+operacionaliza a prova empírica. O **Painel 1** (Villares 1889 → Roty 1897 → Moitte) ilustra in vitro
+como a moldura teórica opera sobre o corpus.
+
+**Capítulo-alvo:** Capítulo 1 — Moldura Teórica (Parte I). Re-arquitetura de 4 para 6 seções com
+integração de Mondzain + Warburg + mini-análise empírica do Painel 1.
+
+**Fonte canônica:** `tese/manuscrito/Capitulo1_rev.md` (119 linhas atuais, 4 seções desenvolvidas).
+
+## Audiência e parâmetros
+
+| Campo | Valor |
+|-------|-------|
+| Audiência primária | Banca de qualificação PPGD/UFSC (nov/2027) + orientador Arno Dal Ri Jr. |
+| Audiência secundária | Leitor internacional futuro (artigo EN/DE derivado pós-quali) |
+| Língua | PT (citações no original; termos warburgianos preservados em alemão) |
+| Word target | 15.000–20.000 palavras (atual ~10.000; expansão de ~50%) |
+| Citação | ABNT NBR 6023:2025 |
+| Iconclass-chave | 48C51 (feminist iconography) |
+
+## Core argument em 3 linhas
+
+1. O Contrato Sexual silenciado por Pateman e o Direito como sistema de imagens demonstrado por Goodrich são duas faces de uma única operação — visíveis quando se acrescenta a economia icônica de Mondzain e o dispositivo Atlas de Warburg.
+2. A alegoria feminina oficial não é ornamento: é **materialização visual do contrato sexual** via quatro modalidades (substituição/naturalização/sacralização/pedagogia) operacionalizadas em três regimes iconocráticos (fundacional/normativo/militar).
+3. O **Atlas Iconocrático com painéis Zwischenraum** é o dispositivo metodológico warburguiano que permite testar empiricamente o Contrato Sexual Visual — anunciado no Cap 1 e desdobrado nos Caps 2, 7.
+
+## Case anchor
+
+**Abertura** (preservada do texto atual): Coluna do Congresso de Bruxelas 1848 + Meganck *Respect à la Constitution* (Huygebaert 2015). Cena belga como Atlas in-vitro: 4 alegorias femininas (Justiça, Nação, Liberdade, Constituição) compondo arquitetura cívica.
+
+**Fechamento** (novo, prova-de-conceito): **Painel 1 — Do Corpo Vivo ao Corpo Máquina** (já em DRAFT em `vault/tese/drafts/painel-1-zwischenraum-DRAFT.md`):
+
+| Item | ID | Função no painel |
+|------|-----|------------------|
+| Villares, *Alegoria da República* (1889) | BR-005 | Polo fundacional — corpo vivo que resiste |
+| Rops, *La République aimable* | FR-005 | Referência implícita — europeu, menos purificado |
+| Roty, *La Semeuse* (1897) | FR-038 | Polo normativo — corpo máquina |
+| Moitte/Janinet, *Liberté* | FR-SCOUT-006 | Contra-alegoria — resistência à abstração |
+
+Mini-análise no fechamento §1.6 (1–2 páginas, ~600 palavras) — não substitui Cap 7, apenas demonstra que a moldura teórica do Cap 1 é operacional.
+
+## Estrutura outline (6 seções, expansão da arquitetura atual de 4)
+
+### §1.1 — O contrato sexual como fundação silenciada *(preserva)*
+
+Pateman (1988/1993): contrato social pressupõe contrato sexual; "lei do direito sexual masculino" (Rich 1980); patriarcado fraternal; três contratos concretos (casamento, trabalho, prostituição).
+
+Abertura mantida: Bruxelas 1848 (Huygebaert; Meganck *Respect à la Constitution*; Coluna do Congresso de 47m com personificação feminina da Constituição → estátua de Leopoldo I).
+
+### §1.2 — O ponto cego visual: o que Pateman não viu *(preserva)*
+
+Pateman analisa contrato como texto; nunca examina selos, moedas, monumentos, alegorias. Marianne 1792 + sufrágio negado; Bélgica de Rogier; Bureau of Printing US + voto federal 1920.
+
+Fechamento mantido — antecipa Goodrich via "perucas, pórticos colunados, espada gravada em aço".
+
+### §1.3 — A visiocracia de Goodrich: o Direito como regime de imagens *(preserva)*
+
+Goodrich (2013a, 2013b, 2017): *ius imaginum* romano; emblemas medievais (Bartolus); visiocracia; "perucas, bancos elevados, cerimônias". Convergência com Legendre. Ponto cego de Goodrich: não examina o gênero da visiocracia.
+
+### §1.4 — **NOVA: Mondzain — economia icônica e Feminilidade de Estado**
+
+Mondzain (2002, edição canônica per CLAUDE.md): a economia do ícone como dispositivo teológico-político ocidental; imagem como fabricação de adesão. Articulação com Legendre (juiz totêmico) e Carson (hystéra) → conceito autoral **Feminilidade de Estado**.
+
+Distinção crítica (per CLAUDE.md terminologia mandatória):
+- Mondzain é fonte da **economia icônica**, não da Feminilidade de Estado
+- Feminilidade de Estado é conceito autoral (Legendre + Carson como genealogia)
+- Goodrich aproximou Mondzain em *Imago Decidendi* (2017) mas sem desenvolver iconocracia explicitamente
+
+Função argumentativa: explicar **por que a imagem opera como dispositivo de poder**, não apenas que opera. Ponte entre Goodrich (visiocracia descritiva) e a operação efetiva sobre o feminino.
+
+~1.500–2.000 palavras.
+
+### §1.5 — **NOVA: Warburg — Pathosformel, Zwischenraum, Nachleben e o Atlas como dispositivo**
+
+Warburg (Bilderatlas Mnemosyne): três conceitos canônicos preservados em alemão:
+- **Pathosformel**: fórmula gestual que recorre transmitindo afetos codificados
+- **Zwischenraum**: intervalo entre imagens onde o sentido se produz por montagem
+- **Nachleben**: sobrevida de formas antigas em contextos novos
+
+O **Atlas Iconocrático** desta tese é dispositivo metodológico warburguiano: 8 painéis temáticos (sumário canônico mar/2026) que montam alegorias femininas em séries comparativas. Cada painel revela Zwischenraum entre alegoria oficial e exclusão real.
+
+Articulação tripartite: Pateman (contrato sexual textual) + Goodrich (visiocracia genérica) + Mondzain (economia icônica) → Warburg (operação metodológica que torna a articulação testável).
+
+~1.500–2.000 palavras.
+
+### §1.6 — Proposição: o Contrato Sexual Visual + mini-análise Painel 1 *(expande atual §1.4)*
+
+Estrutura preservada das 4 modalidades atuais (substituição/naturalização/sacralização/pedagogia). Adições:
+
+1. **Articulação operacional com regimes iconocráticos**: as 4 modalidades produzem 3 regimes (fundacional/normativo/militar) — anúncio do Cap 2.
+2. **Mini-análise Painel 1** (1–2 páginas, ~600 palavras): Villares 1889 → Roty 1897 como **Zwischenraum** do corpo vivo ao corpo máquina; Pathosformel da semeadora repetindo entre República brasileira e Semeuse francesa; Nachleben das figuras clássicas em moedas oficiais. Mini-análise não substitui Cap 7 (Branquitude Neoclássica) — apenas demonstra que a moldura teórica é operacional.
+3. **Anúncio dos próximos capítulos**: Cap 2 (Mondzain + regimes + Atlas metodológico) · Cap 3 (Contrato Racial Visual + colonialidade do ver) · Caps 4-9 (Atlas com 8 painéis demonstrativos).
+
+~1.500 palavras adicionais sobre o §1.4 atual.
+
+## Derivação (Q5)
+
+**ENTRA no Cap 1 revisado:**
+- §1.4 Mondzain (economia icônica + Feminilidade de Estado como conceito autoral)
+- §1.5 Warburg (Pathosformel/Zwischenraum/Nachleben + Atlas como dispositivo)
+- §1.6 mini-análise empírica do Painel 1 (Villares/Roty + Pathosformel + Zwischenraum)
+
+**FICA FORA (alocação canônica preservada):**
+- Análise quantitativa, regimes operacionalizados em escala (Cap 2)
+- Estatística (Kruskal-Wallis, correspondence) (Cap 3)
+- Análise empírica completa do Painel 1 e demais 7 painéis (Cap 7 + Atlas)
+- Contrato Racial Visual desenvolvido (Cap 3)
+- Codificação metodológica (10 indicadores 0–3, dual-agent pipeline) (Cap 2)
+
+## TODO — primeiras 3 ações concretas de escrita
+
+1. **Inserir §1.4 Mondzain** (~1.500–2.000 palavras) entre o atual §1.3 (Goodrich) e o atual §1.4 (que vira §1.6). Articulação: economia icônica como ponte conceitual entre visiocracia (Goodrich) e o feminino. Atenção à terminologia obrigatória — Feminilidade de Estado é conceito autoral, não atribuir a Mondzain.
+
+2. **Inserir §1.5 Warburg** (~1.500–2.000 palavras) após o novo §1.4 (Mondzain). Apresentar 3 conceitos em alemão + Atlas Mnemosyne como genealogia metodológica + anúncio do Atlas Iconocrático como dispositivo desta tese.
+
+3. **Expandir o atual §1.4 (que vira §1.6)**: manter 4 modalidades + adicionar (a) articulação operacional com 3 regimes iconocráticos como anúncio Cap 2, (b) mini-análise Painel 1 (~600 palavras) usando Villares/Roty + Pathosformel/Zwischenraum, (c) anúncio explícito Atlas Iconocrático 8 painéis como produto da tese.
+
+## Pré-condições antes da escrita
+
+- [ ] Confirmar bibliografia: Goodrich-Mondzain "Imago Decidendi" 2017 — referência bibliográfica completa em `references.bib` (Task #3)
+- [ ] Localizar texto de Mondzain (2002) na biblioteca local — bibliografia mínima para §1.4
+- [ ] Confirmar Painel 1 DRAFT como base para mini-análise — `vault/tese/drafts/painel-1-zwischenraum-DRAFT.md` existe e pode ser citado/condensado
+- [ ] Decidir nomeação seções: §1.4 vira §1.6 sem renumeração das já existentes (alternativa: re-numerar; impacto baixo se feito antes de circular)
+
+## Referências de design
+
+- Sumário canônico: `tese/manuscrito/sumario_iconocracia.md`
+- Compilação anterior (cascata): `tese/compilacao-2026-04-19/README.md`
+- Compilação ontem (Cap 7): `tese/compilacao-2026-06-07/README.md`
+- Painel 1 DRAFT: `vault/tese/drafts/painel-1-zwischenraum-DRAFT.md`
+- Atlas Lab v1: `docs/atlas-lab-task-1-implementation-note.md`
+- Decisão dialética N: `docs/decisions/DIALETICA-N165-vs-265.md`
+
+---
+
+*Brainstorm conduzido via skill `thesis-brainstorm`. Q1=C (chapter), Q2=A+B+C (mosaico), Q3=Coluna do Congresso + Painel 1, Q4=banca quali + leitor EN/DE futuro, Q5=Mondzain+Warburg+mini-análise.*
+
+*Próxima sessão: implementar TODO #1 (escrita §1.4 Mondzain). Brainstorming não escreve o artefato; apenas o scaffold.*

--- a/tools/scripts/e1_pathosformel_batch.py
+++ b/tools/scripts/e1_pathosformel_batch.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+e1_pathosformel_batch.py — IMES E1 Pathosformel extraction batch runner.
+
+Reads records.jsonl, identifies items without purification coding,
+applies Gemma-4 (via Ollama) to code the 10 purification indicators,
+and writes results to data/processed/pathosformel_index.jsonl.
+
+Usage:
+    python tools/scripts/e1_pathosformel_batch.py --dry-run     # Test on 5 items
+    python tools/scripts/e1_pathosformel_batch.py --batch 50    # Code 50 items
+    python tools/scripts/e1_pathosformel_batch.py --all          # Code all uncoded
+    python tools/scripts/e1_pathosformel_batch.py --list         # List uncoded only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent.parent
+RECORDS_PATH = REPO / "data" / "processed" / "records.jsonl"
+CORPUS_PATH = REPO / "corpus" / "corpus-data.json"
+OUTPUT_PATH = REPO / "data" / "processed" / "pathosformel_index.jsonl"
+PURIFICATION_PATH = REPO / "data" / "processed" / "purification.jsonl"
+
+OLLAMA_URL = "http://localhost:11434/api/chat"
+OLLAMA_MODEL = "gemma4"
+OLLAMA_TIMEOUT = 300  # seconds per item (gemma4 is slow on MPS)
+
+CITATION_ABNT = (
+    "ITEM. In: ICONOCRACIA Corpus Digital de Alegorias Femininas. "
+    "Florianópolis: PPGD/UFSC, 2026. "
+    "Disponível em: https://iconocracia-companion.warholana.workers.dev. "
+    "Acesso em: {date}."
+)
+
+INDICATORS = [
+    "desincorporacao",
+    "rigidez_postural",
+    "dessexualizacao",
+    "uniformizacao_facial",
+    "heraldizacao",
+    "enquadramento_arquitetonico",
+    "apagamento_narrativo",
+    "monocromatizacao",
+    "serialidade",
+    "inscricao_estatal",
+]
+
+REGIMES = ["fundacional", "normativo", "militar", "contra-alegoria"]
+
+CODING_PROMPT = """Code the 10 purification indicators (0-3) and regime. Output ONLY valid JSON.
+
+Item: {title} | {place} | {date}
+Description: {summary}
+
+Fields: desincorporacao, rigidez_postural, dessexualizacao, uniformizacao_facial, heraldizacao, enquadramento_arquitetonico, apagamento_narrativo, monocromatizacao, serialidade, inscricao_estatal (each 0-3), regime_iconocratico (fundacional|normativo|militar|contra-alegoria), notes (brief justification)
+
+JSON:"""
+
+
+def load_records() -> list[dict]:
+    with open(RECORDS_PATH) as f:
+        return [json.loads(l) for l in f if l.strip()]
+
+
+def load_corpus() -> dict[str, dict]:
+    """Load corpus-data.json and index by URL for sigla lookup."""
+    with open(CORPUS_PATH) as f:
+        items = json.load(f)
+    url_to_item: dict[str, dict] = {}
+    for item in items:
+        url = item.get("url", "")
+        if url:
+            url_to_item[url] = item
+    return url_to_item
+
+
+def build_url_map(records: list[dict]) -> dict[str, dict]:
+    """Build URL -> record mapping."""
+    url_map: dict[str, dict] = {}
+    for r in records:
+        url = r.get("input", {}).get("input_url", "")
+        if url:
+            url_map[url] = r
+    return url_map
+
+
+def call_ollama(prompt: str, model: str = OLLAMA_MODEL) -> str | None:
+    """Call Ollama API and return response content (thinking or content field)."""
+    payload = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "options": {"temperature": 0.1, "num_predict": 2048}
+    }).encode()
+
+    req = urllib.request.Request(
+        OLLAMA_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=OLLAMA_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+            # Gemma-4 may output in 'thinking' field instead of 'content'
+            msg = data.get("message", {})
+            content = msg.get("content", "") or ""
+            thinking = msg.get("thinking", "") or ""
+            return content or thinking or None
+    except Exception as e:
+        print(f"  [ERROR] Ollama call failed: {e}", file=sys.stderr)
+        return None
+
+
+def parse_llm_response(raw: str) -> dict | None:
+    """Try to parse JSON from LLM response, handling thinking prefix."""
+    cleaned = raw.strip()
+    
+    # Strip markdown fences if present
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        cleaned = "\n".join(lines[1:])
+    if cleaned.endswith("```"):
+        cleaned = cleaned.rsplit("```", 1)[0].strip()
+    if cleaned.startswith("json"):
+        cleaned = cleaned[4:].strip()
+
+    # Try parsing the whole thing first
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        pass
+
+    # Find the LAST JSON object in the text (model outputs thinking first, then JSON)
+    # Look for the last occurrence of '{' that starts a valid JSON ending with '}'
+    last_start = cleaned.rfind("{")
+    last_end = cleaned.rfind("}")
+    
+    if last_start >= 0 and last_end > last_start:
+        candidate = cleaned[last_start:last_end+1]
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+    
+    # Try the first JSON block
+    first_start = cleaned.find("{")
+    first_end = cleaned.rfind("}")
+    if first_start >= 0 and first_end > first_start:
+        candidate = cleaned[first_start:first_end+1]
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            pass
+    
+    return None
+
+
+def get_webscout_text(record: dict) -> str:
+    """Extract webscout description from a record."""
+    ws = record.get("webscout", {})
+    summary = ws.get("summary_evidence", "")
+    results = ws.get("search_results", [])
+    extra = []
+    for r in results:
+        notes = r.get("notes", "")
+        if notes:
+            extra.append(notes)
+    all_text = summary
+    if extra:
+        all_text += " " + " ".join(extra[:3])
+    return all_text.strip() or "No description available."
+
+
+def code_item(record: dict, corpus_url_map: dict[str, dict]) -> dict | None:
+    """Code a single item using Gemma-4 via Ollama."""
+    item_id = record["item_id"]
+    inp = record.get("input", {})
+    url = inp.get("input_url", "")
+    title = inp.get("title_hint", "Untitled")
+    place = inp.get("place_hint", "Unknown")
+    date_hint = inp.get("date_hint", "")
+
+    summary = get_webscout_text(record)
+
+    # Get sigla from corpus URL map
+    sigla = ""
+    corpus_item = corpus_url_map.get(url)
+    if corpus_item:
+        sigla = corpus_item.get("id", "")
+    else:
+        # Fallback: search by URL match
+        # We already verified all 52 map, so this shouldn't trigger
+        sigla = item_id[:12]
+
+    # Build prompt
+    prompt = CODING_PROMPT.format(
+        title=title[:100],
+        place=place,
+        date=date_hint,
+        summary=summary[:500]
+    )
+
+    print(f"  Calling Gemma-4 for {sigla or item_id[:12]}...", end=" ", flush=True)
+    raw = call_ollama(prompt)
+    if not raw:
+        print("FAILED (no response)")
+        return None
+
+    parsed = parse_llm_response(raw)
+    if not parsed:
+        print("FAILED (parse error)")
+        print(f"    Raw: {raw[:200]}...")
+        return None
+
+    # Validate indicators
+    indicators = {}
+    for ind in INDICATORS:
+        val = parsed.get(ind)
+        if isinstance(val, (int, float)) and 0 <= val <= 3:
+            indicators[ind] = int(val)
+        else:
+            indicators[ind] = 0  # default on bad parse
+
+    regime = parsed.get("regime_iconocratico", "").strip().lower()
+    if regime not in REGIMES:
+        # Try to match
+        for r in REGIMES:
+            if r in regime:
+                regime = r
+                break
+        else:
+            regime = "fundacional"  # safe default
+
+    composto = sum(indicators.values()) / len(indicators)
+    notes = parsed.get("notes", "")
+    if not isinstance(notes, str):
+        notes = str(notes)
+    notes = notes[:200]
+
+    coded_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    result = {
+        "item_id": item_id,
+        "sigla_id": sigla,
+        "title": title,
+        "place": place,
+        "date": date_hint,
+        "url": url,
+        "coded_by": f"e1-gemma4/{OLLAMA_MODEL}",
+        "coded_at": coded_at,
+        **indicators,
+        "purificacao_composto": round(composto, 1),
+        "regime_iconocratico": regime,
+        "notes": notes,
+    }
+
+    print(f"DONE (score={composto:.1f}, regime={regime})")
+    return result
+
+
+def write_output(results: list[dict], output_path: Path):
+    """Append results to pathosformel_index.jsonl."""
+    mode = "a" if output_path.exists() else "w"
+    with open(output_path, mode) as f:
+        for r in results:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"\nWrote {len(results)} items to {output_path}")
+
+
+def list_uncoded(records: list[dict], corpus_url_map: dict[str, dict]):
+    """List all uncoded items with metadata."""
+    uncoded = [r for r in records
+               if r.get("purificacao", {}).get("purificacao_composto") in (None, -1)]
+    print(f"\nUncoded items: {len(uncoded)}\n")
+    print(f"{'SIGLA':<15} {'TITLE':<55} {'PLACE':<12} {'DATE':<15}")
+    print("-" * 100)
+    for r in uncoded:
+        url = r.get("input", {}).get("input_url", "")
+        corpus_item = corpus_url_map.get(url, {})
+        sigla = corpus_item.get("id", "???")
+        inp = r.get("input", {})
+        print(f"{sigla:<15} {inp.get('title_hint','?')[:53]:<55} "
+              f"{inp.get('place_hint','?'):<12} {inp.get('date_hint','?'):<15}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E1 Pathosformel batch runner")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--dry-run", action="store_true", help="Test on 5 items")
+    group.add_argument("--batch", type=int, metavar="N", help="Code N items")
+    group.add_argument("--all", action="store_true", help="Code all uncoded items")
+    group.add_argument("--list", action="store_true", help="List uncoded items")
+    parser.add_argument("--start", type=int, default=0, help="Skip first N uncoded items")
+    args = parser.parse_args()
+
+    if not any([args.dry_run, args.batch, args.all, args.list]):
+        parser.print_help()
+        sys.exit(1)
+
+    print("=== E1 Pathosformel Extraction ===\n")
+
+    records = load_records()
+    corpus_url_map = load_corpus()
+
+    uncoded = [r for r in records
+               if r.get("purificacao", {}).get("purificacao_composto") in (None, -1)]
+
+    if args.list:
+        list_uncoded(records, corpus_url_map)
+        return
+
+    if not uncoded:
+        print("All items already coded. Nothing to do.")
+        return
+
+    print(f"Records: {len(records)} | Uncoded: {len(uncoded)}")
+
+    # Determine how many to process
+    if args.dry_run:
+        count = min(5, len(uncoded))
+    elif args.all:
+        count = len(uncoded)
+    else:
+        count = min(args.batch, len(uncoded))
+
+    start = args.start
+    target = uncoded[start:start + count]
+
+    print(f"Processing: {len(target)} items (offset={start})\n")
+
+    results = []
+    failures = 0
+
+    for i, record in enumerate(target):
+        print(f"[{start + i + 1}/{len(uncoded)}] ", end="")
+        result = code_item(record, corpus_url_map)
+        if result:
+            results.append(result)
+        else:
+            failures += 1
+            print(f"  -> SKIPPED")
+
+        # Small delay between items to avoid hammering ollama
+        if i < len(target) - 1:
+            time.sleep(1)
+
+    print(f"\n=== Summary ===")
+    print(f"Success: {len(results)} | Failures: {failures}")
+
+    if results:
+        if args.dry_run:
+            print(f"\nDry-run results (NOT written):")
+            for r in results:
+                print(f"  {r['sigla_id']:<12} score={r['purificacao_composto']:.1f} "
+                      f"regime={r['regime_iconocratico']:<15} notes={r['notes'][:60]}")
+            print(f"\nTo write, run with --batch N or --all")
+        else:
+            OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+            write_output(results, OUTPUT_PATH)
+            print(f"\nOutput schema ({len(INDICATORS)} indicators + regime + score)")
+            if results:
+                print(json.dumps(list(results[0].keys()), ensure_ascii=False))
+
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/e1_recode_zeros.py
+++ b/tools/scripts/e1_recode_zeros.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+e1_recode_zeros.py — Re-codifica os 29 itens com score 0.0 no pathosformel_index
+usando descrições enriquecidas das notas do vault (SCOUT-XXX) + thumbnails.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent.parent
+RECORDS_PATH = REPO / "data" / "processed" / "records.jsonl"
+VAULT_DIR = REPO / "vault" / "candidatos"
+PATHOS_INDEX = REPO / "data" / "processed" / "pathosformel_index.jsonl"
+VAULT_RECORDS_PATH = REPO / "data" / "processed" / "vault_records.jsonl"
+
+OLLAMA_URL = "http://localhost:11434/api/chat"
+OLLAMA_MODEL = "gemma4"
+OLLAMA_TIMEOUT = 300
+
+INDICATORS = [
+    "desincorporacao", "rigidez_postural", "dessexualizacao",
+    "uniformizacao_facial", "heraldizacao", "enquadramento_arquitetonico",
+    "apagamento_narrativo", "monocromatizacao", "serialidade", "inscricao_estatal",
+]
+REGIMES = ["fundacional", "normativo", "militar", "contra-alegoria"]
+
+CODING_PROMPT = """Analyze this allegorical image and code the 10 purification indicators (0-3) and regime.
+
+TITLE: {title}
+COUNTRY: {place} | DATE: {date}
+SOURCE: {acervo} | MEDIUM: {suporte}
+THUMBNAIL: {thumb} (view this image for visual analysis)
+DESCRIPTION: {summary}
+
+Scale: 0=absent, 1=minimal, 2=moderate, 3=dominant/extreme
+
+Fields: desincorporacao, rigidez_postural, dessexualizacao, uniformizacao_facial, heraldizacao, enquadramento_arquitetonico, apagamento_narrativo, monocromatizacao, serialidade, inscricao_estatal (each 0-3), regime_iconocratico (fundacional|normativo|militar|contra-alegoria), notes (brief justification in Portuguese)
+
+JSON:"""
+
+
+def load_records() -> dict[str, dict]:
+    with open(RECORDS_PATH) as f:
+        return {json.loads(l)["item_id"]: json.loads(l) for l in f if l.strip()}
+
+
+def load_pathos() -> dict[str, dict]:
+    with open(PATHOS_INDEX) as f:
+        return {json.loads(l)["item_id"]: json.loads(l) for l in f if l.strip()}
+
+
+def read_vault_note(scout_id: int) -> dict:
+    """Extract metadata from a vault note."""
+    for f in VAULT_DIR.glob(f"SCOUT-{scout_id}*.md"):
+        text = f.read_text(encoding="utf-8")
+        
+        # Frontmatter
+        fm = {}
+        fm_match = re.search(r"^---\n(.*?)\n---", text, re.DOTALL)
+        if fm_match:
+            for line in fm_match.group(1).split("\n"):
+                if ":" in line:
+                    k, v = line.split(":", 1)
+                    fm[k.strip().strip('"')] = v.strip().strip('"')
+        
+        # Thumbnail URL
+        thumb = ""
+        # Pattern: [imagem](url)
+        m = re.search(r'\[imagem\]\(((https?://[^)]+))\)', text)
+        if m:
+            thumb = m.group(1)
+        # Pattern: thumbnail: url
+        if not thumb:
+            m = re.search(r'thumbnail[^:]*:\s*(https?://\S+)', text, re.IGNORECASE)
+            if m:
+                thumb = m.group(1).rstrip(")").rstrip(">")
+        
+        # Body text (after frontmatter)
+        body = re.sub(r"^---.*?---\n?", "", text, count=1, flags=re.DOTALL).strip()
+        
+        return {
+            "scout_id": scout_id,
+            "acervo": fm.get("acervo", "").strip('"'),
+            "suporte": fm.get("suporte", "").strip('"'),
+            "motivo": fm.get("motivo_alegorico", "").strip('"'),
+            "regime_fm": fm.get("regime", "").strip('"'),
+            "data_estimada": fm.get("data_estimada", "").strip('"'),
+            "thumb": thumb,
+            "body": body[:500],
+        }
+    return {"scout_id": scout_id, "acervo": "", "suporte": "", "motivo": "", "regime_fm": "", "data_estimada": "", "thumb": "", "body": ""}
+
+
+def find_scout_id(pathos_item: dict, records: dict) -> int | None:
+    """Find SCOUT ID from a pathos item by matching records."""
+    rec = records.get(pathos_item["item_id"])
+    if not rec:
+        return None
+    # The Scout ID is encoded in the webscout search_results notes
+    ws = rec.get("webscout", {})
+    for sr in ws.get("search_results", []):
+        notes = sr.get("notes", "")
+        m = re.search(r"SCOUT-(\d+)", notes)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def call_ollama(prompt: str) -> str | None:
+    payload = json.dumps({
+        "model": OLLAMA_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "options": {"temperature": 0.1, "num_predict": 2048}
+    }).encode()
+    req = urllib.request.Request(
+        OLLAMA_URL, data=payload,
+        headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=OLLAMA_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+            msg = data.get("message", {})
+            content = msg.get("content", "") or ""
+            thinking = msg.get("thinking", "") or ""
+            return content or thinking or None
+    except Exception as e:
+        print(f"  [ERROR] {e}", file=sys.stderr)
+        return None
+
+
+def parse_json(raw: str) -> dict | None:
+    cleaned = raw.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        cleaned = "\n".join(lines[1:])
+    if cleaned.endswith("```"):
+        cleaned = cleaned.rsplit("```", 1)[0].strip()
+    if cleaned.startswith("json"):
+        cleaned = cleaned[4:].strip()
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        pass
+    for pos in ["rfind", "find"]:
+        fn = getattr(cleaned, pos)
+        start = fn("{")
+        end = cleaned.rfind("}")
+        if 0 <= start < end:
+            try:
+                return json.loads(cleaned[start:end+1])
+            except json.JSONDecodeError:
+                pass
+    return None
+
+
+def main():
+    print("=== E1 Re-code: 29 Zero-Score Items ===\n")
+    
+    records = load_records()
+    pathos_items = load_pathos()
+    
+    zeros = {k: v for k, v in pathos_items.items() if v["purificacao_composto"] == 0.0}
+    print(f"Zero-score items to re-code: {len(zeros)}\n")
+    
+    successes = 0
+    failures = 0
+    updated = []
+    
+    for i, (item_id, item) in enumerate(sorted(zeros.items())):
+        scout_id = find_scout_id(item, records)
+        if not scout_id:
+            print(f"[{i+1}/{len(zeros)}] {item['sigla_id']}: NO SCOUT ID — skipping")
+            failures += 1
+            continue
+        
+        vault = read_vault_note(scout_id)
+        rec = records.get(item_id, {})
+        inp = rec.get("input", {})
+        ws = rec.get("webscout", {})
+        
+        # Build enriched description
+        summary = ws.get("summary_evidence", "") or ""
+        # Add context from vault if summary is short
+        if len(summary) < 100 and vault["body"]:
+            summary = vault["body"]
+        
+        title = inp.get("title_hint", item["title"])
+        place = inp.get("place_hint", item.get("place", "?"))
+        date = inp.get("date_hint", item.get("date", ""))
+        acervo = vault["acervo"] or "unknown"
+        suporte = vault["suporte"] or "unknown"
+        thumb = vault["thumb"]
+        
+        prompt = CODING_PROMPT.format(
+            title=title[:120],
+            place=place,
+            date=date,
+            acervo=acervo,
+            suporte=suporte,
+            thumb=thumb or "(no thumbnail available)",
+            summary=summary[:600]
+        )
+        
+        print(f"[{i+1}/{len(zeros)}] {item['sigla_id']:<15} (SCOUT-{scout_id})...", end=" ", flush=True)
+        raw = call_ollama(prompt)
+        if not raw:
+            print("FAILED")
+            failures += 1
+            continue
+        
+        parsed = parse_json(raw)
+        if not parsed:
+            print("PARSE FAILED")
+            print(f"  Raw: {raw[:150]}...")
+            failures += 1
+            continue
+        
+        # Validate
+        indicators = {}
+        for ind in INDICATORS:
+            val = parsed.get(ind)
+            if isinstance(val, (int, float)) and 0 <= val <= 3:
+                indicators[ind] = int(val)
+            else:
+                indicators[ind] = 0
+        
+        regime = parsed.get("regime_iconocratico", "").strip().lower()
+        if regime not in REGIMES:
+            for r in REGIMES:
+                if r in regime:
+                    regime = r
+                    break
+            else:
+                regime = item.get("regime_iconocratico", "fundacional")
+        
+        score = sum(indicators.values()) / len(indicators)
+        notes = parsed.get("notes", "")
+        if not isinstance(notes, str):
+            notes = str(notes)
+        
+        updated_item = dict(item)
+        updated_item.update(indicators)
+        updated_item["purificacao_composto"] = round(score, 1)
+        updated_item["regime_iconocratico"] = regime
+        updated_item["notes"] = notes[:300]
+        updated_item["coded_by"] = "e1-gemma4/gemma4-recode"
+        updated_item["coded_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        
+        updated.append(updated_item)
+        print(f"OK (score={score:.1f}, regime={regime})")
+        successes += 1
+        
+        if i < len(zeros) - 1:
+            time.sleep(1)
+    
+    print(f"\n=== Summary ===")
+    print(f"Success: {successes} | Failures: {failures}")
+    
+    if updated:
+        # Merge with existing pathos index (keep scores > 0, replace zeros)
+        all_items = {}
+        for k, v in pathos_items.items():
+            all_items[k] = v
+        
+        for u in updated:
+            uid = u["item_id"]
+            old_score = all_items.get(uid, {}).get("purificacao_composto", 0)
+            if old_score == 0.0 or True:  # replace all recoded
+                all_items[uid] = u
+        
+        # Write
+        with open(PATHOS_INDEX, "w") as f:
+            for item in sorted(all_items.values(), key=lambda x: x.get("sigla_id", "")):
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
+        print(f"\nUpdated {PATHOS_INDEX} with {len(all_items)} items ({successes} re-coded)")
+    
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/e3_firecrawl_recode.py
+++ b/tools/scripts/e3_firecrawl_recode.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+e3_firecrawl_recode.py — Terceira passagem: extrai descrições via Firecrawl
+para os itens com score 0.0 e re-codifica com Gemma-4.
+
+Uso:
+    python3 tools/scripts/e3_firecrawl_recode.py    # roda todos os 29
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent.parent
+RECORDS_PATH = REPO / "data" / "processed" / "records.jsonl"
+PATHOS_INDEX = REPO / "data" / "processed" / "pathosformel_index.jsonl"
+FC_EXTRACT_DIR = REPO / "data" / "processed" / "fc_descriptions"
+FC_EXTRACT_DIR.mkdir(parents=True, exist_ok=True)
+
+OLLAMA_URL = "http://localhost:11434/api/chat"
+OLLAMA_MODEL = "gemma4"
+OLLAMA_TIMEOUT = 300
+
+INDICATORS = [
+    "desincorporacao", "rigidez_postural", "dessexualizacao",
+    "uniformizacao_facial", "heraldizacao", "enquadramento_arquitetonico",
+    "apagamento_narrativo", "monocromatizacao", "serialidade", "inscricao_estatal",
+]
+REGIMES = ["fundacional", "normativo", "militar", "contra-alegoria"]
+
+CODING_PROMPT = """Analyze this allegorical image and code the 10 purification indicators (0-3) and regime.
+
+TITLE: {title}
+COUNTRY: {place} | DATE: {date}
+SOURCE DESCRIPTION: {description}
+
+Scale: 0=absent, 1=minimal, 2=moderate, 3=dominant/extreme
+
+Fields (all 0-3): desincorporacao, rigidez_postural, dessexualizacao, uniformizacao_facial, heraldizacao, enquadramento_arquitetonico, apagamento_narrativo, monocromatizacao, serialidade, inscricao_estatal
+
+regime_iconocratico: fundacional|normativo|militar|contra-alegoria
+notes: brief justification in Portuguese (1 sentence)
+
+Output ONLY valid JSON. No thinking. No preamble. Just:
+{{"desincorporacao":0,"rigidez_postural":0,"dessexualizacao":0,"uniformizacao_facial":0,"heraldizacao":0,"enquadramento_arquitetonico":0,"apagamento_narrativo":0,"monocromatizacao":0,"serialidade":0,"inscricao_estatal":0,"regime_iconocratico":"","notes":""}}"""
+
+
+def load_pathos() -> dict[str, dict]:
+    with open(PATHOS_INDEX) as f:
+        items = {}
+        for l in f:
+            try:
+                item = json.loads(l)
+                items[item["item_id"]] = item
+            except:
+                pass
+        return items
+
+
+def load_records() -> dict[str, dict]:
+    with open(RECORDS_PATH) as f:
+        return {json.loads(l)["item_id"]: json.loads(l) for l in f if l.strip()}
+
+
+def firecrawl_extract(url: str, sigla: str) -> str | None:
+    """Extract content from URL via firecrawl CLI."""
+    cache_file = FC_EXTRACT_DIR / f"{sigla}.txt"
+    if cache_file.exists():
+        return cache_file.read_text(encoding="utf-8")[:800]
+    
+    try:
+        result = subprocess.run(
+            ["npx", "-y", "firecrawl-cli@latest", "scrape", url, "--format", "markdown"],
+            capture_output=True, text=True, timeout=30
+        )
+        text = (result.stdout or "") + (result.stderr or "")
+        # Clean up
+        text = re.sub(r'\s+', ' ', text).strip()
+        if len(text) > 50:
+            cache_file.write_text(text[:1500])
+            return text[:800]
+        return None
+    except Exception as e:
+        print(f"    FC error: {e}", file=sys.stderr)
+        return None
+
+
+def call_ollama(prompt: str) -> str | None:
+    payload = json.dumps({
+        "model": OLLAMA_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+        "options": {"temperature": 0.1, "num_predict": 2048}
+    }).encode()
+    req = urllib.request.Request(
+        OLLAMA_URL, data=payload,
+        headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=OLLAMA_TIMEOUT) as resp:
+            data = json.loads(resp.read())
+            msg = data.get("message", {})
+            return msg.get("content", "") or msg.get("thinking", "") or None
+    except Exception as e:
+        print(f"  [Ollama ERR] {e}", file=sys.stderr)
+        return None
+
+
+def parse_json(raw: str) -> dict | None:
+    cleaned = raw.strip()
+    for prefix in ["```json", "```", "json"]:
+        if cleaned.startswith(prefix):
+            cleaned = cleaned[len(prefix):].strip()
+    if cleaned.endswith("```"):
+        cleaned = cleaned[:-3].strip()
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        pass
+    # Find last JSON object
+    start = cleaned.rfind("{")
+    end = cleaned.rfind("}")
+    if 0 <= start < end:
+        try:
+            return json.loads(cleaned[start:end+1])
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+def main():
+    print("=== E3 Firecrawl Recode ===\n")
+    
+    all_items = load_pathos()
+    records = load_records()
+    
+    # Find items with score 0.0
+    zeros = {k: v for k, v in all_items.items() if v["purificacao_composto"] == 0.0}
+    print(f"Items to recode: {len(zeros)}\n")
+    
+    successes = 0
+    failures = 0
+    updated = []
+    
+    for i, (item_id, item) in enumerate(sorted(zeros.items())):
+        rec = records.get(item_id, {})
+        inp = rec.get("input", {})
+        url = inp.get("input_url", "") or item.get("url", "")
+        title = inp.get("title_hint", item.get("title", ""))
+        place = inp.get("place_hint", item.get("place", ""))
+        date = inp.get("date_hint", item.get("date", ""))
+        
+        print(f"[{i+1}/{len(zeros)}] {item['sigla_id']:<15} FC extracting...", end=" ", flush=True)
+        
+        # Extract via Firecrawl
+        desc = firecrawl_extract(url, item.get("sigla_id", str(i)))
+        if not desc:
+            # Fallback to existing summary
+            ws = rec.get("webscout", {})
+            desc = ws.get("summary_evidence", "") or title
+            print(f"(using fallback)", end=" ")
+        else:
+            print(f"(FC: {len(desc)}ch)", end=" ")
+        
+        prompt = CODING_PROMPT.format(
+            title=str(title)[:100],
+            place=str(place),
+            date=str(date),
+            description=str(desc)[:700],
+        )
+        
+        print("coding...", end=" ", flush=True)
+        raw = call_ollama(prompt)
+        if not raw:
+            print("FAILED")
+            failures += 1
+            continue
+        
+        parsed = parse_json(raw)
+        if not parsed:
+            print("PARSE FAIL")
+            failures += 1
+            continue
+        
+        # Validate indicators
+        indicators = {}
+        for ind in INDICATORS:
+            val = parsed.get(ind)
+            if isinstance(val, (int, float)) and 0 <= val <= 3:
+                indicators[ind] = int(val)
+            else:
+                indicators[ind] = 0
+        
+        # Parse regime
+        regime_raw = parsed.get("regime_iconocratico", "")
+        if isinstance(regime_raw, dict):
+            regime_raw = str(list(regime_raw.values())[0]) if regime_raw.values() else ""
+        regime = str(regime_raw).strip().lower()
+        if regime not in REGIMES:
+            for r in REGIMES:
+                if r in regime:
+                    regime = r
+                    break
+            else:
+                regime = item.get("regime_iconocratico", "fundacional")
+        
+        score = sum(indicators.values()) / len(indicators)
+        notes = parsed.get("notes", "")
+        if isinstance(notes, dict):
+            notes = str(list(notes.values())[0]) if notes.values() else ""
+        notes = str(notes)[:300]
+        
+        updated_item = dict(item)
+        updated_item.update(indicators)
+        updated_item["purificacao_composto"] = round(score, 1)
+        updated_item["regime_iconocratico"] = regime
+        updated_item["notes"] = notes
+        updated_item["coded_by"] = "e1-gemma4/gemma4-fcrecode"
+        updated_item["coded_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        
+        updated.append(updated_item)
+        print(f"score={score:.1f}, regime={regime}")
+        successes += 1
+        
+        if i < len(zeros) - 1:
+            time.sleep(1)
+    
+    print(f"\n=== Summary ===")
+    print(f"Success: {successes} | Failures: {failures}")
+    
+    if updated:
+        # Merge: replace zeros, keep the rest
+        for u in updated:
+            all_items[u["item_id"]] = u
+        
+        with open(PATHOS_INDEX, "w") as f:
+            for item in sorted(all_items.values(), key=lambda x: x.get("sigla_id", "")):
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
+        print(f"\nWrote {len(all_items)} items to {PATHOS_INDEX}")
+    
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Resgate (Fase 3.1 da auditoria #77) — reconstruído 2026-06-23

> Reconstruído sobre `main` atual (`254b86d`) após 8 dias de avanço de `main`. O branch anterior tinha sido poluído por um base-update (merge commit) e ficou `dirty` com conflitos nos ledgers canônicos.

**O que entra (net-new, verificado ausente em `main`):**
- `tools/scripts/e1_pathosformel_batch.py`, `e1_recode_zeros.py`, `e3_firecrawl_recode.py` — pipeline E1/E3
- `tese/compilacao-2026-06-09/` — scaffold Cap. 1

**Removido do escopo (já entrou em `main` independentemente nos 8 dias):**
- Os 3 decision docs (`audit-coded-by-2026-06-10`, `IRR-INTER-INSTRUMENTO-2026-06-10`, `IRR-RE-RUN-DESIGN-2026-06-09`) — já em `main`.
- `data/processed/pathosformel_index.jsonl` — `main` tem a versão completa (265 linhas); o branch tinha 57 stale.
- Sem blobs de dados (consistente com #79).

⚠️ Se `validate` ficar vermelho, é a deriva de contagem records↔corpus herdada de `main` (linha de reingest diferida), não conteúdo deste PR — que agora é só scripts + scaffold.

Ref: PR #77 (auditoria).

https://claude.ai/code/session_01Ak8vGp2pSjGPdqCFk8Vw1f