### PR TITLE
docs(method): SSOT via critical-apparatus discipline + DuckDB guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,18 @@ Monorepo for the doctoral thesis **"ICONOCRACIA: Alegoria Feminina na História 
 
 > **Master plan**: `docs/PLANO-TESE-ICONOCRACIA.md` — comprehensive thesis architecture, methodology, case rankings, risk matrix, 24-month work plan, and 10 immediate decisions.
 
+---
+
+## ⚠️ Canonical Data & SSOT Methodology (decided 2026-06-19) — read before touching corpus data
+
+**Methodology (`docs/decisions/2026-06-19-ssot-apparatus-critico-design.md`, via dialectic `docs/decisions/dialectic-ssot-2026-06-19/`):** the corpus is a **versioned hermeneutic artifact** governed by a **critical-apparatus discipline**. The canonical version of reference = a sequence of **frozen, git-versioned releases** (snapshot + coding apparatus + dataset card). **Git is the event log** (commit=event, tag=release). A query DB is an **optional derived index (DuckDB), never the master** — see `docs/apparatus/GUIA-consulta-corpus.md`.
+
+**Operational rules for ALL agents (these prevent real mistakes made on 2026-06-19):**
+1. **`origin/main` is canonical** (records.jsonl=308 / corpus-data.json=309). Local clones may be **stale forks** — ALWAYS `git fetch origin` and compare to `origin/main` BEFORE acting on any corpus count. Never trust a local count.
+2. **`corpus-data.json` is a DERIVED EXPORT** of `records.jsonl` (via `records_to_corpus.py`). Editing it directly is **ephemeral** (regenerated). Change the master, then re-export. **NEVER run `records_to_corpus.py --replace`** — it strips `id`/`country`/`support`. Default (merge) mode is correct.
+3. **Quarantine/uncoded already exists** — `tools/scripts/tag_uncoded_purification.py` + `data/processed/purification-manifest.json` + `docs/decisions/quarantine-uncoded-2026-05-30.json`. Don't reinvent it. Validity axis = `coded_by` (instrument provenance), per `docs/decisions/DIALETICA-N165-vs-265.md`; read decisions/* FIRST.
+4. `endurecimento_score=0` is a **valid score** (low purification), not "uncoded". N analítico = coded only (~223), never 309.
+
 **Parent CLAUDE.md context** (do not duplicate; read on demand):
 - `~/Documents/CLAUDE.md` — host layout, stale `/data/` → `~/Documents/` migration, location of binary drop zone `iconocracy-corpus/binaries/` (separate from this repo).
 - `~/Documents/projetos/research/CLAUDE.md` — meta-workspace conventions (sub-repo containment, where new pipelines/labs/apps go).

--- a/docs/apparatus/GUIA-consulta-corpus.md
+++ b/docs/apparatus/GUIA-consulta-corpus.md
@@ -1,0 +1,90 @@
+---
+tags: [meta, data, guide, duckdb, apparatus]
+date: 2026-06-19
+status: guide
+see_also: docs/decisions/2026-06-19-ssot-apparatus-critico-design.md
+---
+
+# Guia — Consultar o corpus Iconocracia (DuckDB sobre releases congelados)
+
+> Engine: **DuckDB** (recomendado) · SQLite (alternativa embarcada) · **NÃO Postgres** (servidor multiusuário, overkill p/ corpus solo de ~300 itens; só valeria p/ backend web multiusuário). DuckDB lê JSON/CSV/Parquet **no lugar**, sem etapa de carga — encaixa no aparato crítico: os arquivos do release são a verdade, o DuckDB é só a camada de consulta.
+
+## 0. Por que DuckDB aqui
+- Zero-ETL: `SELECT ... FROM 'corpus-data.json'` direto. Nenhum mestre vivo a manter.
+- Descartável: o índice é reconstruível do release a qualquer momento (Phase 4 do plano).
+- SQL analítico forte (window functions, agregações) sem servidor.
+
+## 1. Setup (uma vez)
+```bash
+# via skill: use a skill `install-duckdb`, ou:
+brew install duckdb        # CLI
+# Python (no env iconocracy):
+/opt/homebrew/Caskroom/miniforge/base/envs/iconocracy/bin/python3.12 -m pip install duckdb
+```
+CLI: `duckdb` · Python: `import duckdb`.
+
+## 2. Ler o corpus direto do arquivo (sem carregar)
+```sql
+-- corpus-data.json é uma lista de objetos (flat export, id semântico)
+SELECT count(*) AS n FROM read_json_auto('corpus/corpus-data.json');
+
+-- master ledger (records.jsonl, 1 objeto/linha, UUID item_id, estrutura rica)
+SELECT count(*) FROM read_json_auto('data/processed/records.jsonl', format='newline_delimited');
+```
+> Consultar SEMPRE um **release congelado citado** (ex.: tag `corpus-v1.0`), não o working copy, quando o número for pra um capítulo. `git show corpus-v1.0:corpus/corpus-data.json > /tmp/v1.json` e leia de lá.
+
+## 3. Consultas analíticas-chave (colunas reais do corpus)
+Colunas do flat export: `id, url, title, description, motif, regime, endurecimento_score, coded_by, coded_at, citation_abnt, country, support, audit_flags`.
+
+```sql
+-- N por estrato de instrumento (o eixo da DIALETICA-N165): valida o N analítico
+SELECT coalesce(coded_by,'(uncoded)') AS instrumento, count(*) AS n
+FROM read_json_auto('corpus/corpus-data.json')
+GROUP BY 1 ORDER BY n DESC;
+
+-- N analítico = só codificados (exclui Estrato 0)
+SELECT count(*) FROM read_json_auto('corpus/corpus-data.json')
+WHERE coded_by IS NOT NULL AND trim(coded_by) <> '';
+
+-- Distribuição de endurecimento por regime (o coração quantitativo)
+SELECT regime,
+       count(*) AS n,
+       round(avg(endurecimento_score),2) AS media,
+       round(median(endurecimento_score),2) AS mediana
+FROM read_json_auto('corpus/corpus-data.json')
+WHERE regime IS NOT NULL AND regime <> '' AND regime <> 'PENDENTE'
+GROUP BY regime ORDER BY media;
+
+-- Filtro de quarentena: excluir fora-do-escopo (audit_flags é lista)
+SELECT count(*) FROM read_json_auto('corpus/corpus-data.json')
+WHERE NOT list_contains(audit_flags, 'fora-do-escopo');
+
+-- Por país e suporte (cobertura do corpus)
+SELECT country, support, count(*) AS n
+FROM read_json_auto('corpus/corpus-data.json')
+GROUP BY ALL ORDER BY n DESC;
+```
+
+## 4. Padrões do cheat-sheet (Postgres) → traduzidos ao seu caso
+| Padrão Postgres | No seu caso (DuckDB) |
+|---|---|
+| Índices B-tree/GIN manuais | **Desnecessário** — DuckDB é colunar/vetorizado; varre 300 linhas instantaneamente. Índice só importa em escala grande. |
+| `timestamptz` p/ timestamps | `coded_at` já é ISO-8601 string; `CAST(coded_at AS TIMESTAMP)` quando precisar. |
+| `numeric(10,2)` p/ dinheiro | `endurecimento_score` é float ordinal 0–3; ok como DOUBLE. NÃO tratar 0 como ausência (é score válido). |
+| UPSERT `ON CONFLICT` | N/A — você **não escreve no DB**; a verdade é o release git. O DB é read-only derivado. |
+| Cursor pagination | N/A nessa escala. |
+| RLS / pooling / `max_connections` | N/A — sem servidor, sem multiusuário. |
+
+## 5. Montar o índice derivado (Phase 4 do plano) — opcional
+```sql
+-- materializa um .duckdb a partir do release (reconstruível, descartável)
+ATTACH 'corpus-v1.0.duckdb' AS idx;
+CREATE TABLE idx.corpus AS SELECT * FROM read_json_auto('corpus/corpus-data.json');
+-- consulte idx.corpus; delete o arquivo quando quiser, é só cache.
+```
+
+## 6. Se um dia precisar de SQLite em vez de DuckDB
+Mesmo SQL essencial. Diferenças: SQLite não lê JSON nativo tão bem (precisa carregar via script Python `json`→`INSERT`), e é row-store (melhor p/ lookups pontuais que p/ agregação analítica). Para a análise da tese, DuckDB é superior. A skill `sqlite-database-expert` (instalada) cobre o caso SQLite.
+
+## 7. Quando o Postgres faria sentido (e por que não agora)
+Só se você for expor o corpus num **backend web multiusuário com escrita concorrente** (login, edição colaborativa, API pública). Hoje: não há isso (webiconocracy aposentada; companion é estático). Postgres adicionaria um servidor a manter, contra o princípio de menor-custo-de-atenção até 2027. Reabrir só se surgir o caso de uso.

--- a/docs/decisions/2026-06-19-ssot-apparatus-critico-design.md
+++ b/docs/decisions/2026-06-19-ssot-apparatus-critico-design.md
@@ -1,0 +1,90 @@
+---
+tags: [meta, methodology, data, design-spec, decision]
+date: 2026-06-19
+status: draft-for-review
+supersedes_intent: "SQLite event-sourced como mestre (reframed via dialética)"
+see_also:
+  - docs/decisions/DIALETICA-N165-vs-265.md
+  - docs/decisions/dialectic-ssot-2026-06-19/round_1_synthesis.md
+---
+
+# Design Spec — Versão Canônica de Referência via Aparato Crítico
+## (Single-source-of-truth do corpus Iconocracia, sub-projeto 1 de "abordagem de dados metodológica")
+
+## 1. Problema & objetivo
+O corpus hoje não tem **estado conhecível**: a contagem varia (264/265/309/165) entre stores, há fork git local stale (18-ahead/17-behind origin/main), e múltiplas ferramentas (Claude Code, Antigravity/Gemini, crons, edição manual) escrevem em arquivos espalhados. Isso torna qualquer alegação empírica da tese (distribuições de endurecimento, Kruskal-Wallis) **não-reproduzível e, portanto, infalsificável**.
+
+**Objetivo:** estabelecer uma **versão canônica de referência** do corpus — uma só verdade, datada, legível, com proveniência de *juízo* documentada — ao **menor custo da atenção da Ana até nov/2027**.
+
+## 2. Decisão de método (resultado da dialética, aprovada 2026-06-19)
+O corpus é um **artefato hermenêutico versionado**, governado por uma **disciplina de aparato crítico** (modelo da edição crítica filológica). A verdade não é um banco vivo nem prosa solta: é uma **sequência de RELEASES analíticos congelados, versionados no git**.
+
+> Renomeação metodológica: não dizer "single source of truth" (fóssil de engenharia) — dizer **"versão canônica de referência"**.
+
+### Não-objetivos (YAGNI / out of scope deste sub-projeto)
+- **NÃO** construir SQLite event-sourced como mestre. (O DB, se vier, é índice derivado opcional — ver §6.)
+- **NÃO** migrar tudo para um schema novo agora.
+- **NÃO** resolver confiabilidade inter-instrumento (opus vs opus-4.6) — é validade DENTRO de um release (sub-projeto 2).
+- **NÃO** resolver a sincronização multi-máquina Mac↔SSD↔GitHub (sub-projeto 3, fila da dialética).
+
+## 3. Arquitetura
+```
+                 ┌─────────────────────────────────────────┐
+   ferramentas → │  git main (working copy) — UMA canônica  │ ← propõem mudanças como commits/PRs,
+   (CC, Gemini,  │  records.jsonl (master ledger)           │   nunca escrita direta espalhada
+    crons)       └───────────────────┬─────────────────────┘
+                                     │  freeze (tag)
+                                     ▼
+                 ┌─────────────────────────────────────────┐
+                 │  RELEASE congelado  (ex.: corpus-v1.0)   │  = a versão canônica de referência
+                 │   ├─ snapshot legível (records @ corte)  │
+                 │   ├─ APARATO de codificação (racional)   │  ← proveniência-de-JUÍZO
+                 │   └─ DATASET CARD (dimensões, N, estratos,│
+                 │       2 sentidos de "reprodutibilidade") │
+                 └───────────────────┬─────────────────────┘
+                                     │  exports determinísticos
+                                     ▼
+        corpus-data.json · companion · dashboards · (SQLite índice, opcional)
+```
+- **Git É o log de eventos** (de graça): commit = evento; tag = release; mensagem de commit = racional da mudança. Sem event-sourced DB.
+- **Exports são projeções** do release; nunca fontes rivais.
+
+## 4. Componentes
+1. **Processo de release** (`tools/scripts/freeze_release.py`): dado o estado atual do git main, cria uma tag `corpus-vX.Y`, gera o snapshot legível + um stub de dataset card + valida schema/paridade. Idempotente.
+2. **Template do aparato** (`docs/apparatus/TEMPLATE.md` + um registro por release em `docs/apparatus/corpus-vX.Y.md`): campos por coding **contestado/revisado** — `id`, dimensão, valor, **racional** (prosa), revisões anteriores (variant readings), motivo de quarentena. NÃO documenta todos os 309 — só os contestados/usados em alegações.
+3. **Dataset card** (`docs/apparatus/corpus-vX.Y-card.md`): o que cada uma das 10 dimensões significa; N e estratos por `coded_by`; **declaração explícita dos 2 sentidos de "reprodutibilidade"** (estatística vs hermenêutica) e qual a tese reivindica.
+4. **Disciplina de escritor único** (doc + convenção git): entre releases, uma cópia canônica (git main); ferramentas propõem via commit/PR. Mata a proliferação na raiz.
+5. **Índice derivado** (`tools/scripts/build_index.py`) — **DIFERIDO**: só quando consulta/dashboard exigir; reconstruído do release; nunca mestre. Engine recomendado: **DuckDB** (lê os releases JSON no lugar, zero-ETL) — ver `docs/apparatus/GUIA-consulta-corpus.md`.
+
+## 5. Fluxo de dados
+Escrita → git main (commit com racional) → `freeze_release.py` (tag + snapshot + aparato/card) → exports determinísticos. Leitura analítica (notebooks) → lê o release congelado citado, não o working copy.
+
+## 6. O lugar invertido do DB
+A escolha inicial (SQLite event-sourced mestre) é **invertida**: se um índice consultável for necessário, ele é uma **projeção** reconstruível do release git — descartável e reconstruível. A verdade nunca vive nele. Isso preserva o desejo de rigor sem o custo de manter um mestre vivo.
+
+## 7. Migração / pré-requisito (passo 1, bloqueia tudo)
+**Reconciliar a divergência:** adotar `origin/main` (309 registros, onde o trabalho canônico evoluiu) como base; auditar se os 18 commits locais têm trabalho ÚNICO; resolver o fork (rebase seletivo OU reset para origin após salvar o único). SÓ ENTÃO há o que congelar. (Operação planejada — sub-passo com aval da Ana, não bulldoze.)
+
+## 8. Sequência & cost budget
+1. Reconciliar fork ↔ origin/main=309. *(pré-req)*
+2. `freeze_release.py` → `corpus-v1.0` (snapshot + card mínimo). *(custo único ~1 sessão)*
+3. Template do aparato + card com os 2 sentidos de reprodutibilidade. *(~1 sessão)*
+4. Doc da disciplina de escritor único.
+5. Retomar escrita — o aparato **acresce por alegação** (capítulo usa coding → documenta), não upfront.
+- **Custo único:** ~1–2 sessões. **Depois:** cada release = tag + atualização de card (barato). Justificado: torna os capítulos estatísticos defensáveis e é MUITO mais barato que um DB vivo.
+
+## 9. Atritos declarados (a síntese NÃO resolve — são para nomear, não esconder)
+- **"Reprodutibilidade" é indecidível:** dois sentidos opostos; o dataset card os declara.
+- **Custo de atenção (Adorno):** mesmo o aparato custa atenção uma vez; orçado em §8 e amortizado.
+
+## 10. Critérios de sucesso
+- [ ] Existe UMA versão canônica de referência datada e citável; toda contagem é um `SELECT`/script sobre ela, não 4 números divergentes.
+- [ ] Para qualquer coding usado numa alegação, há racional recuperável (aparato).
+- [ ] Exports são reconstruíveis deterministicamente do release.
+- [ ] Nenhuma ferramenta escreve fora do fluxo git.
+- [ ] Tempo de infra ≤ 2 sessões antes de a escrita retomar.
+
+## 11. Fila (sub-projetos seguintes)
+2. Validade analítica DENTRO do release (confiabilidade inter-instrumento) — eixo DIALETICA-N165.
+3. Reconciliação/sync multi-máquina (git-workflow).
+4. O aparato como material do capítulo de metodologia (funde dado e prosa).

--- a/docs/decisions/dialectic-ssot-2026-06-19/README.md
+++ b/docs/decisions/dialectic-ssot-2026-06-19/README.md
@@ -1,0 +1,10 @@
+# Dialética — Single Source of Truth (2026-06-19)
+
+Traço completo da dialética (skill hegelian-dialectic) que decidiu a metodologia de dados do corpus.
+
+- `round_1_context_briefing.md` — enquadramento e pergunta ontológica
+- `round_1_monk_a.md` / `round_1_monk_b.md` — as duas posições (dataset vs hermenêutico) — núcleos
+- `round_1_determinate_negation.md` — análise estrutural da contradição
+- `round_1_synthesis.md` — a síntese (Aufhebung): disciplina de aparato crítico
+
+Spec resultante: `../2026-06-19-ssot-apparatus-critico-design.md`

--- a/docs/decisions/dialectic-ssot-2026-06-19/round_1_context_briefing.md
+++ b/docs/decisions/dialectic-ssot-2026-06-19/round_1_context_briefing.md
@@ -1,0 +1,23 @@
+# Dialectic — Single Source of Truth for the Iconocracia Corpus
+## Round 1 · Context Briefing
+_2026-06-19 · domain: mixed (empirical infra × normative scholarly method)_
+
+## A decisão sob tensão
+Via brainstorming, Ana escolheu (a opção mais rigorosa em cada passo): mestre = SQLite; proveniência = event-sourced/append-only; meta = consolidar os muitos escritores (Claude Code, Antigravity/Gemini, crons, manual) num fluxo único.
+
+## A contradição genuína (nível ontológico, não "DB vs arquivo")
+> **O corpus é um DATASET ou um APARATO HERMENÊUTICO?**
+- **Dataset:** instrumento quantitativo; alegações empíricas (endurecimento, Kruskal-Wallis) são infalsificáveis sem proveniência reproduzível de codificação ⇒ event-sourced DB.
+- **Hermenêutico:** objeto interpretativo; a fonte-única é o juízo da pesquisadora registrado em prosa; o DB impõe frame positivista, fabrica falsa precisão de ordinais 0–3, e consome o recurso escasso (atenção até 2027).
+
+## Situação concreta
+- Ana, doutoranda solo, PPGD/UFSC, história do direito penal / iconografia jurídica. Defesa ~nov/2027. Escreve no Obsidian.
+- ~265–309 registros; 10 indicadores ordinais de "endurecimento" (0–3); regimes fundacional/normativo/militar/contra-alegoria.
+- A ferida (esta semana): contagem incognoscível (264/265/309/165); fork git stale; quarentena reinventada porque o estado era ilegível; ferramentas múltiplas escrevendo em JSONs espalhados.
+- Decisão prévia (DIALETICA-N165-vs-265): corpus = objeto versionado; validade analítica = proveniência de instrumento de codificação.
+
+## Calibração (Convergent-Visionary)
+Ana convergiu rápido em "rigor máximo = certo". Monk A valida a visão de rigor; Monk B crê na alternativa mais forte (corpus hermenêutico; o DB é erro categorial que faminta a tese). O orquestrador julga do assento livre-de-crença.
+
+## Pergunta ontológica condutora
+"Qual é a fonte única da verdade de um corpus doutoral — o store que o guarda, ou a prática acadêmica que o produz? E responder 'o store' converte silenciosamente um objeto hermenêutico num positivista?"

--- a/docs/decisions/dialectic-ssot-2026-06-19/round_1_determinate_negation.md
+++ b/docs/decisions/dialectic-ssot-2026-06-19/round_1_determinate_negation.md
@@ -1,0 +1,28 @@
+# Round 1 — Determinate Negation (orchestrator analysis)
+
+## Surface contradiction
+- **Monk A (dataset):** quantificação ⇒ instrumento empírico ⇒ infalsificável sem proveniência reproduzível ⇒ event-sourced DB.
+- **Monk B (hermenêutico):** codings são argumentos ⇒ sem valor-verdadeiro a proveniar ⇒ DB reifica falsa ontologia + faminta a tese ⇒ congelar + prosa.
+
+## Tensões internas (cada monk se mina)
+- **A** concede que o coding é interpretativo — mas exige *proveniência-de-medição* (event-sourcing como se houvesse valor verdadeiro). Se é juízo, o que precisa rastrear é a **justificativa**, não transição de estado.
+- **B** prescreve "congelar snapshot + dataset card + nada escreve" — que **É uma fonte-única-da-verdade** com proveniência documentada. B reinventou a meta de A negando o nome.
+
+## Suposição compartilhada (a prisão de ambos)
+Ambos deslizam num movimento da **natureza do ATO de codificação** para a **natureza da ARQUITETURA de armazenamento**, conflando quatro coisas: (1) o ato interpretativo, (2) o registro/dado, (3) a alegação estatística, (4) a arquitetura de proveniência. A arquitetura NÃO precisa herdar a ontologia do ato.
+
+## Negação determinada (a falha específica = sinalização)
+- **A falha** ao equiparar "auditável/falsificável" a "event-sourced como medição". Sinaliza: o que se deve é **rastreabilidade-de-justificativa por versão**, não log de transição de um valor-fantasma.
+- **B falha** ao inferir de "o ato é interpretativo" que a **alegação agregada não precisa de substrato fixo/reproduzível**. Sinaliza: o freeze+card de B *é* esse substrato — logo a real necessidade é **fixidez + racional documentado**.
+
+## Pergunta oculta
+"Qual a arquitetura MÍNIMA que torna os juízos de codificação reproduzíveis-como-justificativas (não como medições), ao menor custo da atenção até 2027 — e a defensabilidade exige um *sistema vivo*, ou só um *artefato congelado, legível, com proveniência documentada*?"
+
+## Decomposição boydiana → conexão cross-domain
+Átomos: {fixidez, databilidade, citabilidade, rastreabilidade-de-justificativa, falsifiabilidade, baixo-custo-atenção, sem-falsa-precisão, ontologia-interpretativa, escritor-único, exports-determinísticos}. Ambos convergem num **snapshot congelado documentado**.
+**Injeção externa:** o **apparatus criticus** da edição crítica filológica — 500 anos tornando juízos editoriais interpretativos rastreáveis e falsificáveis **sem reduzi-los a medições** (uma edição congela uma versão; leituras contestadas vão num aparato estruturado, por edição, não num banco vivo). Estrutura emergente que nenhum monk segura: proveniência-de-juízo simultaneamente falsificável (A) e não-positivista (B), a custo ~zero (git já é o log de versões).
+
+## Misfit register (atritos que a síntese NÃO resolve)
+- **[Foucault]** "single source of truth" é fóssil de engenharia; aplicado a objeto hermenêutico, pode ser o erro categorial. Renomear → "versão canônica de referência".
+- **[Derrida]** "reprodutibilidade" carregada em sentidos opostos (estatística vs hermenêutica). Declarar no dataset card.
+- **[Adorno]** escassez de atenção: mesmo o aparato custa atenção uma vez; orçar o gasto único contra 2027.

--- a/docs/decisions/dialectic-ssot-2026-06-19/round_1_monk_a.md
+++ b/docs/decisions/dialectic-ssot-2026-06-19/round_1_monk_a.md
@@ -1,0 +1,3 @@
+# Round 1 — Monk A (Dataset / event-sourced SSOT)
+
+Ver `round_1_synthesis.md` e `round_1_determinate_negation.md`. Tese: o corpus VIRA dataset ao ser quantificado; defensabilidade exige proveniencia event-sourced; quem quantifica sem proveniencia e MAIS positivista.

--- a/docs/decisions/dialectic-ssot-2026-06-19/round_1_monk_b.md
+++ b/docs/decisions/dialectic-ssot-2026-06-19/round_1_monk_b.md
@@ -1,0 +1,3 @@
+# Round 1 — Monk B (Hermeneutic apparatus / practice-as-SSOT)
+
+Ver `round_1_synthesis.md` e `round_1_determinate_negation.md`. Tese: o corpus e aparato hermeneutico; a fonte-unica e a pratica interpretativa; o DB e erro categorial que faminta a tese; congelar + prosa.

--- a/docs/decisions/dialectic-ssot-2026-06-19/round_1_synthesis.md
+++ b/docs/decisions/dialectic-ssot-2026-06-19/round_1_synthesis.md
@@ -1,0 +1,40 @@
+# Round 1 — Synthesis (Aufhebung)
+
+## The synthesis
+**O corpus da Iconocracia é um ARTEFATO HERMENÊUTICO VERSIONADO, governado por uma disciplina de APARATO CRÍTICO.** A fonte-única-da-verdade não é um banco vivo nem a prosa solta — é uma **sequência de RELEASES analíticos congelados, versionados no git**, cada um composto de:
+1. um **snapshot legível** dos registros (o estado de codificação naquele corte),
+2. um **aparato de codificação** — o racional dos juízos contestados/revisados e os motivos de quarentena (como *variant readings* numa edição crítica),
+3. um **dataset card** — o que cada uma das 10 dimensões significa, o N e seus estratos por instrumento, e a declaração explícita dos DOIS sentidos de "reprodutibilidade".
+
+## Por que é Aufhebung (não compromisso)
+- **Cancela** o binário dataset-XOR-hermenêutica e DB-XOR-prosa.
+- **Preserva** a falsifiabilidade/auditabilidade de A *e* a ontologia interpretativa + escassez-de-atenção de B.
+- **Eleva** para uma tecnologia de proveniência **nativa das humanidades** (o apparatus criticus, 500 anos de filologia): torna o juízo interpretativo rastreável e contestável **sem** convertê-lo em medição com "valor verdadeiro".
+
+## Os movimentos concretos
+1. **Git É o log de eventos — de graça.** Cada release é um commit/tag; o diff entre releases é o "o que mudou e por quê" (a mensagem de commit carrega o racional). Não precisa de event-sourced DB separado para proveniência.
+2. **Proveniência-de-juízo, não de-medição.** O aparato registra POR QUE um coding é o que é. Codings contestados/revisados levam nota — como leituras variantes. Satisfaz A (a leitora re-audita o juízo) sem o positivismo de B (é prosa+estrutura, não um log de transição de um valor-fantasma).
+3. **Escritores consolidados pela disciplina de release**, não por lock de DB: entre releases, UMA cópia de trabalho é canônica (git main); ferramentas propõem mudanças como commits/PRs.
+4. **O DB é infra OPCIONAL e adiada — e INVERTIDA:** se/quando consulta/dashboards exigirem, um índice (DuckDB) vira **projeção** reconstruída dos releases git — nunca o mestre.
+5. **Renomear o alvo (misfit Foucault):** não "single source of truth" — **"versão canônica de referência"**.
+6. **Declarar a indecidível (misfit Derrida):** o dataset card declara que "reprodutibilidade" tem dois sentidos — estatística (re-rodar) e hermenêutica (leitora competente chega a leitura comparável) — e que a tese reivindica o segundo, exibindo o primeiro como ilustração.
+
+## Reversibility check (Boyd) — cada claim traça a um átomo
+fixity→freeze; datability→git tag; justification-trace→aparato; falsifiability→juízo re-auditável; low-cost→git grátis + incremental; no-false-precision→racional em prosa; interpretive-ontology→modelo de variantes; single-writer→workflow git; deterministic-exports→releases. ✓ Sem claim órfão.
+
+## Sequência (o "o que primeiro")
+1. Reconciliar a divergência (origin/main=309; resolver fork local).
+2. Congelar `v-atual` (snapshot + tag + dataset card).
+3. Template do aparato.
+4. Declarar os dois sentidos de reprodutibilidade.
+5. Retomar a escrita — o aparato ACRESCE por alegação, não upfront.
+
+## Model update
+- **Antes:** "Preciso de um SQLite event-sourced como fonte única da verdade."
+- **Depois:** "Preciso de uma disciplina de aparato crítico — releases congelados versionados no git + racional de codificação — como versão canônica de referência; o DB é índice derivado opcional."
+- **Porque:** ambos os monks convergiam num snapshot congelado documentado; a proveniência-de-juízo já tem tecnologia humanista nativa que o git implementa de graça.
+
+## Dialectic queue (contradições abertas)
+1. Reconciliação multi-máquina (Mac↔SSD-Linux↔GitHub) — git-workflow.
+2. Confiabilidade inter-instrumento (opus vs opus-4.6) — validade DENTRO de um release.
+3. O aparato como objeto de escrita (funde dado e prosa).

--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,25 @@
+# Findings — SSOT / abordagem de dados (2026-06-19)
+
+## Estado do dado (CRÍTICO)
+- **`origin/main` é canônico:** corpus-data.json=**309**, records.jsonl=**308**, uncoded=78.
+- **Local `main` era fork STALE** (264/265; 18-ahead/17-behind). Atenção: SEMPRE `git fetch` + comparar com origin/main antes de tocar dado.
+- **Mecanismo de quarentena JÁ EXISTE no origin** (2026-05-30): `tag_uncoded_purification.py`, `build_purification_manifest.py`, `purification-manifest.json`, `docs/decisions/quarantine-uncoded-2026-05-30.json` (mesmos 41 ids). flag `fora-do-escopo:27` também existe.
+
+## Arquitetura de dados (descoberta empírica)
+- `corpus-data.json` é EXPORT derivado de `records.jsonl` via `records_to_corpus.py` (modo merge default preserva campos curados id/country/support + extras; `--replace` os QUEBRA — não usar).
+- Editar o export é efêmero (regenerado). A verdade tem que ser release congelado.
+- Git já é o log de eventos. DB redundante como mestre.
+
+## Resultado da dialética
+- Verdade = disciplina de aparato crítico (releases git congelados + aparato + dataset card). DB = índice derivado opcional (DuckDB).
+- Cross-domain: apparatus criticus filológico = proveniência-de-juízo sem positivismo.
+- 2 atritos a declarar: "reprodutibilidade" tem 2 sentidos; custo de atenção.
+
+## Demo DuckDB (validada ao vivo no corpus local 264)
+- N por estrato: iconocode-opus 100, vault-import 58, uncoded 41, opus-4.6-refined 29, migration 19, opus-4.6-image 16, manual 1. N analítico (codificados) = 223.
+- **Endurecimento por regime (gradiente monotônico):** contra-alegoria 0,63 < fundacional 0,83 < normativo 1,09 < militar 1,60.
+- (Recomputar na verdade canônica 309 após reconciliar.)
+
+## Ambiente
+- jsonschema 4.26.0 + duckdb 1.5.4 instalados no conda env `iconocracy`.
+- Python: `/opt/homebrew/Caskroom/miniforge/base/envs/iconocracy/bin/python3.12`.

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,14 @@
+# Progress Log — SSOT / abordagem de dados
+
+## Sessão 2026-06-19
+- ✅ Brainstorming (superpowers): escopo → fonte única da verdade; raiz → multi-ferramenta/consolidar.
+- ✅ Dialética (hegelian-dialectic, 1 rodada, 2 monks): tensão dataset vs hermenêutica → síntese aprovada (aparato crítico git-versionado; DB = índice derivado). Virou a escolha inicial (SQLite event-sourced).
+- ✅ Design spec: `docs/decisions/2026-06-19-ssot-apparatus-critico-design.md`.
+- ✅ Guia de consulta DuckDB: `docs/apparatus/GUIA-consulta-corpus.md` (validado ao vivo).
+- ✅ Planning files: task_plan.md, findings.md, progress.md.
+- ⏳ PRÓXIMO: Phase 0 (reconciliar fork ↔ origin/main=309) — precisa do aval da Ana na estratégia. NÃO bulldoze.
+
+### Notas
+- Esta entrega foi publicada via branch `docs/ssot-methodology-2026-06-19` (a partir de origin/main, base 309), pois o main local divergente não pode dar fast-forward push.
+- Artefatos superseded (nframe-audit, corpus/quarantine reinventada, analytic_corpus.py) NÃO foram commitados — o origin já tem o mecanismo real de quarentena.
+- ATENÇÃO operacional: há automação (crons/worktrees) que apaga arquivos untracked no working tree do main local. Trabalhar via branch/worktree isolado.

--- a/task_plan.md
+++ b/task_plan.md
@@ -1,0 +1,43 @@
+# Task Plan — Versão Canônica de Referência via Aparato Crítico (SSOT sub-projeto 1)
+
+**Goal:** Estabelecer UMA versão canônica de referência do corpus Iconocracia — datada, legível, com proveniência de juízo — ao menor custo de atenção até nov/2027. Metodologia: disciplina de aparato crítico (releases git congelados + aparato de codificação + dataset card). DB = índice derivado opcional (DuckDB).
+
+**Spec:** `docs/decisions/2026-06-19-ssot-apparatus-critico-design.md`
+**Dialética:** `docs/decisions/dialectic-ssot-2026-06-19/round_1_synthesis.md`
+**Guia de consulta:** `docs/apparatus/GUIA-consulta-corpus.md`
+
+---
+
+## Phase 0 — Reconciliar a divergência (PRÉ-REQUISITO, bloqueia tudo) — Status: pending
+Local `main` está 18-ahead/17-behind `origin/main` (309 reg, canônico).
+- [ ] 0.1 Auditar os 18 commits locais: têm trabalho ÚNICO? (`git log origin/main..main`).
+- [ ] 0.2 Auditar os 17 commits do origin que faltam local (#67–#87).
+- [ ] 0.3 Decidir estratégia COM Ana: reset / rebase seletivo / cherry-pick. NÃO bulldoze.
+- [ ] 0.4 Executar; confirmar local == origin/main (309/308).
+- **Aceitação:** `git rev-list --left-right --count origin/main...HEAD` = 0/0; corpus = 309; nada único perdido.
+
+## Phase 1 — Congelar corpus-v1.0 — Status: pending
+- [ ] 1.1 `tools/scripts/freeze_release.py` (tag + snapshot legível + valida). Idempotente.
+- [ ] 1.2 Rodar; produzir snapshot + tag.
+- [ ] 1.3 Stub dataset card `docs/apparatus/corpus-v1.0-card.md`.
+
+## Phase 2 — Aparato + dataset card — Status: pending
+- [ ] 2.1 `docs/apparatus/TEMPLATE.md` (campos por coding contestado).
+- [ ] 2.2 Card: 10 dimensões + 2 sentidos de "reprodutibilidade".
+- [ ] 2.3 Popular o aparato só para codings usados em alegações.
+
+## Phase 3 — Disciplina de escritor único — Status: pending
+- [ ] 3.1 `docs/WORKFLOW-single-writer.md`.
+- [ ] 3.2 Redirecionar escritores concorrentes (crons em JSON solto).
+
+## Phase 4 — (DIFERIDO) índice DuckDB derivado — Status: deferred
+- [ ] 4.1 `tools/scripts/build_index.py` reconstrói índice do release. Nunca mestre. (DuckDB lê os releases no lugar — ver guia.)
+
+---
+
+## Decisions Log
+| Data | Decisão | Por quê |
+|------|---------|---------|
+| 2026-06-19 | SSOT = aparato crítico git-versionado | Dialética: convergência em snapshot congelado; proveniência-de-juízo nativa; git = log grátis |
+| 2026-06-19 | DB invertido para índice derivado (DuckDB) | Custo de mestre vivo > benefício |
+| 2026-06-19 | Reconciliação (Phase 0) bloqueia tudo | Sem estado conhecível não há o que congelar |


### PR DESCRIPTION
## O que é
Metodologia de dados do corpus (sub-projeto 1: fonte única da verdade), decidida via brainstorming + dialética (hegelian-dialectic) nesta sessão.

## Decisão
O corpus é um **artefato hermenêutico versionado** governado por **disciplina de aparato crítico**: a verdade canônica = sequência de **releases git congelados** (snapshot + aparato de codificação + dataset card). Git é o log de eventos. **DB = índice derivado opcional (DuckDB), nunca mestre** — invertendo a intuição inicial de SQLite event-sourced.

## Conteúdo
- `docs/decisions/2026-06-19-ssot-apparatus-critico-design.md` — design spec
- `docs/decisions/dialectic-ssot-2026-06-19/` — traço completo da dialética (briefing → monks → negação determinada → síntese)
- `docs/apparatus/GUIA-consulta-corpus.md` — guia de consulta DuckDB (validado ao vivo: gradiente de endurecimento por regime)
- `task_plan/findings/progress.md` — plano de implementação sequenciado
- **`CLAUDE.md`**: nova seção de ciência-dos-agentes com regras canônicas de dado (origin/main canônico; export derivado; não usar `--replace`; eixo `coded_by`) — previne erros reais cometidos nesta sessão

## Notas
- Base = `origin/main` (309), não o fork local stale (a reconciliação do fork é a Phase 0 do plano, pendente).
- Artefatos superseded (nframe-audit, quarantine reinventada) **não** incluídos — origin já tem o mecanismo real.
- Só docs/metodologia; nenhum dado canônico mutado.