### PR TITLE
fix(ci): add vercel.json to serve corpus dashboard as static preview

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": null,
+  "installCommand": null,
+  "outputDirectory": "corpus"
+}


### PR DESCRIPTION
Adds a single `vercel.json` so the Vercel preview deploy stops erroring and instead serves the corpus dashboard as a static site.

## Why
The Vercel preview deploy was failing on every PR: the project had no repo-side config, so Vercel auto-detected no framework and attempted a build/install with nothing valid to run (no `package.json`; only Python config present), producing no output directory.

## What
`corpus/index.html` is fully self-contained static HTML (dataset embedded inline as `const CORPUS = [...]`; no build, no data fetch). This `vercel.json` disables build/install and serves `corpus/` as the static output root — each PR now gets a working live preview instead of a failed deploy. **Verified:** the deploy went Ready/DEPLOYED on the earlier commit.

## Note on scope
This branch was rebased onto current `main` and reduced to **just `vercel.json`**. Earlier iterations had also bundled a `companion-data.json` regen and a `.github/labeler.yml` fix, but `main` was force-rewritten and advanced significantly since (corpus 265→284, codebook v2, Cap. 1 consolidation, IRR audit). Those older changes are now stale/superseded by `main` (the companion regen in particular produced incorrect data against the newer record schema, per Codex review), so they were dropped to keep this a clean, conflict-free, single-purpose change. The labeler config can be reintroduced as a separate PR off `main` if wanted.

Conflict-free against current `main`; `validate` passes (main is 278/278). The previously-failing `label` check no longer applies (current `main` has no labeler workflow).