### PR TITLE
docs(atlas): navigable knowledge-graph layer over the thesis corpus

### DIFF
--- a/atlas/ADRs e Decisões — MOC.md
+++ b/atlas/ADRs e Decisões — MOC.md
@@ -1,0 +1,66 @@
+---
+title: ADRs e Decisões — MOC
+aliases:
+  - MOC Decisões
+  - ADRs
+type: kg/decisao
+tags:
+  - kg
+  - projeto/iconocracia
+  - meta/moc
+  - arquitetura
+related:
+  - "[[Iconocracia — Mapa Central]]"
+  - "[[Hierarquia de Dados — MOC]]"
+  - "[[Endurecimento]]"
+sources:
+  - ../docs/adr/003-jsonl-as-canonical.md
+  - ../docs/decisions/DIALETICA-N165-vs-265.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# ADRs e Decisões — MOC
+
+As decisões de arquitetura (ADRs) e as decisões **metodológicas** que governam o
+corpus.
+
+## Architecture Decision Records
+
+| ADR | Decisão | Liga a |
+| --- | --- | --- |
+| [ADR-001](../docs/adr/001-drive-as-raw-store.md) | Google Drive como armazenamento de dados brutos | [[Hierarquia de Dados — MOC]] |
+| [ADR-002](../docs/adr/002-notion-as-index.md) | Notion como índice catalográfico *(substituído)* | → ADR-004 |
+| [ADR-003](../docs/adr/003-jsonl-as-canonical.md) | **JSONL como formato canônico** de registros | [[Hierarquia de Dados — MOC]] |
+| [ADR-004](../docs/adr/004-vault-as-index.md) | Vault Obsidian como espelho catalográfico (substitui Notion) | [[WebScout]] |
+| [ADR-005](../docs/adr/005-github-and-hf-release-surfaces.md) | GitHub como backbone canônico · Hugging Face como superfície pública | release |
+
+> [!note] ADRs presentes
+> O repositório traz **ADR-001 a 005**. A **política de cobertura parcial de
+> purificação** vive no dossiê de decisões abaixo (não há ADR dedicado a ela).
+
+## Decisão metodológica em aberto — o N analítico
+
+> [!question] DECISÃO PENDENTE (Ana)
+> Qual é o **N analítico válido**? O enquadramento "165 vs 265" foi **rejeitado**
+> por revisão adversarial. O eixo real é **estrato de validade de codificação ×
+> proveniência de instrumento**, não data.
+
+- **Corpus bruto (todos os itens)** → NÃO é um N analítico válido: inclui itens sem `regime` (não codificados).
+- **Estrato IconoCode** → apenas itens codificados pelo instrumento IconoCode.
+- **Todos os codificados** → após auditoria de confiabilidade inter-instrumento.
+
+> Os tamanhos de cada estrato variam a cada auditoria — ver [`../CLAUDE.md`](../CLAUDE.md) §*Known Data Issues*.
+
+Dossiê de decisão:
+
+- [DIALÉTICA N=165 vs 265](../docs/decisions/DIALETICA-N165-vs-265.md) — o framing rejeitado e o reenquadramento
+- [Estratificação + quarentena (2026-05-30)](../docs/decisions/ESTRATIFICACAO-2026-05-30.md)
+- [IRR piloto inter-instrumento (2026-05-30)](../docs/decisions/IRR-PILOTO-2026-05-30.md)
+- [Status consolidado (2026-05-30)](../docs/decisions/STATUS-2026-05-30.md)
+
+> [!warning] Fora de escopo deste grafo
+> Resolver o N analítico é trabalho metodológico em andamento. Este nó **mapeia**
+> a decisão; não a antecipa. Ver [[Manuscrito — MOC]] (Cap. 2 substituirá
+> "N=165" por "N=[válido]").

--- a/atlas/Conceitos — MOC.md
+++ b/atlas/Conceitos — MOC.md
@@ -1,0 +1,74 @@
+---
+title: Conceitos — MOC
+aliases:
+  - MOC Conceitos
+type: kg/moc
+tags:
+  - kg
+  - projeto/iconocracia
+  - meta/moc
+related:
+  - "[[Iconocracia — Mapa Central]]"
+  - "[[Purificação Clássica]]"
+  - "[[Endurecimento]]"
+  - "[[Contrato Sexual Visual]]"
+  - "[[Contrato Racial Visual]]"
+  - "[[Feminilidade de Estado]]"
+  - "[[Regimes Iconocráticos]]"
+  - "[[Vocabulário Warburguiano]]"
+sources:
+  - ../CLAUDE.md
+  - ../concepts/glossario.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Conceitos — MOC
+
+Mapa da **espinha teórica** da tese. Quatro conceitos são **autorais** (originais
+da tese) e têm regras estritas de atribuição em
+[`../CLAUDE.md`](../CLAUDE.md) §*Mandatory Terminology*.
+
+> [!warning] Atribuição — não confundir
+> Os conceitos autorais **não** devem ser atribuídos aos autores que inspiram o
+> nome. Ver cada nó para a regra exata.
+
+## Os quatro conceitos autorais
+
+| # | Conceito | Não atribuir a | Raiz genealógica | Cap. |
+| --- | --- | --- | --- | --- |
+| 1 | [[Contrato Sexual Visual]] | Pateman | Pateman (contrato **não** visual) + extensão autoral | Cap. 1 |
+| 2 | [[Feminilidade de Estado]] | Mondzain | Legendre (juiz totêmico) + Carson (*hystéra*) | Cap. 1–2 |
+| 3 | [[Contrato Racial Visual]] | — | branquitude constitutiva; transferência transatlântica | Cap. 3 |
+| 4 | [[Purificação Clássica]] | — | matriz jurídica (Kantorowicz/Legendre/Hespanha) + ferramental (Latour/Haraway/Descola) | Cap. 5.2 |
+
+## Conceito-instrumento
+
+- [[Purificação Clássica]] é **operacionalizada** empiricamente em
+  **[[Endurecimento]]** — 10 indicadores ordinais (0–3) medidos por [[IconoCode]].
+- [[Endurecimento]] alimenta os **[[Regimes Iconocráticos]]** (a tipologia
+  diacrônica FUNDACIONAL → NORMATIVO → MILITAR, com a CONTRA-ALEGORIA como
+  quarto regime epistêmico).
+
+## Vocabulário herdado
+
+- [[Vocabulário Warburguiano]] — *Pathosformel*, *Nachleben*, *Zwischenraum*
+  (sempre em alemão).
+- **Mondzain** — sempre edição **2002** (economia icônica); ver
+  [economia-iconica](../concepts/economia-iconica.md).
+
+## Notas conceituais pré-existentes (repo)
+
+O grafo conecta-se às notas em [`../concepts/`](../concepts/):
+
+- [Contrato Sexual Visual (concepts/)](../concepts/contrato-sexual-visual.md)
+- [Feminilidade de Estado (concepts/)](../concepts/feminilidade-de-estado.md)
+- [Economia Icônica](../concepts/economia-iconica.md) · [Visiocracia](../concepts/visiocracia.md)
+- [Iconologia](../concepts/iconologia.md) · [Iconometria](../concepts/iconometria.md)
+- [Atlas Iconográfico](../concepts/atlas-iconografico.md) · [Glossário](../concepts/glossario.md)
+
+> [!todo] Lacuna conhecida
+> As notas em `concepts/` estão em inglês e contêm `[[wikilinks]]` órfãos
+> (ex.: `[[Pateman]]`, `[[Allegory]]`). Os nós deste grafo reancoram cada
+> conceito na terminologia canônica em português.

--- a/atlas/Contrato Racial Visual.md
+++ b/atlas/Contrato Racial Visual.md
@@ -1,0 +1,52 @@
+---
+title: Contrato Racial Visual
+aliases:
+  - Conceito #3
+type: kg/conceito
+tags:
+  - kg
+  - projeto/iconocracia
+  - conceito/autoral
+  - tema/raca
+  - "#contrato-racial-visual"
+  - "#colonialidade-do-ver"
+related:
+  - "[[Contrato Sexual Visual]]"
+  - "[[Feminilidade de Estado]]"
+  - "[[Purificação Clássica]]"
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../CLAUDE.md
+  - ../tese/manuscrito/Capitulo3_analise_quantitativa.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Contrato Racial Visual
+
+**Conceito autoral #3.** A **branquitude constitutiva** da alegoria dita
+"universal": a figura neutra do Estado é, de fato, racialmente marcada, e seus
+modelos neoclássicos circulam por **transferência transatlântica**.
+
+> [!info] Eixo analítico
+> Onde o [[Contrato Sexual Visual]] expõe o gênero do pacto, o Contrato Racial
+> Visual expõe sua **raça** — a *colonialidade do ver* inscrita na forma
+> neoclássica "universal".
+
+## Marcadores no corpus
+
+Itens que tocam este eixo recebem as flags `#contrato-racial-visual` e
+`#colonialidade-do-ver` (ver tags em [`../CLAUDE.md`](../CLAUDE.md) §*Vault Tags*).
+Relevante sobretudo para os recortes **US** (Columbia, Liberty) e **BR**
+(A República, A Justiça) — ver [[Parâmetros do Corpus]].
+
+## Desenvolvimento
+
+- Cap. 3 — [análise quantitativa](../tese/manuscrito/Capitulo3_analise_quantitativa.md)
+  e formulação do conceito (transferência de modelos neoclássicos).
+
+## Conexões
+
+- par de: [[Contrato Sexual Visual]]
+- operado por: [[Purificação Clássica]] → [[Endurecimento]]

--- a/atlas/Contrato Sexual Visual.md
+++ b/atlas/Contrato Sexual Visual.md
@@ -1,0 +1,49 @@
+---
+title: Contrato Sexual Visual
+aliases:
+  - Conceito #1
+type: kg/conceito
+tags:
+  - kg
+  - projeto/iconocracia
+  - conceito/autoral
+  - tema/genero
+related:
+  - "[[Feminilidade de Estado]]"
+  - "[[Contrato Racial Visual]]"
+  - "[[Purificação Clássica]]"
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../CLAUDE.md
+  - ../concepts/contrato-sexual-visual.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Contrato Sexual Visual
+
+**Conceito autoral #1.** Extensão *visual* do contrato sexual: como as imagens
+jurídico-políticas instituem e reforçam, pela própria forma, a ordem de gênero
+que o pacto fundador pressupõe e oculta.
+
+> [!warning] Atribuição (obrigatória)
+> **Não atribuir a Pateman.** Pateman é a fonte do contrato sexual **não visual**;
+> a extensão **visual** é autoral da tese. Ver [`../CLAUDE.md`](../CLAUDE.md).
+
+## Relação com os demais conceitos
+
+- Forma par com o [[Contrato Racial Visual]] (conceito #3): gênero e raça como
+  dois eixos do mesmo pacto representacional.
+- A figura que encarna esse contrato é teorizada em [[Feminilidade de Estado]].
+- Sua imposição formal sobre a imagem é o que a [[Purificação Clássica]] executa
+  e o [[Endurecimento]] mede.
+
+## Nota pré-existente
+
+- [concepts/contrato-sexual-visual.md](../concepts/contrato-sexual-visual.md)
+  (em inglês; contém wikilinks órfãos — este nó é a âncora canônica em português).
+
+## Desenvolvimento
+
+- Cap. 1 — fundamentação teórica.

--- a/atlas/Endurecimento.md
+++ b/atlas/Endurecimento.md
@@ -1,0 +1,92 @@
+---
+title: Endurecimento
+aliases:
+  - endurecimento_score
+type: kg/conceito
+tags:
+  - kg
+  - projeto/iconocracia
+  - conceito/autoral
+  - metodo/quantitativo
+  - "#endurecimento"
+related:
+  - "[[Purificação Clássica]]"
+  - "[[Regimes Iconocráticos]]"
+  - "[[IconoCode]]"
+  - "[[Hierarquia de Dados — MOC]]"
+  - "[[Esquemas JSON]]"
+sources:
+  - ../CLAUDE.md
+  - ../tools/schemas/purification-record.schema.json
+  - ../data/processed/purification.jsonl
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Endurecimento
+
+Operacionalização **empírica** da [[Purificação Clássica]]. Mede, em escala
+**ordinal 0–3**, o grau em que uma alegoria feminina foi extraída da história e
+fixada como signo rígido do Estado.
+
+> [!warning] Terminologia (obrigatória)
+> Sempre em português: **Endurecimento**. NUNCA "hardening" nem "embrutecimento".
+> `endurecimento_score = 0` é um **escore válido** (baixa purificação), não
+> "não codificado".
+
+## Os 10 indicadores
+
+Cada indicador é um inteiro **ordinal 0–3** (`minimum: 0, maximum: 3` no
+[esquema de purificação](../tools/schemas/purification-record.schema.json) — **não
+há `enum`** para os indicadores). As chaves do schema são **ASCII, sem acento**:
+
+| # | Chave (`purification-record`) | Lê |
+| --- | --- | --- |
+| 1 | `desincorporacao` | corpo vivo → corpo abstrato/ausente |
+| 2 | `rigidez_postural` | gesto → pose hierática |
+| 3 | `dessexualizacao` | corpo sexuado → corpo neutralizado |
+| 4 | `uniformizacao_facial` | rosto individual → tipo facial |
+| 5 | `heraldizacao` | figura → emblema/brasão |
+| 6 | `enquadramento_arquitetonico` | cena → nicho/fachada forense |
+| 7 | `apagamento_narrativo` | narrativa → ícone isolado |
+| 8 | `monocromatizacao` | cor → metal/pedra/monocromia |
+| 9 | `serialidade` | obra única → série (moeda, selo) |
+| 10 | `inscricao_estatal` | imagem → imagem com legenda/insígnia do Estado |
+
+> [!note] Escore composto e regime (mesmo schema)
+> Além dos 10 indicadores, o `purification-record` traz `purificacao_composto`
+> (0–3) e `regime_iconocratico` — este sim um `enum`:
+> `fundacional · normativo · militar · contra-alegoria` (ver
+> [[Regimes Iconocráticos]]).
+>
+> Os rótulos humanos **acentuados** (ex.: "heraldicização") aparecem em
+> [`../CLAUDE.md`](../CLAUDE.md); o **contrato de dados** usa as chaves ASCII
+> acima.
+
+## Da medida ao regime
+
+O perfil dos 10 indicadores posiciona a imagem num dos
+[[Regimes Iconocráticos]]: baixos escores → FUNDACIONAL; altos e seriais →
+MILITAR. A subversão deliberada desses indicadores caracteriza a CONTRA-ALEGORIA.
+
+## Onde vive o dado
+
+- **Ledger de codificação:** [`../data/processed/purification.jsonl`](../data/processed/purification.jsonl) — ledger de endurecimento (contagem ao vivo: `code_purification.py --status`).
+- **Esquema:** [[Esquemas JSON]] → `purification-record.schema.json`.
+- **Itens codificados (com `regime`):** subconjunto do corpus — cobertura **parcial**.
+- **Produzido por:** [[IconoCode]] (3 níveis Panofsky + 10 indicadores).
+- **Política de cobertura parcial:** dossiê de decisões → [DIALÉTICA do N](../docs/decisions/DIALETICA-N165-vs-265.md).
+
+> [!question] Tensão metodológica aberta
+> Os itens **sem `regime`** (não codificados) implicam que o total bruto do corpus
+> **não é um N analítico válido**. Os tamanhos correntes vivem em
+> [`../CLAUDE.md`](../CLAUDE.md) §*Known Data Issues*. Ver [[ADRs e Decisões — MOC]]
+> e [a dialética do N](../docs/decisions/DIALETICA-N165-vs-265.md).
+
+## Comandos
+
+```bash
+python tools/scripts/code_purification.py --status      # progresso da codificação
+python tools/scripts/code_purification.py --export-csv  # regenera corpus_dataset.csv
+```

--- a/atlas/Esquemas JSON.md
+++ b/atlas/Esquemas JSON.md
@@ -1,0 +1,59 @@
+---
+title: Esquemas JSON
+aliases:
+  - Schemas
+  - Esquemas
+type: kg/esquema
+tags:
+  - kg
+  - projeto/iconocracia
+  - dados
+  - validacao
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+  - "[[WebScout]]"
+  - "[[IconoCode]]"
+  - "[[Endurecimento]]"
+sources:
+  - ../tools/schemas/master-record.schema.json
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Esquemas JSON
+
+Os **7 esquemas** (JSON Schema 2020-12) em [`../tools/schemas/`](../tools/schemas/)
+que validam todo o fluxo. Validador: `python tools/scripts/validate_schemas.py`.
+
+| Esquema | Valida | Etapa |
+| --- | --- | --- |
+| [`master-record`](../tools/schemas/master-record.schema.json) | o registro canônico completo | saída do pipeline |
+| [`webscout-input`](../tools/schemas/webscout-input.schema.json) | consulta de descoberta | [[WebScout]] |
+| [`webscout-output`](../tools/schemas/webscout-output.schema.json) | candidatos descobertos | [[WebScout]] |
+| [`iconocode-output`](../tools/schemas/iconocode-output.schema.json) | análise Panofsky + indicadores | [[IconoCode]] |
+| [`purification-record`](../tools/schemas/purification-record.schema.json) | 1 registro de codificação 0–3 | [[Endurecimento]] |
+| [`argos-manifest`](../tools/schemas/argos-manifest.schema.json) | manifesto de aquisição | ARGOS |
+| [`research-cluster`](../tools/schemas/research-cluster.schema.json) | clusters temáticos (tópico × prompts × extração) | pesquisa |
+
+## Anatomia do `master-record`
+
+Campos **obrigatórios** (top-level):
+
+```
+master_record_version · batch_id · item_id · item_hash ·
+input · webscout · iconocode · exports · timestamps
+```
+
+Campo opcional: `purificacao` (bloco de [[Endurecimento]]).
+
+> [!note] O `master-record` é o nó-cola
+> Ele embute a saída do [[WebScout]] (`webscout`), a do [[IconoCode]]
+> (`iconocode`) e a codificação de [[Endurecimento]] (`purificacao`) — por isso é
+> o topo da [[Hierarquia de Dados — MOC]].
+
+## CI/CD
+
+`.github/workflows/validate.yml` valida `records.jsonl` contra `master-record`,
+checa consistência com `corpus-data.json` e **rejeita binários em `data/raw/`**
+([ADR-001](../docs/adr/001-drive-as-raw-store.md)).

--- a/atlas/Feminilidade de Estado.md
+++ b/atlas/Feminilidade de Estado.md
@@ -1,0 +1,57 @@
+---
+title: Feminilidade de Estado
+aliases:
+  - Conceito #2
+type: kg/conceito
+tags:
+  - kg
+  - projeto/iconocracia
+  - conceito/autoral
+  - tema/genero
+  - tema/estado
+related:
+  - "[[Contrato Sexual Visual]]"
+  - "[[Purificação Clássica]]"
+  - "[[Regimes Iconocráticos]]"
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../CLAUDE.md
+  - ../concepts/feminilidade-de-estado.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Feminilidade de Estado
+
+**Conceito autoral #2.** A personificação do Estado e da nação por **figuras
+alegóricas femininas** — e o modo como essa escolha de imagem molda a percepção
+da natureza, do poder e da legitimidade do Estado.
+
+> [!warning] Atribuição (obrigatória)
+> **Não atribuir a Mondzain.** Raízes genealógicas declaradas:
+> **Legendre** (juiz totêmico) + **Carson** (*hystéra*). Ver
+> [`../CLAUDE.md`](../CLAUDE.md). Quando Mondzain for citada, usar **sempre** a
+> edição **2002**.
+
+## Motivos que a encarnam
+
+Os "motivos" do corpus são as faces concretas deste conceito — Marianne, La
+République, Justitia, Britannia, Columbia, Germania, A República (BR)… Ver a lista
+completa em [[Parâmetros do Corpus#Países e motivos]].
+
+## Relações
+
+- A figura feminina-de-Estado é o **sujeito** sobre o qual incide a
+  [[Purificação Clássica]]; seu endurecimento progressivo define os
+  [[Regimes Iconocráticos]].
+- Articula-se com o [[Contrato Sexual Visual]] (o pacto que a institui).
+
+## Nota pré-existente
+
+- [concepts/feminilidade-de-estado.md](../concepts/feminilidade-de-estado.md)
+  (em inglês; este nó é a âncora canônica em português).
+
+## Desenvolvimento
+
+- Cap. 1–2.

--- a/atlas/Hierarquia de Dados — MOC.md
+++ b/atlas/Hierarquia de Dados — MOC.md
@@ -1,0 +1,74 @@
+---
+title: Hierarquia de Dados — MOC
+aliases:
+  - MOC Dados
+  - Hierarquia de Dados
+type: kg/moc
+tags:
+  - kg
+  - projeto/iconocracia
+  - meta/moc
+  - dados
+related:
+  - "[[Iconocracia — Mapa Central]]"
+  - "[[Esquemas JSON]]"
+  - "[[Parâmetros do Corpus]]"
+  - "[[IconoCode]]"
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../CLAUDE.md
+  - ../data/processed/records.jsonl
+  - ../corpus/corpus-data.json
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Hierarquia de Dados — MOC
+
+A ordem **canônica de fonte-da-verdade**. Quem deriva de quem.
+
+```mermaid
+graph TD
+    R[1. records.jsonl<br/>ledger operacional canônico] --> C[2. corpus-data.json<br/>export público]
+    P[3. purification.jsonl<br/>ledger de endurecimento] -.codifica.-> R
+    R --> V[4. vault/candidatos/<br/>espelho catalográfico]
+    C --> COMP[companion-data.json]
+    C --> HF[Hugging Face / dashboards]
+```
+
+| Ordem | Arquivo | Papel | ADR |
+| --- | --- | --- | --- |
+| 1 | [`records.jsonl`](../data/processed/records.jsonl) | ledger operacional canônico | [ADR-003](../docs/adr/003-jsonl-as-canonical.md) |
+| 2 | [`corpus-data.json`](../corpus/corpus-data.json) | export público | [ADR-005](../docs/adr/005-github-and-hf-release-surfaces.md) |
+| 3 | [`purification.jsonl`](../data/processed/purification.jsonl) | ledger de [[Endurecimento]] | [decisão N](../docs/decisions/DIALETICA-N165-vs-265.md) |
+| 4 | `vault/candidatos/` | espelho catalográfico auxiliar | [ADR-004](../docs/adr/004-vault-as-index.md) |
+
+## Contagens atuais
+
+> [!info] As contagens vivem na fonte, não neste grafo
+> Os números derivam a cada sync — fixá-los aqui só geraria drift. Para o estado
+> corrente, consulte sempre:
+> - **Documentado** (com data da última auditoria): [`../CLAUDE.md`](../CLAUDE.md) §*Known Data Issues*.
+> - **Ao vivo:** `python tools/scripts/validate_schemas.py` (validade de `records.jsonl`)
+>   e `python tools/scripts/records_to_corpus.py --diff` (drift records → corpus).
+
+## Regra de rastreabilidade
+
+Todo item existe em **três lugares**: Google Drive + `drive-manifest.json`
+([ADR-001](../docs/adr/001-drive-as-raw-store.md)) · `vault/candidatos/` ·
+`records.jsonl`.
+
+## Reconciliação
+
+```bash
+python tools/scripts/records_to_corpus.py --diff          # preview drift records→corpus
+python tools/scripts/sync_companion.py --output corpus/companion-data.json
+python tools/scripts/validate_schemas.py                  # valida records.jsonl
+```
+
+## Conexões
+
+- estrutura validada por: [[Esquemas JSON]]
+- parâmetros do conteúdo: [[Parâmetros do Corpus]]
+- governança: [[ADRs e Decisões — MOC]]

--- a/atlas/IconoCode.md
+++ b/atlas/IconoCode.md
@@ -1,0 +1,59 @@
+---
+title: IconoCode
+aliases:
+  - Icono Code
+  - ICONOCODE
+type: kg/pipeline
+tags:
+  - kg
+  - projeto/iconocracia
+  - pipeline
+  - metodo/quantitativo
+related:
+  - "[[Pipeline Dual-Agente — MOC]]"
+  - "[[WebScout]]"
+  - "[[Endurecimento]]"
+  - "[[Regimes Iconocráticos]]"
+  - "[[Esquemas JSON]]"
+sources:
+  - ../CLAUDE.md
+  - ../tools/schemas/iconocode-output.schema.json
+  - ../tools/schemas/purification-record.schema.json
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# IconoCode
+
+Segundo agente do [[Pipeline Dual-Agente — MOC|pipeline]]: **análise visual** dos
+candidatos vindos do [[WebScout]].
+
+## O que produz
+
+1. **Análise de Panofsky em 3 níveis** — pré-iconográfico → iconográfico →
+   iconológico.
+2. **10 indicadores de [[Endurecimento]]** (escala ordinal 0–3) → posiciona a
+   imagem num [[Regimes Iconocráticos|regime]].
+
+## Contrato de dados
+
+- **Saída:** [`iconocode-output.schema.json`](../tools/schemas/iconocode-output.schema.json)
+- **Codificação de purificação:** [`purification-record.schema.json`](../tools/schemas/purification-record.schema.json)
+- O bloco `iconocode` é um dos campos obrigatórios do **master record** — ver
+  [[Esquemas JSON]] e [[Hierarquia de Dados — MOC]].
+
+## Modo ICONOCODE (agente)
+
+Triggers: `codificar`, `iconocode`, `analisar imagem`, ou ao receber uma imagem.
+Codificação de lote/status via:
+
+```bash
+python tools/scripts/code_purification.py --status
+```
+
+> [!question] Confiabilidade inter-instrumento
+> O corpus foi codificado por **6 instrumentos** (`coded_by`); a auditoria de
+> confiabilidade entre `iconocode-opus` e `opus-4.6` está pendente e condiciona o
+> N analítico. Ver [[ADRs e Decisões — MOC]] e
+> [IRR-PILOTO](../docs/decisions/IRR-PILOTO-2026-05-30.md).

--- a/atlas/Iconocracia — Mapa Central.md
+++ b/atlas/Iconocracia — Mapa Central.md
@@ -1,0 +1,99 @@
+---
+title: Iconocracia — Mapa Central
+aliases:
+  - Mapa Central
+  - Hub
+  - MOC Raiz
+type: kg/hub
+tags:
+  - kg
+  - projeto/iconocracia
+  - meta/moc
+related:
+  - "[[Conceitos — MOC]]"
+  - "[[Pipeline Dual-Agente — MOC]]"
+  - "[[Hierarquia de Dados — MOC]]"
+  - "[[ADRs e Decisões — MOC]]"
+  - "[[Manuscrito — MOC]]"
+sources:
+  - ../CLAUDE.md
+  - ../docs/PLANO-TESE-ICONOCRACIA.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Iconocracia — Mapa Central
+
+Hub raiz do [[README|knowledge graph]] da tese **ICONOCRACIA: Alegoria Feminina
+na História da Cultura Jurídica (Séculos XIX–XX)** (PPGD/UFSC, defesa 2026).
+A partir daqui chega-se a qualquer nó em no máximo dois saltos.
+
+> [!info] Tese em uma frase
+> Como a alegoria feminina foi mobilizada, **purificada** e **endurecida** para
+> personificar o Estado e o Direito entre 1800 e 2000 — e como mensurar essa
+> operação num corpus de imagens jurídico-políticas.
+
+## Os quatro eixos do grafo
+
+```mermaid
+graph TD
+    HUB[Iconocracia — Mapa Central]
+    HUB --> C[Conceitos]
+    HUB --> P[Pipeline Dual-Agente]
+    HUB --> D[Hierarquia de Dados]
+    HUB --> A[ADRs e Decisões]
+    HUB --> M[Manuscrito]
+    C -->|operacionaliza| P
+    P -->|produz| D
+    D -->|fundamenta| M
+    A -->|governa| D
+```
+
+## 1. Conceitos → [[Conceitos — MOC]]
+
+A espinha teórica autoral. Os quatro conceitos originais da tese:
+
+- [[Purificação Clássica]] — conceito #4, a operação-matriz
+- [[Endurecimento]] — operacionalização empírica da Purificação (10 indicadores 0–3)
+- [[Contrato Sexual Visual]] — conceito #1
+- [[Contrato Racial Visual]] — conceito #3
+- [[Feminilidade de Estado]] — conceito #2
+- [[Regimes Iconocráticos]] — FUNDACIONAL → NORMATIVO → MILITAR → CONTRA-ALEGORIA
+- [[Vocabulário Warburguiano]] — *Pathosformel*, *Nachleben*, *Zwischenraum*
+
+## 2. Pipeline → [[Pipeline Dual-Agente — MOC]]
+
+Como as imagens entram e são analisadas:
+
+- [[WebScout]] (descoberta em arquivos digitais) → [[IconoCode]] (Panofsky + endurecimento)
+- Orquestração de aquisição via ARGOS
+
+## 3. Dados → [[Hierarquia de Dados — MOC]]
+
+A cadeia canônica de fontes-da-verdade:
+
+- [[Esquemas JSON]] — 7 esquemas que validam tudo
+- [[Parâmetros do Corpus]] — países, suportes, período, critérios de inclusão
+
+## 4. Decisões → [[ADRs e Decisões — MOC]]
+
+As 6 ADRs + a dialética metodológica do **N analítico** (estratos de codificação).
+
+## 5. Manuscrito → [[Manuscrito — MOC]]
+
+Os capítulos em [`../tese/manuscrito/`](../tese/manuscrito/) e onde cada conceito é desenvolvido.
+
+## Cobertura exaustiva → [[Stubs — Índice]]
+
+Além da espinha curada acima, os **nós-stub** auto-gerados dão cobertura
+exaustiva às superfícies documentais (ADRs, decisões, esquemas, capítulos,
+conceitos, docs, notebooks) — a contagem corrente fica em [[Stubs — Índice]].
+Regenerar: `python atlas/_generate_stubs.py`.
+
+---
+
+> [!note] Estado do corpus
+> As contagens (`records.jsonl`, `corpus-data.json`, codificados) variam a cada
+> sync — este grafo não as fixa. Para os números atuais, ver
+> [[Hierarquia de Dados — MOC]] e [`../CLAUDE.md`](../CLAUDE.md) §*Known Data Issues*.

--- a/atlas/Manuscrito — MOC.md
+++ b/atlas/Manuscrito — MOC.md
@@ -1,0 +1,55 @@
+---
+title: Manuscrito — MOC
+aliases:
+  - MOC Manuscrito
+  - Capítulos
+type: kg/manuscrito
+tags:
+  - kg
+  - projeto/iconocracia
+  - meta/moc
+  - manuscrito
+related:
+  - "[[Iconocracia — Mapa Central]]"
+  - "[[Conceitos — MOC]]"
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../tese/manuscrito/sumario_iconocracia.md
+  - ../tese/manuscrito/LEIAME.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Manuscrito — MOC
+
+Os capítulos em [`../tese/manuscrito/`](../tese/manuscrito/) e onde cada
+[[Conceitos — MOC|conceito]] é desenvolvido. Compilação via Pandoc:
+`make -C tese/manuscrito/ docx`.
+
+| Peça | Arquivo | Conceitos centrais |
+| --- | --- | --- |
+| Introdução | [`Introducao_rev.md`](../tese/manuscrito/Introducao_rev.md) | tese geral; N analítico |
+| Cap. 1 | [`Capitulo1_rev.md`](../tese/manuscrito/Capitulo1_rev.md) | [[Contrato Sexual Visual]] · [[Feminilidade de Estado]] |
+| Cap. 2 — Metodologia | [`Capitulo2_metodologia.md`](../tese/manuscrito/Capitulo2_metodologia.md) | [[Esquemas JSON]] · dataset card · N |
+| Cap. 3 — Análise quantitativa | [`Capitulo3_analise_quantitativa.md`](../tese/manuscrito/Capitulo3_analise_quantitativa.md) | [[Endurecimento]] · [[Contrato Racial Visual]] |
+| Conclusão | _(ainda não no manuscrito)_ | síntese |
+| Sumário | [`sumario_iconocracia.md`](../tese/manuscrito/sumario_iconocracia.md) | — |
+
+> [!warning] Arquivos protegidos
+> Os `*_original` (ex.: `Capitulo1_original_v2.md`, `Introducao_original_v2.md`)
+> são **protegidos** por hook PreToolUse. Revisar em `tese/manuscrito/drafts/`.
+
+## Pendências de redação ligadas ao dado
+
+> [!todo] N=165 ainda no texto
+> Cap. 2 (`:66,161`) e Introdução (`:127,193`) afirmam **N=165**, enquanto o
+> corpus cresceu além disso. A substituição por "N=[válido]" depende de
+> [[ADRs e Decisões — MOC|resolver o N analítico]]. Contagens atuais e o item 3 em
+> [`../CLAUDE.md`](../CLAUDE.md) §*Known Data Issues*.
+
+## Antes de commitar capítulos
+
+- ABNT NBR 6023:2025 — rodar verificação (`/abnt-checker`, `/chapter-integrity`).
+- Terminologia obrigatória — ver [[Conceitos — MOC]] e
+  `python tools/scripts/check_thesis_terms.py`.

--- a/atlas/Parâmetros do Corpus.md
+++ b/atlas/Parâmetros do Corpus.md
@@ -1,0 +1,67 @@
+---
+title: Parâmetros do Corpus
+aliases:
+  - Parametros do Corpus
+  - Critérios de inclusão
+type: kg/dado
+tags:
+  - kg
+  - projeto/iconocracia
+  - "#corpus"
+  - "#pais"
+  - "#suporte"
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+  - "[[Feminilidade de Estado]]"
+  - "[[Regimes Iconocráticos]]"
+  - "[[Contrato Racial Visual]]"
+sources:
+  - ../CLAUDE.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Parâmetros do Corpus
+
+Os limites que definem o que **entra** no corpus. Fonte: [`../CLAUDE.md`](../CLAUDE.md)
+§*Corpus Parameters*.
+
+## Critérios de inclusão (todos os 5 obrigatórios)
+
+1. figura alegórica feminina
+2. função jurídico-política explícita
+3. datável 1800–2000
+4. um dos 6 países
+5. suporte aceito
+
+## Países e motivos
+
+| País | Motivos (encarnações de [[Feminilidade de Estado]]) |
+| --- | --- |
+| **FR** | Marianne · La République · La Justice · La Liberté |
+| **UK** | Britannia · Justice · Hibernia · Scotia |
+| **DE** | Germania · Justitia · Minerva |
+| **US** | Columbia · Lady Justice · Liberty · America |
+| **BE** | La Belgique |
+| **BR** | A República · A Justiça |
+
+## Suportes aceitos
+
+moeda · selo · monumento/escultura · arquitetura forense · estampa/gravura ·
+frontispício · papel-moeda · cartaz.
+
+## Período
+
+1800–2000 — **prioridade 1880–1920** (auge da personificação estatal endurecida).
+
+## Iconclass
+
+Código-chave da iconografia feminista: **48C51**.
+
+> [!note] Tags namespaced
+> `pais/` (BR, FR, UK, DE, US, BE) · `suporte/` (moeda, selo, monumento, …) ·
+> `regime/` (fundacional, normativo, militar) · `motivo/` (marianne, republica,
+> justitia, britannia, columbia, germania, belgique). Flags: `#verificar`,
+> `#possivel-duplicata`, `#contra-alegoria`, `#ausencia-alegorica`,
+> `#colonialidade-do-ver`, `#contrato-racial-visual`.

--- a/atlas/Pipeline Dual-Agente — MOC.md
+++ b/atlas/Pipeline Dual-Agente — MOC.md
@@ -1,0 +1,67 @@
+---
+title: Pipeline Dual-Agente — MOC
+aliases:
+  - Pipeline
+  - MOC Pipeline
+type: kg/moc
+tags:
+  - kg
+  - projeto/iconocracia
+  - meta/moc
+  - pipeline
+related:
+  - "[[Iconocracia — Mapa Central]]"
+  - "[[WebScout]]"
+  - "[[IconoCode]]"
+  - "[[Hierarquia de Dados — MOC]]"
+  - "[[Endurecimento]]"
+sources:
+  - ../CLAUDE.md
+  - ../docs/dual-agent-corpus-builder.md
+  - ../docs/WORKFLOW.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Pipeline Dual-Agente — MOC
+
+Como uma imagem entra no corpus e vira um **master record**.
+
+```mermaid
+graph LR
+    A[Arquivos digitais<br/>Europeana · Gallica · LOC · BnF · Numista · Colnect] --> WS[WebScout<br/>descoberta]
+    WS --> IC[IconoCode<br/>Panofsky + 10 indicadores]
+    IC --> MR[(records.jsonl<br/>master records)]
+    ARGOS[ARGOS<br/>orquestração de aquisição] -.coordena.-> WS
+```
+
+## Etapas
+
+1. **[[WebScout]]** — descoberta em arquivos digitais → `webscout-output`.
+2. **[[IconoCode]]** — análise visual em 3 níveis Panofsky + 10 indicadores de
+   [[Endurecimento]] → `iconocode-output`.
+3. **Saída** → [[Hierarquia de Dados — MOC|records.jsonl]] (canônico).
+
+## ARGOS — orquestração de aquisição
+
+Workflow que constrói o **manifesto** de aquisição pendente e deriva grupos de
+despacho. Trigger `argos`. Comandos:
+
+```bash
+python tools/scripts/argos_build_manifest.py
+python tools/scripts/argos_prepare_dispatch.py --manifest data/raw/argos/manifest.json
+python tools/scripts/argos_report.py
+```
+
+- Esquema: [[Esquemas JSON|argos-manifest.schema.json]]
+- Runbook: [`../docs/ARGOS_RUNBOOK.md`](../docs/ARGOS_RUNBOOK.md)
+
+## Fontes
+
+- Visão geral: [dual-agent-corpus-builder](../docs/dual-agent-corpus-builder.md) · [WORKFLOW](../docs/WORKFLOW.md)
+- Metodologia: [methodology](../docs/methodology.md)
+
+> [!note] Implementação espelhada (Iuris Visio)
+> A runtime do pipeline é reimplementada em TypeScript/Cloudflare Workers no
+> repositório irmão **iuris-visio-roadmap** (Durable Objects: WebScout, IconoCode).

--- a/atlas/Purificação Clássica.md
+++ b/atlas/Purificação Clássica.md
@@ -1,0 +1,68 @@
+---
+title: Purificação Clássica
+aliases:
+  - Purificacao Classica
+  - Conceito #4
+type: kg/conceito
+tags:
+  - kg
+  - projeto/iconocracia
+  - conceito/autoral
+  - metodo/operacionalizacao
+related:
+  - "[[Endurecimento]]"
+  - "[[Regimes Iconocráticos]]"
+  - "[[Contrato Sexual Visual]]"
+  - "[[Feminilidade de Estado]]"
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../CLAUDE.md
+  - ../tese/manuscrito/Capitulo3_analise_quantitativa.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Purificação Clássica
+
+**Conceito autoral #4.** Operação formal de **extração do feminino histórico**
+para fixá-lo no **eterno alegórico** — o gesto pelo qual mulheres concretas e
+datadas são convertidas em figuras atemporais do Estado e do Direito.
+
+> [!info] Definição operativa
+> A Purificação Clássica é a **operação-matriz**; o [[Endurecimento]] é a sua
+> **medida**. Onde a Purificação descreve *o que* a cultura jurídica faz à
+> alegoria feminina, o Endurecimento quantifica *quanto* ela já foi feita em cada
+> imagem.
+
+## Dupla matriz teórica
+
+| Matriz | Função | Autores |
+| --- | --- | --- |
+| **Primária — jurídica** | núcleo do conceito | Kantorowicz · Legendre · Hespanha |
+| **Ferramental — purificação/híbridos** | operadores analíticos | Latour (1991) · Haraway (1985) · Descola |
+
+> [!warning] Uso terminológico (obrigatório)
+> No manuscrito final, usar **sempre** "Purificação Clássica" — nunca
+> "purificação iconocrática". Ver [`../CLAUDE.md`](../CLAUDE.md).
+> A matriz ferramental (Latour/Haraway/Descola) entra **como ferramenta**, não
+> como filiação ao **"ciberfeminismo"** — termo **proibido** no texto da tese
+> (reservado a paper derivado pós-defesa).
+
+## Operacionalização
+
+A Purificação Clássica torna-se mensurável via [[Endurecimento]], cujos
+**10 indicadores ordinais (0–3)** decompõem a operação em dimensões observáveis
+(desincorporação, dessexualização, heraldicização, etc.). Ver
+[[Endurecimento#Os 10 indicadores]].
+
+## Desenvolvimento no manuscrito
+
+- Cap. 5.2 — formulação completa do conceito.
+- Cap. 3 — [análise quantitativa](../tese/manuscrito/Capitulo3_analise_quantitativa.md) que mede a operação no corpus.
+
+## Conexões
+
+- ↳ medida por: [[Endurecimento]]
+- ↳ tipifica regimes: [[Regimes Iconocráticos]]
+- ↳ dialoga com: [[Contrato Sexual Visual]], [[Feminilidade de Estado]]

--- a/atlas/README.md
+++ b/atlas/README.md
@@ -1,0 +1,113 @@
+# Atlas — Knowledge Graph ICONOCRACIA
+
+Camada de **mapa de conhecimento navegável** sobre o monorepo da tese
+*ICONOCRACIA: Alegoria Feminina na História da Cultura Jurídica (Séculos XIX–XX)*.
+
+> [!warning] Não confundir com o *Atlas Iconográfico*
+> Esta pasta `atlas/` é o **grafo de conhecimento do repositório** (meta-camada
+> de navegação). É distinta do conceito warburguiano **Atlas Iconográfico**
+> (leitura do corpus como atlas mnemônico), documentado em
+> [concepts/atlas-iconografico.md](../concepts/atlas-iconografico.md).
+
+Estas notas **não duplicam** o conteúdo do repositório — elas **interligam** o
+material que já existe disperso (conceitos, ADRs, esquemas JSON, capítulos,
+pipeline, dados) em um único grafo consultável. Cada nó é um arquivo Markdown em
+[Obsidian Flavored Markdown](<../vault/meta/Guia — Obsidian Flavored Markdown.md>)
+com frontmatter padronizado, `[[wikilinks]]` para outros nós do grafo e links
+Markdown relativos (`../`) para os arquivos-fonte reais.
+
+> [!info] Ponto de entrada
+> Abra **[[Iconocracia — Mapa Central]]**. É o hub que conecta todos os MOCs
+> (Maps of Content) temáticos.
+
+## Como abrir como vault
+
+Esta pasta foi pensada para ser aberta diretamente no Obsidian:
+
+```
+Obsidian → Open folder as vault → iconocracy-corpus/knowledge-graph/
+```
+
+Os `[[wikilinks]]` resolvem entre os nós do grafo (estrutura plana, sem
+subpastas). Os links para fontes fora do grafo (`../docs/...`, `../tools/...`,
+`../tese/...`, `../concepts/...`) são links Markdown relativos — clicáveis tanto
+no Obsidian quanto no GitHub.
+
+## Convenção de frontmatter (para consultas Dataview)
+
+Todo nó abre com:
+
+```yaml
+---
+title: Nome do nó
+aliases: []
+type: kg/conceito        # kg/hub | kg/moc | kg/conceito | kg/pipeline | kg/dado | kg/esquema | kg/decisao | kg/manuscrito | kg/stub
+tags:
+  - kg
+  - projeto/iconocracia
+related:
+  - "[[Outro nó]]"
+sources:
+  - ../docs/adr/003-jsonl-as-canonical.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+```
+
+Isso torna o grafo consultável. Exemplos (requer plugin **Dataview**):
+
+````markdown
+```dataview
+LIST FROM #kg WHERE type = "kg/conceito" SORT file.name ASC
+```
+````
+
+````markdown
+```dataview
+TABLE related, sources FROM #kg WHERE type = "kg/pipeline"
+```
+````
+
+## Mapa dos MOCs
+
+| MOC | Cobre |
+| --- | --- |
+| [[Iconocracia — Mapa Central]] | hub raiz: liga tudo |
+| [[Conceitos — MOC]] | os 4 conceitos autorais + Warburg + regimes |
+| [[Pipeline Dual-Agente — MOC]] | WebScout → IconoCode → ARGOS |
+| [[Hierarquia de Dados — MOC]] | records.jsonl → corpus-data.json → purification → vault |
+| [[ADRs e Decisões — MOC]] | 6 ADRs + decisões metodológicas |
+| [[Manuscrito — MOC]] | capítulos e estado da redação |
+| [[Stubs — Índice]] | stubs auto-gerados (cobertura exaustiva; contagem no índice) |
+
+## Espinha curada vs. stubs gerados
+
+O grafo tem **duas camadas**:
+
+1. **Espinha** (escrita à mão, em `atlas/*.md`) — leitura curada: hub, 5 MOCs e
+   os nós conceituais/pipeline/dados. É aqui que mora a interpretação.
+2. **Stubs** (gerados, em `atlas/stubs/<categoria>/`) — um nó por arquivo-fonte
+   (ADRs, decisões, esquemas, capítulos, conceitos, docs, notebooks), cada um com
+   resumo-âncora + link para a fonte + backlink ao MOC. Dão **cobertura
+   exaustiva** sem duplicar conteúdo.
+
+```bash
+python atlas/_generate_stubs.py   # regenera atlas/stubs/ por inteiro (idempotente)
+```
+
+> [!warning] Stubs são descartáveis
+> Nunca edite `atlas/stubs/**` à mão — é regenerado. Para mudar o conteúdo,
+> edite o arquivo-fonte; para mudar a estrutura/cobertura, edite o gerador
+> (`SURFACES` em `_generate_stubs.py`).
+
+## Regras de manutenção
+
+- **Fonte da verdade permanece nos arquivos originais.** Os nós resumem e
+  apontam; não substituem `docs/`, `tools/schemas/`, `tese/manuscrito/`.
+- Terminologia obrigatória segue [`../CLAUDE.md`](../CLAUDE.md) §*Mandatory
+  Terminology* (Endurecimento, Purificação Clássica, etc.).
+- **Contagens não são fixadas neste grafo** — derivam a cada sync. Para o estado
+  atual, ver [`../CLAUDE.md`](../CLAUDE.md) §*Known Data Issues* e
+  `python tools/scripts/validate_schemas.py` / `records_to_corpus.py --diff`.
+- Voz acadêmica: português formal, enquadramento jurídico-penal.

--- a/atlas/Regimes Iconocráticos.md
+++ b/atlas/Regimes Iconocráticos.md
@@ -1,0 +1,62 @@
+---
+title: Regimes Iconocráticos
+aliases:
+  - Regimes
+  - regime
+type: kg/conceito
+tags:
+  - kg
+  - projeto/iconocracia
+  - conceito/tipologia
+  - "#regime"
+related:
+  - "[[Endurecimento]]"
+  - "[[Purificação Clássica]]"
+  - "[[Feminilidade de Estado]]"
+  - "[[Parâmetros do Corpus]]"
+sources:
+  - ../CLAUDE.md
+  - ../docs/anexo-m5-quarto-regime-epistemico.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Regimes Iconocráticos
+
+Tipologia **diacrônica** dos modos de existência da alegoria feminina jurídica.
+Cada regime é um perfil característico de [[Endurecimento]].
+
+```mermaid
+graph LR
+    F[FUNDACIONAL<br/>sacrificial · corpo vivo] --> N[NORMATIVO<br/>domesticado · burocrático]
+    N --> M[MILITAR<br/>endurecido · imperial]
+    F -.subverte.-> CA[CONTRA-ALEGORIA<br/>subversiva · contestada]
+    N -.subverte.-> CA
+    M -.subverte.-> CA
+```
+
+| Regime | Corpo | Tom | Endurecimento típico |
+| --- | --- | --- | --- |
+| **FUNDACIONAL** | vivo, sacrificial | revolucionário | baixo |
+| **NORMATIVO** | domesticado | burocrático | médio |
+| **MILITAR** | endurecido | imperial | alto + serial |
+| **CONTRA-ALEGORIA** | reapropriado | subversivo/contestado | indicadores invertidos |
+
+> [!note] Quarto regime epistêmico
+> A **CONTRA-ALEGORIA** não é uma fase cronológica, mas um regime *epistêmico*
+> transversal — a imagem que recusa ou inverte a purificação. Ver
+> [anexo-m5](../docs/anexo-m5-quarto-regime-epistemico.md) e a flag
+> `#contra-alegoria`.
+
+## No dado
+
+- Campo `regime` em [`../corpus/corpus-data.json`](../corpus/corpus-data.json):
+  parte dos itens classificada, parte sem `regime` (cobertura **parcial** — ver
+  [[Endurecimento]] e [[ADRs e Decisões — MOC]]).
+- Tags de vault: `regime/fundacional`, `regime/normativo`, `regime/militar`.
+
+## Conexões
+
+- derivado de: [[Endurecimento]] (perfil dos 10 indicadores)
+- incide sobre: [[Feminilidade de Estado]]

--- a/atlas/Vocabulário Warburguiano.md
+++ b/atlas/Vocabulário Warburguiano.md
@@ -1,0 +1,51 @@
+---
+title: Vocabulário Warburguiano
+aliases:
+  - Warburg
+  - Pathosformel
+  - Nachleben
+  - Zwischenraum
+type: kg/conceito
+tags:
+  - kg
+  - projeto/iconocracia
+  - conceito/herdado
+  - "#painel"
+related:
+  - "[[Regimes Iconocráticos]]"
+  - "[[Purificação Clássica]]"
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../CLAUDE.md
+  - ../concepts/atlas-iconografico.md
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# Vocabulário Warburguiano
+
+Operadores herdados de Aby Warburg, mobilizados para ler a **sobrevivência** e a
+**migração** das fórmulas alegóricas. **Sempre em alemão.**
+
+| Termo | Sentido na tese |
+| --- | --- |
+| **Pathosformel** | fórmula de pathos: gesto/postura codificada que reaparece carregada de afeto |
+| **Nachleben** | sobrevivência/pervivência das imagens através do tempo |
+| **Zwischenraum** | "espaço intermediário" — a distância crítica entre imagens num painel comparativo |
+
+> [!warning] Terminologia (obrigatória)
+> Manter **Pathosformel**, **Nachleben** e **Zwischenraum** em alemão, sem
+> tradução. Ver [`../CLAUDE.md`](../CLAUDE.md).
+
+## Uso operacional
+
+- O modo **ZWISCHENRAUM** monta **painéis comparativos** (tag `#painel`,
+  trigger `zwischenraum`). Ver [`../CLAUDE.md`](../CLAUDE.md) §*Mode Routing*.
+- Liga-se ao [Atlas Iconográfico](../concepts/atlas-iconografico.md) (leitura do
+  corpus como atlas mnemônico à la *Mnemosyne*).
+
+## Conexões
+
+- instrumento de leitura para: [[Regimes Iconocráticos]] (recorrência de *Pathosformeln* endurecidas)
+- tensão produtiva com: [[Purificação Clássica]] (a purificação tenta *deter* o *Nachleben*)

--- a/atlas/WebScout.md
+++ b/atlas/WebScout.md
@@ -1,0 +1,54 @@
+---
+title: WebScout
+aliases:
+  - Web Scout
+  - SCOUT
+type: kg/pipeline
+tags:
+  - kg
+  - projeto/iconocracia
+  - pipeline
+  - "#corpus"
+related:
+  - "[[Pipeline Dual-Agente — MOC]]"
+  - "[[IconoCode]]"
+  - "[[Esquemas JSON]]"
+  - "[[Parâmetros do Corpus]]"
+sources:
+  - ../CLAUDE.md
+  - ../tools/schemas/webscout-input.schema.json
+  - ../tools/schemas/webscout-output.schema.json
+status: ativo
+created: 2026-06-19
+updated: 2026-06-19
+---
+
+# WebScout
+
+Primeiro agente do [[Pipeline Dual-Agente — MOC|pipeline dual-agente]]:
+**descoberta** de imagens candidatas em arquivos digitais.
+
+## Arquivos consultados
+
+Europeana · Gallica · LOC · BnF · Numista · Colnect.
+
+## Contrato de dados
+
+- **Entrada:** [`webscout-input.schema.json`](../tools/schemas/webscout-input.schema.json)
+- **Saída:** [`webscout-output.schema.json`](../tools/schemas/webscout-output.schema.json)
+- Ver [[Esquemas JSON]] para o conjunto completo.
+
+## Modo SCOUT (agente)
+
+Triggers: `scout [query]`, `campanha N`, `buscar`, `lacunas`, `auditoria`.
+Gera notas Obsidian em `vault/candidatos/` (padrão `XX-NNN Título.md`) e roda
+análise de lacunas. Filtra pelos [[Parâmetros do Corpus|critérios de inclusão]].
+
+> [!note] Resiliência de arquivo
+> Falhas de arquivo (ex.: Gallica 429, Europeana timeout) acionam a rotina de
+> *fallback* (IIIF → retries → Playwright → registro metadata-only com
+> `#imagem-pendente`).
+
+## Próxima etapa
+
+→ [[IconoCode]] (análise visual dos candidatos descobertos).

--- a/atlas/_generate_stubs.py
+++ b/atlas/_generate_stubs.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Gera nós-stub do Atlas (knowledge graph) varrendo as superfícies documentais
+do repositório.
+
+Cada stub é um nó Obsidian Flavored Markdown que **resume e aponta** para um
+arquivo-fonte canônico (não duplica conteúdo). Os stubs dão cobertura exaustiva
+ao grafo; a "espinha" (nós escritos à mão) permanece a leitura curada.
+
+Uso (a partir da raiz do repo):
+
+    python atlas/_generate_stubs.py
+
+Idempotente: regenera `atlas/stubs/` por inteiro a cada execução.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+ATLAS = REPO / "atlas"
+STUBS = ATLAS / "stubs"
+TODAY = _dt.date.today().isoformat()
+
+# (categoria, MOC de backlink, tag-extra, lista de globs relativos ao repo)
+SURFACES: list[tuple[str, str, str, list[str]]] = [
+    ("adr",        "ADRs e Decisões — MOC", "arquitetura", ["docs/adr/*.md"]),
+    ("decisao",    "ADRs e Decisões — MOC", "decisao",     ["docs/decisions/*.md"]),
+    ("schema",     "Esquemas JSON",         "dados",       ["tools/schemas/*.json"]),
+    ("manuscrito", "Manuscrito — MOC",      "manuscrito",  ["tese/manuscrito/*.md"]),
+    ("conceito",   "Conceitos — MOC",       "conceito",    ["concepts/*.md"]),
+    ("entidade",   "Iconocracia — Mapa Central", "entidade", ["entities/*.md"]),
+    ("doc",        "Iconocracia — Mapa Central", "doc",     ["docs/*.md"]),
+    ("notebook",   "Hierarquia de Dados — MOC", "analise", ["notebooks/*.ipynb"]),
+]
+
+# Não gerar stub para arquivos-fonte protegidos / ruidosos.
+EXCLUDE = re.compile(r"_original|/LEIAME\.md$|/README\.md$")
+
+_FM = re.compile(r"^---\n.*?\n---\n", re.S)
+_H = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.M)
+
+
+def clean_summary(text: str) -> str:
+    """Neutraliza marcação que não resolve fora do vault de origem: wikilinks,
+    imagens e links Markdown viram texto puro (evita ghosts e paths quebrados)."""
+    text = re.sub(r"!\[[^\]]*\]\([^)]*\)", "", text)          # imagens
+    text = re.sub(r"\[\[([^\]|#]+)(?:#[^\]|]*)?\|([^\]]+)\]\]", r"\2", text)  # [[a|b]]->b
+    text = re.sub(r"\[\[([^\]|#]+)(?:[#][^\]]*)?\]\]", r"\1", text)           # [[a]]->a
+    text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)      # [t](u)->t
+    return text.strip()
+
+
+def slug(name: str) -> str:
+    return name.replace(".md", "").replace(".json", "").replace(".ipynb", "")
+
+
+def title_summary(path: Path) -> tuple[str, str]:
+    """Extrai (título, resumo curto) de um arquivo-fonte."""
+    if path.suffix == ".json":
+        try:
+            d = json.loads(path.read_text(encoding="utf-8"))
+            return d.get("title", path.stem), (d.get("description", "") or "").strip()
+        except (json.JSONDecodeError, OSError):
+            return path.stem, ""
+    if path.suffix == ".ipynb":
+        try:
+            nb = json.loads(path.read_text(encoding="utf-8"))
+            for cell in nb.get("cells", []):
+                if cell.get("cell_type") == "markdown":
+                    src = "".join(cell.get("source", []))
+                    m = _H.search(src)
+                    if m:
+                        return m.group(1), ""
+        except (json.JSONDecodeError, OSError):
+            pass
+        return path.stem, ""
+    # markdown
+    text = path.read_text(encoding="utf-8")
+    body = _FM.sub("", text)
+    m = _H.search(body)
+    title = m.group(1) if m else path.stem
+    summary = ""
+    for line in body.splitlines():
+        s = line.strip()
+        if not s or s[0] in "#>|!-*" or s.startswith("<!--") or s.startswith("```"):
+            continue
+        summary = clean_summary(s)
+        if summary:
+            break
+    return title, summary[:240]
+
+
+def emit(path: Path, category: str, moc: str, tag: str) -> Path:
+    rel_to_repo = path.relative_to(REPO)
+    out = STUBS / category / (slug(path.name) + ".md")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    rel_link = os.path.relpath(path, out.parent)
+    title, summary = title_summary(path)
+    safe_title = title.replace('"', "'")
+    fm = [
+        "---",
+        f'title: "{safe_title}"',
+        "type: kg/stub",
+        "generated: true",
+        "generator: atlas/_generate_stubs.py",
+        "tags:",
+        "  - kg",
+        "  - kg/stub",
+        f"  - kg/{tag}",
+        "  - projeto/iconocracia",
+        "related:",
+        f'  - "[[{moc}]]"',
+        "sources:",
+        f"  - {rel_link}",
+        f"created: {TODAY}",
+        f"updated: {TODAY}",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        "> [!info] Nó-stub gerado automaticamente",
+        f"> Resumo-âncora de [`{rel_to_repo}`]({rel_link}). **Edite a fonte**, não",
+        "> este stub — ele é regenerado por `atlas/_generate_stubs.py`.",
+        "",
+    ]
+    if summary:
+        fm += [summary, ""]
+    fm += [
+        f"- **Fonte:** [`{rel_to_repo}`]({rel_link})",
+        f"- **MOC:** [[{moc}]]",
+        f"- **Categoria:** `{category}`",
+        "",
+    ]
+    out.write_text("\n".join(fm), encoding="utf-8")
+    return out
+
+
+def main() -> None:
+    if STUBS.exists():
+        shutil.rmtree(STUBS)
+    STUBS.mkdir(parents=True)
+
+    by_cat: dict[str, list[tuple[str, str]]] = {}
+    total = 0
+    for category, moc, tag, globs in SURFACES:
+        for g in globs:
+            for path in sorted(REPO.glob(g)):
+                if EXCLUDE.search(path.as_posix()):
+                    continue
+                out = emit(path, category, moc, tag)
+                title, _ = title_summary(path)
+                by_cat.setdefault(category, []).append((title, out.stem))
+                total += 1
+
+    # Índice dos stubs
+    idx = [
+        "---",
+        "title: Stubs — Índice",
+        "type: kg/moc",
+        "generated: true",
+        "generator: atlas/_generate_stubs.py",
+        "tags:",
+        "  - kg",
+        "  - kg/stub",
+        "  - meta/moc",
+        "  - projeto/iconocracia",
+        "related:",
+        '  - "[[Iconocracia — Mapa Central]]"',
+        f"created: {TODAY}",
+        f"updated: {TODAY}",
+        "---",
+        "",
+        "# Stubs — Índice",
+        "",
+        "Cobertura exaustiva auto-gerada das superfícies documentais do repo.",
+        f"**{total} stubs** em {len(by_cat)} categorias. Regenerar:",
+        "`python atlas/_generate_stubs.py`.",
+        "",
+        "> [!warning] Não editar à mão",
+        "> Estes nós são regenerados. Para mudar o conteúdo, edite o arquivo-fonte;",
+        "> para mudar a estrutura, edite o gerador.",
+        "",
+    ]
+    for category in sorted(by_cat):
+        idx.append(f"## `{category}` ({len(by_cat[category])})")
+        idx.append("")
+        for title, stem in sorted(by_cat[category]):
+            idx.append(f"- [[{stem}|{title}]]")
+        idx.append("")
+    (STUBS / "Stubs — Índice.md").write_text("\n".join(idx), encoding="utf-8")
+
+    print(f"Gerados {total} stubs em {len(by_cat)} categorias → {STUBS.relative_to(REPO)}/")
+    for category in sorted(by_cat):
+        print(f"  {category}: {len(by_cat[category])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/atlas/stubs/Stubs — Índice.md
+++ b/atlas/stubs/Stubs — Índice.md
@@ -1,0 +1,121 @@
+---
+title: Stubs — Índice
+type: kg/moc
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - meta/moc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Stubs — Índice
+
+Cobertura exaustiva auto-gerada das superfícies documentais do repo.
+**72 stubs** em 8 categorias. Regenerar:
+`python atlas/_generate_stubs.py`.
+
+> [!warning] Não editar à mão
+> Estes nós são regenerados. Para mudar o conteúdo, edite o arquivo-fonte;
+> para mudar a estrutura, edite o gerador.
+
+## `adr` (5)
+
+- [[001-drive-as-raw-store|ADR-001: Google Drive como armazenamento de dados brutos]]
+- [[002-notion-as-index|ADR-002: Notion como índice catalográfico]]
+- [[003-jsonl-as-canonical|ADR-003: JSONL como formato canônico de registros]]
+- [[004-vault-as-index|ADR-004 — Vault Obsidian como Espelho Catalográfico (substitui Notion)]]
+- [[005-github-and-hf-release-surfaces|ADR-005 — GitHub como Backbone Canônico e Hugging Face como Superfície Pública]]
+
+## `conceito` (9)
+
+- [[atlas-iconografico|Atlas Iconográfico]]
+- [[contrato-sexual-visual|Contrato Sexual Visual]]
+- [[economia-iconica|Economia Icônica]]
+- [[feminilidade-de-estado|Feminilidade de Estado]]
+- [[glossario|Glossário de Conceitos Operativos]]
+- [[iconologia|Iconologia]]
+- [[iconometria|Iconometria]]
+- [[prompts|Prompts para Pesquisa Iconográfica]]
+- [[visiocracia|Visiocracia]]
+
+## `decisao` (4)
+
+- [[DIALETICA-N165-vs-265|Dialética — Corpus N=165 vs 265]]
+- [[ESTRATIFICACAO-2026-05-30|Estratificação do corpus + quarentena — 2026-05-30]]
+- [[IRR-PILOTO-2026-05-30|IRR piloto inter-instrumento + achado de integridade — 2026-05-30]]
+- [[STATUS-2026-05-30|Status consolidado — 2026-05-30]]
+
+## `doc` (33)
+
+- [[ARGOS_RUNBOOK|ARGOS operator runbook]]
+- [[anexo-m3-protocolo-auditoria-externa|Anexo M.3 — Protocolo de Auditoria Externa com Poder Real]]
+- [[anexo-m4-archive-repertoire|Anexo M.4 — Forma-arquivo vs. repertoire: a grade é constitutivamente iconocrática?]]
+- [[anexo-m5-quarto-regime-epistemico|Anexo M.5 — Decisão Editorial: Quarto Regime Epistêmico]]
+- [[atlas-lab-task-1-implementation-note|Atlas Lab v1 — Task 1 implementation note]]
+- [[literature-bibliography-2026-03-31|BIBLIOGRAPHY: ICONOCRACY -- Female Allegory in the History of Legal Culture (19th-20th c.)]]
+- [[CHECKLIST-SEMANAL|CHECKLIST SEMANAL — TESE "ICONOCRACIA"]]
+- [[CODEBOOK_PROMPTS|CODEBOOK DE PROMPTS — ICONOCRACIA]]
+- [[METHOD_CONTRACT_2026-04-23|Contrato metodológico ICONOCRACY — 2026-04-23]]
+- [[COOKBOOK|Cookbook — Pesquisa Historiográfica e Iconográfica]]
+- [[RECONCILE|Corpus Reconciliation]]
+- [[diagramas-mermaid|Diagramas Mermaid — ICONOCRACIA]]
+- [[drive-structure|Estrutura de Pastas no Google Drive]]
+- [[huggingface-release|Hugging Face Release Flow]]
+- [[PLANO-TESE-ICONOCRACIA|ICONOCRACIA: Plano de Tese]]
+- [[gap-analysis-2026-03-31|ICONOCRACY CORPUS GAP ANALYSIS]]
+- [[ICONOCRACIA_PROJETO|Iconocracia — Projecto de Pesquisa no Gallica]]
+- [[lacunas-aquisicao-iconografica-2026-04|Lacunas de Aquisição Iconográfica — 2026-04-25]]
+- [[MANUAL|Manual de Instruções — Repositório Iconocracia]]
+- [[methodology|Metodologia — Cartografia Warburguiana do Imaginário Jurídico]]
+- [[notion-capture-2026-03-31|Notion Capture Draft - 2026-03-31]]
+- [[notion-schema|Notion Schema (Historical)]]
+- [[OPERATING_MODEL|Operating Model — ICONOCRACY]]
+- [[scripts|Pipeline Scripts]]
+- [[SESSION-2026-04-28-CLOSE|Resumo da sessão — 2026-04-28 (pause)]]
+- [[dual-agent-corpus-builder|SPEC-1 — Dual-Agent Corpus Builder (WebScout → IconoCode)]]
+- [[perplexity-deep-research-2026-03-31|SYSTEMATIC MAPPING OF SCHOLARSHIP ON FEMALE ALLEGORIES IN STATE AND LEGAL ICONOGRAPHY (1789–1988)]]
+- [[T3-GEMMA4-WORKFLOW|T3 — Gemma-4 IconoCode Workflow]]
+- [[T3-coding-queue|T3 — IconoCode Coding Queue]]
+- [[T4-LPAI-INGEST-REPORT|T4 — LPAI v2 Ingest Report (staging phase)]]
+- [[WORKFLOW|Workflow Operacional]]
+- [[workspace-map|Workspace Map]]
+- [[ROADMAP-2026-04-29|🌅 29 de abril — Bom dia, Ana]]
+
+## `entidade` (1)
+
+- [[iconocracia-companion|Iconocracia Companion]]
+
+## `manuscrito` (5)
+
+- [[Capitulo1_rev|CAPÍTULO 1]]
+- [[Capitulo2_metodologia|CAPÍTULO 2]]
+- [[Capitulo3_analise_quantitativa|CAPÍTULO 3]]
+- [[sumario_iconocracia|ICONOCRACIA]]
+- [[Introducao_rev|INTRODUÇÃO]]
+
+## `notebook` (8)
+
+- [[01_exploratory|01 — Estatísticas Descritivas do Corpus (Cap. 6.1)]]
+- [[02_kruskal_wallis|02 — Regimes x Morfologia: Kruskal-Wallis (Cap. 6.2)]]
+- [[03_regression|03 — Preditores do endurecimento (Cap. 6.3)]]
+- [[04_correspondence|04 — Análise de Correspondência Múltipla (Cap. 6.4)]]
+- [[05_temporal|05 — Dinâmica Temporal do Corpus (análise nova)]]
+- [[06_clustering|06 — Clustering dos Indicadores de endurecimento (análise nova)]]
+- [[07_dimensionality|07 — Análise de Dimensionalidade (PCA) (análise nova)]]
+- [[08_multidimensional_scoring|08 — Refatoração Multidimensional do Score endurecimento (análise nova)]]
+
+## `schema` (7)
+
+- [[argos-manifest.schema|ArgosManifest]]
+- [[iconocode-output.schema|IconoCodeOutput]]
+- [[master-record.schema|MasterRecord]]
+- [[purification-record.schema|PurificationRecord]]
+- [[research-cluster.schema|ResearchClusterDoc]]
+- [[webscout-input.schema|WebScoutInput]]
+- [[webscout-output.schema|WebScoutOutput]]

--- a/atlas/stubs/adr/001-drive-as-raw-store.md
+++ b/atlas/stubs/adr/001-drive-as-raw-store.md
@@ -1,0 +1,29 @@
+---
+title: "ADR-001: Google Drive como armazenamento de dados brutos"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/arquitetura
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/adr/001-drive-as-raw-store.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ADR-001: Google Drive como armazenamento de dados brutos
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/adr/001-drive-as-raw-store.md`](../../../docs/adr/001-drive-as-raw-store.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Arquivos brutos (imagens, PDFs de acervos, dumps) vivem exclusivamente no Google Drive.
+
+- **Fonte:** [`docs/adr/001-drive-as-raw-store.md`](../../../docs/adr/001-drive-as-raw-store.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `adr`

--- a/atlas/stubs/adr/002-notion-as-index.md
+++ b/atlas/stubs/adr/002-notion-as-index.md
@@ -1,0 +1,29 @@
+---
+title: "ADR-002: Notion como índice catalográfico"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/arquitetura
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/adr/002-notion-as-index.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ADR-002: Notion como índice catalográfico
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/adr/002-notion-as-index.md`](../../../docs/adr/002-notion-as-index.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+O Notion serve como interface de catalogação e índice do corpus.
+
+- **Fonte:** [`docs/adr/002-notion-as-index.md`](../../../docs/adr/002-notion-as-index.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `adr`

--- a/atlas/stubs/adr/003-jsonl-as-canonical.md
+++ b/atlas/stubs/adr/003-jsonl-as-canonical.md
@@ -1,0 +1,29 @@
+---
+title: "ADR-003: JSONL como formato canônico de registros"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/arquitetura
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/adr/003-jsonl-as-canonical.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ADR-003: JSONL como formato canônico de registros
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/adr/003-jsonl-as-canonical.md`](../../../docs/adr/003-jsonl-as-canonical.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+O arquivo `data/processed/records.jsonl` é a fonte canônica do corpus.
+
+- **Fonte:** [`docs/adr/003-jsonl-as-canonical.md`](../../../docs/adr/003-jsonl-as-canonical.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `adr`

--- a/atlas/stubs/adr/004-vault-as-index.md
+++ b/atlas/stubs/adr/004-vault-as-index.md
@@ -1,0 +1,29 @@
+---
+title: "ADR-004 — Vault Obsidian como Espelho Catalográfico (substitui Notion)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/arquitetura
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/adr/004-vault-as-index.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ADR-004 — Vault Obsidian como Espelho Catalográfico (substitui Notion)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/adr/004-vault-as-index.md`](../../../docs/adr/004-vault-as-index.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+O ADR-002 designava o Notion como espelho catalográfico do corpus. Na prática,
+
+- **Fonte:** [`docs/adr/004-vault-as-index.md`](../../../docs/adr/004-vault-as-index.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `adr`

--- a/atlas/stubs/adr/005-github-and-hf-release-surfaces.md
+++ b/atlas/stubs/adr/005-github-and-hf-release-surfaces.md
@@ -1,0 +1,29 @@
+---
+title: "ADR-005 — GitHub como Backbone Canônico e Hugging Face como Superfície Pública"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/arquitetura
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/adr/005-github-and-hf-release-surfaces.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ADR-005 — GitHub como Backbone Canônico e Hugging Face como Superfície Pública
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/adr/005-github-and-hf-release-surfaces.md`](../../../docs/adr/005-github-and-hf-release-surfaces.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+O repositório vinha acumulando duas funções incompatíveis:
+
+- **Fonte:** [`docs/adr/005-github-and-hf-release-surfaces.md`](../../../docs/adr/005-github-and-hf-release-surfaces.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `adr`

--- a/atlas/stubs/conceito/atlas-iconografico.md
+++ b/atlas/stubs/conceito/atlas-iconografico.md
@@ -1,0 +1,29 @@
+---
+title: "Atlas Iconográfico"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/atlas-iconografico.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Atlas Iconográfico
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/atlas-iconografico.md`](../../../concepts/atlas-iconografico.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A synthetic component of the Iconocracia research, this Atlas organizes and visualizes the findings from the quantitative (Iconometria) and qualitative (Iconologia) analyses. It aims to map the relationships between different iconographic e
+
+- **Fonte:** [`concepts/atlas-iconografico.md`](../../../concepts/atlas-iconografico.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/conceito/contrato-sexual-visual.md
+++ b/atlas/stubs/conceito/contrato-sexual-visual.md
@@ -1,0 +1,29 @@
+---
+title: "Contrato Sexual Visual"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/contrato-sexual-visual.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Contrato Sexual Visual
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/contrato-sexual-visual.md`](../../../concepts/contrato-sexual-visual.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A concept explored in the Iconocracia thesis, building upon Pateman's work on the social contract.
+
+- **Fonte:** [`concepts/contrato-sexual-visual.md`](../../../concepts/contrato-sexual-visual.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/conceito/economia-iconica.md
+++ b/atlas/stubs/conceito/economia-iconica.md
@@ -1,0 +1,29 @@
+---
+title: "Economia Icônica"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/economia-iconica.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Economia Icônica
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/economia-iconica.md`](../../../concepts/economia-iconica.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A concept developed by Mondzain (2002),¹ which analyzes the circulation and value of images within a given society, framing them as a form of economic currency.
+
+- **Fonte:** [`concepts/economia-iconica.md`](../../../concepts/economia-iconica.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/conceito/feminilidade-de-estado.md
+++ b/atlas/stubs/conceito/feminilidade-de-estado.md
@@ -1,0 +1,29 @@
+---
+title: "Feminilidade de Estado"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/feminilidade-de-estado.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Feminilidade de Estado
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/feminilidade-de-estado.md`](../../../concepts/feminilidade-de-estado.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A concept specific to the Iconocracia thesis, referring to the personification of the state or nation through female allegorical figures. This concept examines how the choice of female imagery for the state influences perceptions of its nat
+
+- **Fonte:** [`concepts/feminilidade-de-estado.md`](../../../concepts/feminilidade-de-estado.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/conceito/glossario.md
+++ b/atlas/stubs/conceito/glossario.md
@@ -1,0 +1,29 @@
+---
+title: "Glossário de Conceitos Operativos"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/glossario.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Glossário de Conceitos Operativos
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/glossario.md`](../../../concepts/glossario.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+This glossary defines key terms and concepts used throughout the Iconocracia research, providing their sources and relevance to the thesis.
+
+- **Fonte:** [`concepts/glossario.md`](../../../concepts/glossario.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/conceito/iconologia.md
+++ b/atlas/stubs/conceito/iconologia.md
@@ -1,0 +1,29 @@
+---
+title: "Iconologia"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/iconologia.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Iconologia
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/iconologia.md`](../../../concepts/iconologia.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A qualitative approach to the interpretation of images, focusing on understanding the deeper symbolic meanings, cultural contexts, and historical interpretations of visual elements. In Iconocracia, this complements quantitative analysis by 
+
+- **Fonte:** [`concepts/iconologia.md`](../../../concepts/iconologia.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/conceito/iconometria.md
+++ b/atlas/stubs/conceito/iconometria.md
@@ -1,0 +1,29 @@
+---
+title: "Iconometria"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/iconometria.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Iconometria
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/iconometria.md`](../../../concepts/iconometria.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A quantitative approach to the analysis of images, focusing on measurable aspects and patterns within a corpus of visual data. In the context of Iconocracia, it involves the systematic counting and analysis of iconographic elements to ident
+
+- **Fonte:** [`concepts/iconometria.md`](../../../concepts/iconometria.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/conceito/prompts.md
+++ b/atlas/stubs/conceito/prompts.md
@@ -1,0 +1,29 @@
+---
+title: "Prompts para Pesquisa Iconográfica"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/prompts.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Prompts para Pesquisa Iconográfica
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/prompts.md`](../../../concepts/prompts.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+This section outlines various prompts designed to guide research activities within the Iconocracia project. These prompts categorize tasks related to corpus management, iconographic coding, theoretical analysis, and data synthesis.
+
+- **Fonte:** [`concepts/prompts.md`](../../../concepts/prompts.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/conceito/visiocracia.md
+++ b/atlas/stubs/conceito/visiocracia.md
@@ -1,0 +1,29 @@
+---
+title: "Visiocracia"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/conceito
+  - projeto/iconocracia
+related:
+  - "[[Conceitos — MOC]]"
+sources:
+  - ../../../concepts/visiocracia.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Visiocracia
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`concepts/visiocracia.md`](../../../concepts/visiocracia.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+An analytical framework proposed by Goodrich, which posits that in modern societies, visual representations and the act of seeing (vision) increasingly shape political power and social order. It explores how control over the visual field tr
+
+- **Fonte:** [`concepts/visiocracia.md`](../../../concepts/visiocracia.md)
+- **MOC:** [[Conceitos — MOC]]
+- **Categoria:** `conceito`

--- a/atlas/stubs/decisao/DIALETICA-N165-vs-265.md
+++ b/atlas/stubs/decisao/DIALETICA-N165-vs-265.md
@@ -1,0 +1,29 @@
+---
+title: "Dialética — Corpus N=165 vs 265"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/decisao
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/decisions/DIALETICA-N165-vs-265.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Dialética — Corpus N=165 vs 265
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/decisions/DIALETICA-N165-vs-265.md`](../../../docs/decisions/DIALETICA-N165-vs-265.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Material de apoio à decisão (skill `hegelian-dialectic`). NÃO é a decisão — é o mapa da
+
+- **Fonte:** [`docs/decisions/DIALETICA-N165-vs-265.md`](../../../docs/decisions/DIALETICA-N165-vs-265.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `decisao`

--- a/atlas/stubs/decisao/ESTRATIFICACAO-2026-05-30.md
+++ b/atlas/stubs/decisao/ESTRATIFICACAO-2026-05-30.md
@@ -1,0 +1,29 @@
+---
+title: "Estratificação do corpus + quarentena — 2026-05-30"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/decisao
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/decisions/ESTRATIFICACAO-2026-05-30.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Estratificação do corpus + quarentena — 2026-05-30
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/decisions/ESTRATIFICACAO-2026-05-30.md`](../../../docs/decisions/ESTRATIFICACAO-2026-05-30.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Passo 1 da ação reformulada (ver `DIALETICA-N165-vs-265.md`). Read-only sobre o corpus;
+
+- **Fonte:** [`docs/decisions/ESTRATIFICACAO-2026-05-30.md`](../../../docs/decisions/ESTRATIFICACAO-2026-05-30.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `decisao`

--- a/atlas/stubs/decisao/IRR-PILOTO-2026-05-30.md
+++ b/atlas/stubs/decisao/IRR-PILOTO-2026-05-30.md
@@ -1,0 +1,29 @@
+---
+title: "IRR piloto inter-instrumento + achado de integridade — 2026-05-30"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/decisao
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/decisions/IRR-PILOTO-2026-05-30.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# IRR piloto inter-instrumento + achado de integridade — 2026-05-30
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/decisions/IRR-PILOTO-2026-05-30.md`](../../../docs/decisions/IRR-PILOTO-2026-05-30.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Passo 3 do sequenciamento (ver `DIALETICA-N165-vs-265.md`). Search-first → adotou
+
+- **Fonte:** [`docs/decisions/IRR-PILOTO-2026-05-30.md`](../../../docs/decisions/IRR-PILOTO-2026-05-30.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `decisao`

--- a/atlas/stubs/decisao/STATUS-2026-05-30.md
+++ b/atlas/stubs/decisao/STATUS-2026-05-30.md
@@ -1,0 +1,29 @@
+---
+title: "Status consolidado — 2026-05-30"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/decisao
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/decisions/STATUS-2026-05-30.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Status consolidado — 2026-05-30
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/decisions/STATUS-2026-05-30.md`](../../../docs/decisions/STATUS-2026-05-30.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Saída da sessão de integridade GitHub + decisões pendentes. Organizado por: (✅) feito,
+
+- **Fonte:** [`docs/decisions/STATUS-2026-05-30.md`](../../../docs/decisions/STATUS-2026-05-30.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `decisao`

--- a/atlas/stubs/doc/ARGOS_RUNBOOK.md
+++ b/atlas/stubs/doc/ARGOS_RUNBOOK.md
@@ -1,0 +1,29 @@
+---
+title: "ARGOS operator runbook"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/ARGOS_RUNBOOK.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ARGOS operator runbook
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/ARGOS_RUNBOOK.md`](../../../docs/ARGOS_RUNBOOK.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Practical walkthrough for rerunning ARGOS from scratch from the repository root.
+
+- **Fonte:** [`docs/ARGOS_RUNBOOK.md`](../../../docs/ARGOS_RUNBOOK.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/CHECKLIST-SEMANAL.md
+++ b/atlas/stubs/doc/CHECKLIST-SEMANAL.md
@@ -1,0 +1,29 @@
+---
+title: "CHECKLIST SEMANAL — TESE 'ICONOCRACIA'"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/CHECKLIST-SEMANAL.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# CHECKLIST SEMANAL — TESE "ICONOCRACIA"
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/CHECKLIST-SEMANAL.md`](../../../docs/CHECKLIST-SEMANAL.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Semana de: ___/___/_____ a ___/___/_____
+
+- **Fonte:** [`docs/CHECKLIST-SEMANAL.md`](../../../docs/CHECKLIST-SEMANAL.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/CODEBOOK_PROMPTS.md
+++ b/atlas/stubs/doc/CODEBOOK_PROMPTS.md
@@ -1,0 +1,29 @@
+---
+title: "CODEBOOK DE PROMPTS — ICONOCRACIA"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/CODEBOOK_PROMPTS.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# CODEBOOK DE PROMPTS — ICONOCRACIA
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/CODEBOOK_PROMPTS.md`](../../../docs/CODEBOOK_PROMPTS.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+1. CORPUS — Ingestao e Catalogacao
+
+- **Fonte:** [`docs/CODEBOOK_PROMPTS.md`](../../../docs/CODEBOOK_PROMPTS.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/COOKBOOK.md
+++ b/atlas/stubs/doc/COOKBOOK.md
@@ -1,0 +1,29 @@
+---
+title: "Cookbook — Pesquisa Historiográfica e Iconográfica"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/COOKBOOK.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Cookbook — Pesquisa Historiográfica e Iconográfica
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/COOKBOOK.md`](../../../docs/COOKBOOK.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+1. Princípios de cozinha
+
+- **Fonte:** [`docs/COOKBOOK.md`](../../../docs/COOKBOOK.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/ICONOCRACIA_PROJETO.md
+++ b/atlas/stubs/doc/ICONOCRACIA_PROJETO.md
@@ -1,0 +1,29 @@
+---
+title: "Iconocracia — Projecto de Pesquisa no Gallica"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/ICONOCRACIA_PROJETO.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Iconocracia — Projecto de Pesquisa no Gallica
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/ICONOCRACIA_PROJETO.md`](../../../docs/ICONOCRACIA_PROJETO.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Pesquisa iconográfica para a tese **Iconocracia** (PPGAV/UFSC), explorando o acervo digital da Bibliothèque nationale de France (Gallica) para constituir dois corpora paralelos:
+
+- **Fonte:** [`docs/ICONOCRACIA_PROJETO.md`](../../../docs/ICONOCRACIA_PROJETO.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/MANUAL.md
+++ b/atlas/stubs/doc/MANUAL.md
@@ -1,0 +1,29 @@
+---
+title: "Manual de Instruções — Repositório Iconocracia"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/MANUAL.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Manual de Instruções — Repositório Iconocracia
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/MANUAL.md`](../../../docs/MANUAL.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+1. Visão geral do projeto
+
+- **Fonte:** [`docs/MANUAL.md`](../../../docs/MANUAL.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/METHOD_CONTRACT_2026-04-23.md
+++ b/atlas/stubs/doc/METHOD_CONTRACT_2026-04-23.md
@@ -1,0 +1,29 @@
+---
+title: "Contrato metodológico ICONOCRACY — 2026-04-23"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/METHOD_CONTRACT_2026-04-23.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Contrato metodológico ICONOCRACY — 2026-04-23
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/METHOD_CONTRACT_2026-04-23.md`](../../../docs/METHOD_CONTRACT_2026-04-23.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Os 10 indicadores de endurecimento usam escala ordinal 0-3.
+
+- **Fonte:** [`docs/METHOD_CONTRACT_2026-04-23.md`](../../../docs/METHOD_CONTRACT_2026-04-23.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/OPERATING_MODEL.md
+++ b/atlas/stubs/doc/OPERATING_MODEL.md
@@ -1,0 +1,29 @@
+---
+title: "Operating Model — ICONOCRACY"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/OPERATING_MODEL.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Operating Model — ICONOCRACY
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/OPERATING_MODEL.md`](../../../docs/OPERATING_MODEL.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+This document defines the day-to-day operating model for `iconocracy-corpus`.
+
+- **Fonte:** [`docs/OPERATING_MODEL.md`](../../../docs/OPERATING_MODEL.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/PLANO-TESE-ICONOCRACIA.md
+++ b/atlas/stubs/doc/PLANO-TESE-ICONOCRACIA.md
@@ -1,0 +1,29 @@
+---
+title: "ICONOCRACIA: Plano de Tese"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/PLANO-TESE-ICONOCRACIA.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ICONOCRACIA: Plano de Tese
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/PLANO-TESE-ICONOCRACIA.md`](../../../docs/PLANO-TESE-ICONOCRACIA.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+1. Núcleo Conceitual
+
+- **Fonte:** [`docs/PLANO-TESE-ICONOCRACIA.md`](../../../docs/PLANO-TESE-ICONOCRACIA.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/RECONCILE.md
+++ b/atlas/stubs/doc/RECONCILE.md
@@ -1,0 +1,29 @@
+---
+title: "Corpus Reconciliation"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/RECONCILE.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Corpus Reconciliation
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/RECONCILE.md`](../../../docs/RECONCILE.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+The ICONOCRACY corpus lives in **two canonical stores** that must stay
+
+- **Fonte:** [`docs/RECONCILE.md`](../../../docs/RECONCILE.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/ROADMAP-2026-04-29.md
+++ b/atlas/stubs/doc/ROADMAP-2026-04-29.md
@@ -1,0 +1,29 @@
+---
+title: "🌅 29 de abril — Bom dia, Ana"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/ROADMAP-2026-04-29.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 🌅 29 de abril — Bom dia, Ana
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/ROADMAP-2026-04-29.md`](../../../docs/ROADMAP-2026-04-29.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Tudo está em ordem. Aqui está o que você tem pronto para hoje.
+
+- **Fonte:** [`docs/ROADMAP-2026-04-29.md`](../../../docs/ROADMAP-2026-04-29.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/SESSION-2026-04-28-CLOSE.md
+++ b/atlas/stubs/doc/SESSION-2026-04-28-CLOSE.md
@@ -1,0 +1,29 @@
+---
+title: "Resumo da sessão — 2026-04-28 (pause)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/SESSION-2026-04-28-CLOSE.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Resumo da sessão — 2026-04-28 (pause)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/SESSION-2026-04-28-CLOSE.md`](../../../docs/SESSION-2026-04-28-CLOSE.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Itens promovidos (10):
+
+- **Fonte:** [`docs/SESSION-2026-04-28-CLOSE.md`](../../../docs/SESSION-2026-04-28-CLOSE.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/T3-GEMMA4-WORKFLOW.md
+++ b/atlas/stubs/doc/T3-GEMMA4-WORKFLOW.md
@@ -1,0 +1,29 @@
+---
+title: "T3 — Gemma-4 IconoCode Workflow"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/T3-GEMMA4-WORKFLOW.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# T3 — Gemma-4 IconoCode Workflow
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/T3-GEMMA4-WORKFLOW.md`](../../../docs/T3-GEMMA4-WORKFLOW.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Automated IconoCode coding for the 19 uncoded corpus items (queue:
+
+- **Fonte:** [`docs/T3-GEMMA4-WORKFLOW.md`](../../../docs/T3-GEMMA4-WORKFLOW.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/T3-coding-queue.md
+++ b/atlas/stubs/doc/T3-coding-queue.md
@@ -1,0 +1,29 @@
+---
+title: "T3 — IconoCode Coding Queue"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/T3-coding-queue.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# T3 — IconoCode Coding Queue
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/T3-coding-queue.md`](../../../docs/T3-coding-queue.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Each item below needs:
+
+- **Fonte:** [`docs/T3-coding-queue.md`](../../../docs/T3-coding-queue.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/T4-LPAI-INGEST-REPORT.md
+++ b/atlas/stubs/doc/T4-LPAI-INGEST-REPORT.md
@@ -1,0 +1,29 @@
+---
+title: "T4 — LPAI v2 Ingest Report (staging phase)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/T4-LPAI-INGEST-REPORT.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# T4 — LPAI v2 Ingest Report (staging phase)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/T4-LPAI-INGEST-REPORT.md`](../../../docs/T4-LPAI-INGEST-REPORT.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+via `tools/scripts/validate_schemas.py`. Every record carries an
+
+- **Fonte:** [`docs/T4-LPAI-INGEST-REPORT.md`](../../../docs/T4-LPAI-INGEST-REPORT.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/WORKFLOW.md
+++ b/atlas/stubs/doc/WORKFLOW.md
@@ -1,0 +1,29 @@
+---
+title: "Workflow Operacional"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/WORKFLOW.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Workflow Operacional
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/WORKFLOW.md`](../../../docs/WORKFLOW.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Workflow curto para tocar a tese sem perder tempo com drift de estrutura, Git ou release.
+
+- **Fonte:** [`docs/WORKFLOW.md`](../../../docs/WORKFLOW.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/anexo-m3-protocolo-auditoria-externa.md
+++ b/atlas/stubs/doc/anexo-m3-protocolo-auditoria-externa.md
@@ -1,0 +1,29 @@
+---
+title: "Anexo M.3 — Protocolo de Auditoria Externa com Poder Real"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/anexo-m3-protocolo-auditoria-externa.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Anexo M.3 — Protocolo de Auditoria Externa com Poder Real
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/anexo-m3-protocolo-auditoria-externa.md`](../../../docs/anexo-m3-protocolo-auditoria-externa.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A versão v6 das seis condições α–ζ prevê "auditabilidade". A versão v6-reparada (Anexo M.2) declara que "sem auditores com poder institucional de recusa, α–ζ são laudo pericial assinado pelo réu". Esta declaração é retórica forte — mas exig
+
+- **Fonte:** [`docs/anexo-m3-protocolo-auditoria-externa.md`](../../../docs/anexo-m3-protocolo-auditoria-externa.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/anexo-m4-archive-repertoire.md
+++ b/atlas/stubs/doc/anexo-m4-archive-repertoire.md
@@ -1,0 +1,29 @@
+---
+title: "Anexo M.4 — Forma-arquivo vs. repertoire: a grade é constitutivamente iconocrática?"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/anexo-m4-archive-repertoire.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Anexo M.4 — Forma-arquivo vs. repertoire: a grade é constitutivamente iconocrática?
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/anexo-m4-archive-repertoire.md`](../../../docs/anexo-m4-archive-repertoire.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Monge B não diz que o Atlas é bem ou mal feito. Diz que **a forma-arquivo é, por constituição, uma operação de poder**. Isso tem três camadas:
+
+- **Fonte:** [`docs/anexo-m4-archive-repertoire.md`](../../../docs/anexo-m4-archive-repertoire.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/anexo-m5-quarto-regime-epistemico.md
+++ b/atlas/stubs/doc/anexo-m5-quarto-regime-epistemico.md
@@ -1,0 +1,29 @@
+---
+title: "Anexo M.5 — Decisão Editorial: Quarto Regime Epistêmico"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/anexo-m5-quarto-regime-epistemico.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Anexo M.5 — Decisão Editorial: Quarto Regime Epistêmico
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/anexo-m5-quarto-regime-epistemico.md`](../../../docs/anexo-m5-quarto-regime-epistemico.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A tese **não** declara o Atlas-topológico como quarto regime epistêmico no sentido Daston/Galison.
+
+- **Fonte:** [`docs/anexo-m5-quarto-regime-epistemico.md`](../../../docs/anexo-m5-quarto-regime-epistemico.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/atlas-lab-task-1-implementation-note.md
+++ b/atlas/stubs/doc/atlas-lab-task-1-implementation-note.md
@@ -1,0 +1,29 @@
+---
+title: "Atlas Lab v1 — Task 1 implementation note"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/atlas-lab-task-1-implementation-note.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Atlas Lab v1 — Task 1 implementation note
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/atlas-lab-task-1-implementation-note.md`](../../../docs/atlas-lab-task-1-implementation-note.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Date: 2026-04-10
+
+- **Fonte:** [`docs/atlas-lab-task-1-implementation-note.md`](../../../docs/atlas-lab-task-1-implementation-note.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/diagramas-mermaid.md
+++ b/atlas/stubs/doc/diagramas-mermaid.md
@@ -1,0 +1,29 @@
+---
+title: "Diagramas Mermaid — ICONOCRACIA"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/diagramas-mermaid.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Diagramas Mermaid — ICONOCRACIA
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/diagramas-mermaid.md`](../../../docs/diagramas-mermaid.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Diagramas para colar no Notion/Obsidian (blocos de código Mermaid).
+
+- **Fonte:** [`docs/diagramas-mermaid.md`](../../../docs/diagramas-mermaid.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/drive-structure.md
+++ b/atlas/stubs/doc/drive-structure.md
@@ -1,0 +1,29 @@
+---
+title: "Estrutura de Pastas no Google Drive"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/drive-structure.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Estrutura de Pastas no Google Drive
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/drive-structure.md`](../../../docs/drive-structure.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Mapa da organização dos arquivos brutos no Google Drive.
+
+- **Fonte:** [`docs/drive-structure.md`](../../../docs/drive-structure.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/dual-agent-corpus-builder.md
+++ b/atlas/stubs/doc/dual-agent-corpus-builder.md
@@ -1,0 +1,29 @@
+---
+title: "SPEC-1 — Dual-Agent Corpus Builder (WebScout → IconoCode)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/dual-agent-corpus-builder.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# SPEC-1 — Dual-Agent Corpus Builder (WebScout → IconoCode)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/dual-agent-corpus-builder.md`](../../../docs/dual-agent-corpus-builder.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+This document defines an MVP-ready, batch-first architecture for building a traceable iconographic corpus focused on female allegories in legal culture (Brazil/Europe, XV–XX c.).
+
+- **Fonte:** [`docs/dual-agent-corpus-builder.md`](../../../docs/dual-agent-corpus-builder.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/gap-analysis-2026-03-31.md
+++ b/atlas/stubs/doc/gap-analysis-2026-03-31.md
@@ -1,0 +1,29 @@
+---
+title: "ICONOCRACY CORPUS GAP ANALYSIS"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/gap-analysis-2026-03-31.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ICONOCRACY CORPUS GAP ANALYSIS
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/gap-analysis-2026-03-31.md`](../../../docs/gap-analysis-2026-03-31.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+The 1910s peak at 11 items. The 1800s, 1810s, 1840s, 1980s, and 1990s have zero items.
+
+- **Fonte:** [`docs/gap-analysis-2026-03-31.md`](../../../docs/gap-analysis-2026-03-31.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/huggingface-release.md
+++ b/atlas/stubs/doc/huggingface-release.md
@@ -1,0 +1,29 @@
+---
+title: "Hugging Face Release Flow"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/huggingface-release.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Hugging Face Release Flow
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/huggingface-release.md`](../../../docs/huggingface-release.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+This repository treats Hugging Face as a **public release surface**:
+
+- **Fonte:** [`docs/huggingface-release.md`](../../../docs/huggingface-release.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/lacunas-aquisicao-iconografica-2026-04.md
+++ b/atlas/stubs/doc/lacunas-aquisicao-iconografica-2026-04.md
@@ -1,0 +1,29 @@
+---
+title: "Lacunas de Aquisição Iconográfica — 2026-04-25"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/lacunas-aquisicao-iconografica-2026-04.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Lacunas de Aquisição Iconográfica — 2026-04-25
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/lacunas-aquisicao-iconografica-2026-04.md`](../../../docs/lacunas-aquisicao-iconografica-2026-04.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A tese estuda alegoria feminina em dispositivos jurídico-estatais. Tribunais, palácios de justiça e fachadas forenses são o dispositivo arquitetônico central onde a iconocracia se materializa como espaço público. O corpus atual tem **zero**
+
+- **Fonte:** [`docs/lacunas-aquisicao-iconografica-2026-04.md`](../../../docs/lacunas-aquisicao-iconografica-2026-04.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/literature-bibliography-2026-03-31.md
+++ b/atlas/stubs/doc/literature-bibliography-2026-03-31.md
@@ -1,0 +1,29 @@
+---
+title: "BIBLIOGRAPHY: ICONOCRACY -- Female Allegory in the History of Legal Culture (19th-20th c.)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/literature-bibliography-2026-03-31.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# BIBLIOGRAPHY: ICONOCRACY -- Female Allegory in the History of Legal Culture (19th-20th c.)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/literature-bibliography-2026-03-31.md`](../../../docs/literature-bibliography-2026-03-31.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Generated 2026-03-31 by Claude Code agents. Organized by theme with ABNT-style citations.
+
+- **Fonte:** [`docs/literature-bibliography-2026-03-31.md`](../../../docs/literature-bibliography-2026-03-31.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/methodology.md
+++ b/atlas/stubs/doc/methodology.md
@@ -1,0 +1,29 @@
+---
+title: "Metodologia — Cartografia Warburguiana do Imaginário Jurídico"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/methodology.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Metodologia — Cartografia Warburguiana do Imaginário Jurídico
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/methodology.md`](../../../docs/methodology.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+O pipeline obedece à disciplina `teoria → codebook → amostragem → piloto → confiabilidade → freeze → análise`. A barreira **FREEZE** é inegociável: **nenhuma inferência substantiva é proposta antes do congelamento do dataset**. Mudança de i
+
+- **Fonte:** [`docs/methodology.md`](../../../docs/methodology.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/notion-capture-2026-03-31.md
+++ b/atlas/stubs/doc/notion-capture-2026-03-31.md
@@ -1,0 +1,29 @@
+---
+title: "Notion Capture Draft - 2026-03-31"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/notion-capture-2026-03-31.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Notion Capture Draft - 2026-03-31
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/notion-capture-2026-03-31.md`](../../../docs/notion-capture-2026-03-31.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+This draft packages the current Codex conversation into Notion-ready pages.
+
+- **Fonte:** [`docs/notion-capture-2026-03-31.md`](../../../docs/notion-capture-2026-03-31.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/notion-schema.md
+++ b/atlas/stubs/doc/notion-schema.md
@@ -1,0 +1,29 @@
+---
+title: "Notion Schema (Historical)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/notion-schema.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Notion Schema (Historical)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/notion-schema.md`](../../../docs/notion-schema.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Notion is no longer part of the active ICONOCRACY operating model.
+
+- **Fonte:** [`docs/notion-schema.md`](../../../docs/notion-schema.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/perplexity-deep-research-2026-03-31.md
+++ b/atlas/stubs/doc/perplexity-deep-research-2026-03-31.md
@@ -1,0 +1,29 @@
+---
+title: "SYSTEMATIC MAPPING OF SCHOLARSHIP ON FEMALE ALLEGORIES IN STATE AND LEGAL ICONOGRAPHY (1789–1988)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/perplexity-deep-research-2026-03-31.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# SYSTEMATIC MAPPING OF SCHOLARSHIP ON FEMALE ALLEGORIES IN STATE AND LEGAL ICONOGRAPHY (1789–1988)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/perplexity-deep-research-2026-03-31.md`](../../../docs/perplexity-deep-research-2026-03-31.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Martin Jay's "Must Justice Be Blind?" (1996/1999) brings critical theory and feminist analysis to bear on the most ubiquitous legal allegory. Drawing on Horkheimer and Adorno, Jay argues that Justitia's blindfold represents the suppression 
+
+- **Fonte:** [`docs/perplexity-deep-research-2026-03-31.md`](../../../docs/perplexity-deep-research-2026-03-31.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/scripts.md
+++ b/atlas/stubs/doc/scripts.md
@@ -1,0 +1,29 @@
+---
+title: "Pipeline Scripts"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/scripts.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Pipeline Scripts
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/scripts.md`](../../../docs/scripts.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+All scripts live in `tools/scripts/`. Run from repository root:
+
+- **Fonte:** [`docs/scripts.md`](../../../docs/scripts.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/doc/workspace-map.md
+++ b/atlas/stubs/doc/workspace-map.md
@@ -1,0 +1,29 @@
+---
+title: "Workspace Map"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/doc
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../docs/workspace-map.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Workspace Map
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/workspace-map.md`](../../../docs/workspace-map.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Mapa operacional do ecossistema ICONOCRACIA apos a migracao para `/Users/ana/Research`.
+
+- **Fonte:** [`docs/workspace-map.md`](../../../docs/workspace-map.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `doc`

--- a/atlas/stubs/entidade/iconocracia-companion.md
+++ b/atlas/stubs/entidade/iconocracia-companion.md
@@ -1,0 +1,29 @@
+---
+title: "Iconocracia Companion"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/entidade
+  - projeto/iconocracia
+related:
+  - "[[Iconocracia — Mapa Central]]"
+sources:
+  - ../../../entities/iconocracia-companion.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# Iconocracia Companion
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`entities/iconocracia-companion.md`](../../../entities/iconocracia-companion.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+This page serves as an entry point to the research companion for the thesis **\"Iconocracia: Alegoria Feminina na História da Cultura Jurídica (Séculos XIX–XX)\"**.
+
+- **Fonte:** [`entities/iconocracia-companion.md`](../../../entities/iconocracia-companion.md)
+- **MOC:** [[Iconocracia — Mapa Central]]
+- **Categoria:** `entidade`

--- a/atlas/stubs/manuscrito/Capitulo1_rev.md
+++ b/atlas/stubs/manuscrito/Capitulo1_rev.md
@@ -1,0 +1,29 @@
+---
+title: "CAPÍTULO 1"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/manuscrito
+  - projeto/iconocracia
+related:
+  - "[[Manuscrito — MOC]]"
+sources:
+  - ../../../tese/manuscrito/Capitulo1_rev.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# CAPÍTULO 1
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tese/manuscrito/Capitulo1_rev.md`](../../../tese/manuscrito/Capitulo1_rev.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Em 1848, enquanto a onda revolucionária varria a Europa e novas constituições eram redigidas em Paris, Viena, Berlim e Copenhague, o parlamento belga debatia não a revolução, mas o *culto* à sua própria Constituição. Stefan Huygebaert demon
+
+- **Fonte:** [`tese/manuscrito/Capitulo1_rev.md`](../../../tese/manuscrito/Capitulo1_rev.md)
+- **MOC:** [[Manuscrito — MOC]]
+- **Categoria:** `manuscrito`

--- a/atlas/stubs/manuscrito/Capitulo2_metodologia.md
+++ b/atlas/stubs/manuscrito/Capitulo2_metodologia.md
@@ -1,0 +1,29 @@
+---
+title: "CAPÍTULO 2"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/manuscrito
+  - projeto/iconocracia
+related:
+  - "[[Manuscrito — MOC]]"
+sources:
+  - ../../../tese/manuscrito/Capitulo2_metodologia.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# CAPÍTULO 2
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tese/manuscrito/Capitulo2_metodologia.md`](../../../tese/manuscrito/Capitulo2_metodologia.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Se o Capítulo 1 demonstrou que o contrato sexual possui uma dimensão visual — que a hipervisibilidade alegórica feminina compensa a invisibilidade cívica das mulheres reais —, resta agora a questão de *como* tornar essa hipótese verificável
+
+- **Fonte:** [`tese/manuscrito/Capitulo2_metodologia.md`](../../../tese/manuscrito/Capitulo2_metodologia.md)
+- **MOC:** [[Manuscrito — MOC]]
+- **Categoria:** `manuscrito`

--- a/atlas/stubs/manuscrito/Capitulo3_analise_quantitativa.md
+++ b/atlas/stubs/manuscrito/Capitulo3_analise_quantitativa.md
@@ -1,0 +1,29 @@
+---
+title: "CAPÍTULO 3"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/manuscrito
+  - projeto/iconocracia
+related:
+  - "[[Manuscrito — MOC]]"
+sources:
+  - ../../../tese/manuscrito/Capitulo3_analise_quantitativa.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# CAPÍTULO 3
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tese/manuscrito/Capitulo3_analise_quantitativa.md`](../../../tese/manuscrito/Capitulo3_analise_quantitativa.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A análise quantitativa do corpus ICONOCRACIA permite, em primeira instância, mapear a distribuição espacial, temporal e institucional das alegorias femininas que compõem a base empírica desta tese. Com um total de **265 registros** (dos qua
+
+- **Fonte:** [`tese/manuscrito/Capitulo3_analise_quantitativa.md`](../../../tese/manuscrito/Capitulo3_analise_quantitativa.md)
+- **MOC:** [[Manuscrito — MOC]]
+- **Categoria:** `manuscrito`

--- a/atlas/stubs/manuscrito/Introducao_rev.md
+++ b/atlas/stubs/manuscrito/Introducao_rev.md
@@ -1,0 +1,29 @@
+---
+title: "INTRODUÇÃO"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/manuscrito
+  - projeto/iconocracia
+related:
+  - "[[Manuscrito — MOC]]"
+sources:
+  - ../../../tese/manuscrito/Introducao_rev.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# INTRODUÇÃO
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tese/manuscrito/Introducao_rev.md`](../../../tese/manuscrito/Introducao_rev.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+A história do Direito foi tradicionalmente concebida como a história dos textos normativos, das doutrinas e das instituições formais. Essa abordagem textualista, embora indispensável, obscurece uma dimensão constitutiva da legalidade modern
+
+- **Fonte:** [`tese/manuscrito/Introducao_rev.md`](../../../tese/manuscrito/Introducao_rev.md)
+- **MOC:** [[Manuscrito — MOC]]
+- **Categoria:** `manuscrito`

--- a/atlas/stubs/manuscrito/sumario_iconocracia.md
+++ b/atlas/stubs/manuscrito/sumario_iconocracia.md
@@ -1,0 +1,29 @@
+---
+title: "ICONOCRACIA"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/manuscrito
+  - projeto/iconocracia
+related:
+  - "[[Manuscrito — MOC]]"
+sources:
+  - ../../../tese/manuscrito/sumario_iconocracia.md
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ICONOCRACIA
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tese/manuscrito/sumario_iconocracia.md`](../../../tese/manuscrito/sumario_iconocracia.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Versão de trabalho — Março 2026
+
+- **Fonte:** [`tese/manuscrito/sumario_iconocracia.md`](../../../tese/manuscrito/sumario_iconocracia.md)
+- **MOC:** [[Manuscrito — MOC]]
+- **Categoria:** `manuscrito`

--- a/atlas/stubs/notebook/01_exploratory.md
+++ b/atlas/stubs/notebook/01_exploratory.md
@@ -1,0 +1,27 @@
+---
+title: "01 — Estatísticas Descritivas do Corpus (Cap. 6.1)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/analise
+  - projeto/iconocracia
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+sources:
+  - ../../../notebooks/01_exploratory.ipynb
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 01 — Estatísticas Descritivas do Corpus (Cap. 6.1)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`notebooks/01_exploratory.ipynb`](../../../notebooks/01_exploratory.ipynb). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`notebooks/01_exploratory.ipynb`](../../../notebooks/01_exploratory.ipynb)
+- **MOC:** [[Hierarquia de Dados — MOC]]
+- **Categoria:** `notebook`

--- a/atlas/stubs/notebook/02_kruskal_wallis.md
+++ b/atlas/stubs/notebook/02_kruskal_wallis.md
@@ -1,0 +1,27 @@
+---
+title: "02 — Regimes x Morfologia: Kruskal-Wallis (Cap. 6.2)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/analise
+  - projeto/iconocracia
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+sources:
+  - ../../../notebooks/02_kruskal_wallis.ipynb
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 02 — Regimes x Morfologia: Kruskal-Wallis (Cap. 6.2)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`notebooks/02_kruskal_wallis.ipynb`](../../../notebooks/02_kruskal_wallis.ipynb). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`notebooks/02_kruskal_wallis.ipynb`](../../../notebooks/02_kruskal_wallis.ipynb)
+- **MOC:** [[Hierarquia de Dados — MOC]]
+- **Categoria:** `notebook`

--- a/atlas/stubs/notebook/03_regression.md
+++ b/atlas/stubs/notebook/03_regression.md
@@ -1,0 +1,27 @@
+---
+title: "03 — Preditores do endurecimento (Cap. 6.3)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/analise
+  - projeto/iconocracia
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+sources:
+  - ../../../notebooks/03_regression.ipynb
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 03 — Preditores do endurecimento (Cap. 6.3)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`notebooks/03_regression.ipynb`](../../../notebooks/03_regression.ipynb). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`notebooks/03_regression.ipynb`](../../../notebooks/03_regression.ipynb)
+- **MOC:** [[Hierarquia de Dados — MOC]]
+- **Categoria:** `notebook`

--- a/atlas/stubs/notebook/04_correspondence.md
+++ b/atlas/stubs/notebook/04_correspondence.md
@@ -1,0 +1,27 @@
+---
+title: "04 — Análise de Correspondência Múltipla (Cap. 6.4)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/analise
+  - projeto/iconocracia
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+sources:
+  - ../../../notebooks/04_correspondence.ipynb
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 04 — Análise de Correspondência Múltipla (Cap. 6.4)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`notebooks/04_correspondence.ipynb`](../../../notebooks/04_correspondence.ipynb). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`notebooks/04_correspondence.ipynb`](../../../notebooks/04_correspondence.ipynb)
+- **MOC:** [[Hierarquia de Dados — MOC]]
+- **Categoria:** `notebook`

--- a/atlas/stubs/notebook/05_temporal.md
+++ b/atlas/stubs/notebook/05_temporal.md
@@ -1,0 +1,27 @@
+---
+title: "05 — Dinâmica Temporal do Corpus (análise nova)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/analise
+  - projeto/iconocracia
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+sources:
+  - ../../../notebooks/05_temporal.ipynb
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 05 — Dinâmica Temporal do Corpus (análise nova)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`notebooks/05_temporal.ipynb`](../../../notebooks/05_temporal.ipynb). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`notebooks/05_temporal.ipynb`](../../../notebooks/05_temporal.ipynb)
+- **MOC:** [[Hierarquia de Dados — MOC]]
+- **Categoria:** `notebook`

--- a/atlas/stubs/notebook/06_clustering.md
+++ b/atlas/stubs/notebook/06_clustering.md
@@ -1,0 +1,27 @@
+---
+title: "06 — Clustering dos Indicadores de endurecimento (análise nova)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/analise
+  - projeto/iconocracia
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+sources:
+  - ../../../notebooks/06_clustering.ipynb
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 06 — Clustering dos Indicadores de endurecimento (análise nova)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`notebooks/06_clustering.ipynb`](../../../notebooks/06_clustering.ipynb). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`notebooks/06_clustering.ipynb`](../../../notebooks/06_clustering.ipynb)
+- **MOC:** [[Hierarquia de Dados — MOC]]
+- **Categoria:** `notebook`

--- a/atlas/stubs/notebook/07_dimensionality.md
+++ b/atlas/stubs/notebook/07_dimensionality.md
@@ -1,0 +1,27 @@
+---
+title: "07 — Análise de Dimensionalidade (PCA) (análise nova)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/analise
+  - projeto/iconocracia
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+sources:
+  - ../../../notebooks/07_dimensionality.ipynb
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 07 — Análise de Dimensionalidade (PCA) (análise nova)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`notebooks/07_dimensionality.ipynb`](../../../notebooks/07_dimensionality.ipynb). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`notebooks/07_dimensionality.ipynb`](../../../notebooks/07_dimensionality.ipynb)
+- **MOC:** [[Hierarquia de Dados — MOC]]
+- **Categoria:** `notebook`

--- a/atlas/stubs/notebook/08_multidimensional_scoring.md
+++ b/atlas/stubs/notebook/08_multidimensional_scoring.md
@@ -1,0 +1,27 @@
+---
+title: "08 — Refatoração Multidimensional do Score endurecimento (análise nova)"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/analise
+  - projeto/iconocracia
+related:
+  - "[[Hierarquia de Dados — MOC]]"
+sources:
+  - ../../../notebooks/08_multidimensional_scoring.ipynb
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# 08 — Refatoração Multidimensional do Score endurecimento (análise nova)
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`notebooks/08_multidimensional_scoring.ipynb`](../../../notebooks/08_multidimensional_scoring.ipynb). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`notebooks/08_multidimensional_scoring.ipynb`](../../../notebooks/08_multidimensional_scoring.ipynb)
+- **MOC:** [[Hierarquia de Dados — MOC]]
+- **Categoria:** `notebook`

--- a/atlas/stubs/schema/argos-manifest.schema.md
+++ b/atlas/stubs/schema/argos-manifest.schema.md
@@ -1,0 +1,27 @@
+---
+title: "ArgosManifest"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/dados
+  - projeto/iconocracia
+related:
+  - "[[Esquemas JSON]]"
+sources:
+  - ../../../tools/schemas/argos-manifest.schema.json
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ArgosManifest
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tools/schemas/argos-manifest.schema.json`](../../../tools/schemas/argos-manifest.schema.json). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`tools/schemas/argos-manifest.schema.json`](../../../tools/schemas/argos-manifest.schema.json)
+- **MOC:** [[Esquemas JSON]]
+- **Categoria:** `schema`

--- a/atlas/stubs/schema/iconocode-output.schema.md
+++ b/atlas/stubs/schema/iconocode-output.schema.md
@@ -1,0 +1,27 @@
+---
+title: "IconoCodeOutput"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/dados
+  - projeto/iconocracia
+related:
+  - "[[Esquemas JSON]]"
+sources:
+  - ../../../tools/schemas/iconocode-output.schema.json
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# IconoCodeOutput
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tools/schemas/iconocode-output.schema.json`](../../../tools/schemas/iconocode-output.schema.json). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`tools/schemas/iconocode-output.schema.json`](../../../tools/schemas/iconocode-output.schema.json)
+- **MOC:** [[Esquemas JSON]]
+- **Categoria:** `schema`

--- a/atlas/stubs/schema/master-record.schema.md
+++ b/atlas/stubs/schema/master-record.schema.md
@@ -1,0 +1,27 @@
+---
+title: "MasterRecord"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/dados
+  - projeto/iconocracia
+related:
+  - "[[Esquemas JSON]]"
+sources:
+  - ../../../tools/schemas/master-record.schema.json
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# MasterRecord
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tools/schemas/master-record.schema.json`](../../../tools/schemas/master-record.schema.json). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`tools/schemas/master-record.schema.json`](../../../tools/schemas/master-record.schema.json)
+- **MOC:** [[Esquemas JSON]]
+- **Categoria:** `schema`

--- a/atlas/stubs/schema/purification-record.schema.md
+++ b/atlas/stubs/schema/purification-record.schema.md
@@ -1,0 +1,29 @@
+---
+title: "PurificationRecord"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/dados
+  - projeto/iconocracia
+related:
+  - "[[Esquemas JSON]]"
+sources:
+  - ../../../tools/schemas/purification-record.schema.json
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# PurificationRecord
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tools/schemas/purification-record.schema.json`](../../../tools/schemas/purification-record.schema.json). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Single coding record for endurecimento purification indicators (0-3 ordinal scale). Multiple records per item_id are allowed for inter-rater reliability.
+
+- **Fonte:** [`tools/schemas/purification-record.schema.json`](../../../tools/schemas/purification-record.schema.json)
+- **MOC:** [[Esquemas JSON]]
+- **Categoria:** `schema`

--- a/atlas/stubs/schema/research-cluster.schema.md
+++ b/atlas/stubs/schema/research-cluster.schema.md
@@ -1,0 +1,29 @@
+---
+title: "ResearchClusterDoc"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/dados
+  - projeto/iconocracia
+related:
+  - "[[Esquemas JSON]]"
+sources:
+  - ../../../tools/schemas/research-cluster.schema.json
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# ResearchClusterDoc
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tools/schemas/research-cluster.schema.json`](../../../tools/schemas/research-cluster.schema.json). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Workflow doc defining N thematic research clusters (topic × prompts × typed extraction schema). Consumed by tools/scripts/run_research_cluster.py to orchestrate Semantic Scholar + OpenAlex + Zotero cascade and write Obsidian vault notes.
+
+- **Fonte:** [`tools/schemas/research-cluster.schema.json`](../../../tools/schemas/research-cluster.schema.json)
+- **MOC:** [[Esquemas JSON]]
+- **Categoria:** `schema`

--- a/atlas/stubs/schema/webscout-input.schema.md
+++ b/atlas/stubs/schema/webscout-input.schema.md
@@ -1,0 +1,27 @@
+---
+title: "WebScoutInput"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/dados
+  - projeto/iconocracia
+related:
+  - "[[Esquemas JSON]]"
+sources:
+  - ../../../tools/schemas/webscout-input.schema.json
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# WebScoutInput
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tools/schemas/webscout-input.schema.json`](../../../tools/schemas/webscout-input.schema.json). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`tools/schemas/webscout-input.schema.json`](../../../tools/schemas/webscout-input.schema.json)
+- **MOC:** [[Esquemas JSON]]
+- **Categoria:** `schema`

--- a/atlas/stubs/schema/webscout-output.schema.md
+++ b/atlas/stubs/schema/webscout-output.schema.md
@@ -1,0 +1,27 @@
+---
+title: "WebScoutOutput"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/dados
+  - projeto/iconocracia
+related:
+  - "[[Esquemas JSON]]"
+sources:
+  - ../../../tools/schemas/webscout-output.schema.json
+created: 2026-06-22
+updated: 2026-06-22
+---
+
+# WebScoutOutput
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`tools/schemas/webscout-output.schema.json`](../../../tools/schemas/webscout-output.schema.json). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+- **Fonte:** [`tools/schemas/webscout-output.schema.json`](../../../tools/schemas/webscout-output.schema.json)
+- **MOC:** [[Esquemas JSON]]
+- **Categoria:** `schema`


### PR DESCRIPTION
## O que é

Uma camada de **mapa de conhecimento navegável** em `atlas/` (Obsidian Flavored Markdown) que une o material disperso do monorepo — conceitos autorais, pipeline dual-agente, hierarquia canônica de dados, ADRs/decisões, esquemas JSON e manuscrito — num **grafo único, consultável via Dataview**. Os nós **resumem e apontam**; a fonte da verdade permanece em `docs/`, `tools/schemas/`, `tese/manuscrito/`, `concepts/`.

Nasceu de uma conversa sobre a skill "Tapestry" (que **não** constrói grafos de conhecimento). Em vez de instalá-la, construímos a coisa que ela prometia, sobre o corpus real.

> `atlas/` é a meta-camada de navegação do repositório — distinta do conceito warburguiano *Atlas Iconográfico* (`concepts/atlas-iconografico.md`).

## Duas camadas

1. **Espinha curada** (`atlas/*.md`, 18 nós escritos à mão) — hub + 5 MOCs + nós conceituais/pipeline/dados. É onde mora a interpretação.
2. **Stubs gerados** (`atlas/stubs/<categoria>/`) via `atlas/_generate_stubs.py` — um nó por arquivo-fonte (adr · decisao · schema · manuscrito · conceito · entidade · doc · notebook), com resumo-âncora + link relativo + backlink ao MOC. Idempotente; summaries sanitizados (sem ghosts/links quebrados). Regenerar: `python atlas/_generate_stubs.py`.

## Contagens são dinâmicas

O grafo **não fixa números de corpus** (records/itens/codificados) — eles derivam a cada sync. Os nós apontam para [`CLAUDE.md`](../CLAUDE.md) §*Known Data Issues* e para `validate_schemas.py` / `records_to_corpus.py --diff` em vez de hard-codar contagens que envelhecem.

## Higiene de branch (rebase)

A branch havia sido cortada de uma **linhagem divergente** e arrastava 15 PRs já mergeados (#59–#84) → diff de 1.258 arquivos + conflito. **Foi rebaseada sobre o `main` atual** e reduzida a **um único commit aditivo** (`atlas/` apenas). Os links foram repontados aos alvos que **existem no `main`** (ex.: `main` não tem ADR-007 nem `conclusao.md`).

## Validação

- **91 nós · 0 wikilinks quebrados · 0 links relativos quebrados.**
- Terminologia e regras de não-atribuição espelham `CLAUDE.md`; `Endurecimento` usa as chaves ASCII reais do `purification-record.schema.json` (0–3, sem `enum`).
- Adição pura: nenhum arquivo pré-existente alterado.

## CI (nota)

- **`validate` ❌ é pré-existente no `main`** — falha em `data/processed/records.jsonl` (165/264 válidos; 99 com `medium_norm`/`period`/`year` nulos). **Não é causado por este PR** (docs-only, não toca `records.jsonl`). Está sendo investigado em separado.
- **Vercel** = build de projeto pré-existente (sem `vercel.json`).

## Como usar

`Obsidian → Open folder as vault → iconocracy-corpus/atlas/` → abrir **`Iconocracia — Mapa Central`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5tquq1U7L8HPD1PUFr74J