### PR TITLE
docs: desambigua Iconclass 48C51 no CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ Active automation:
 | **Pathosformel**, **Zwischenraum**, **Nachleben** | Warburg — always in German |
 | **Mondzain** | Always 2002 edition |
 | **ABNT NBR 6023:2025** | Citation standard for all references |
-| **Iconclass 48C51** | Key code for feminist iconography |
+| **Iconclass 48C51** | Rótulo **interno do projeto** para a sub-rede de iconografia feminista (`extract_feminist_network.py` → `feminist_network_48C51_pt.json`). ⚠ **Não é o rótulo oficial.** No iconclass.org, `48C51` = *"painting (incl. book-illumination, miniature-painting)"*; os códigos oficiais do recorte jurídico são **44** (*state; law; political life*) e **11M44** (*Justitia*). No manuscrito, não afirmar "48C51 = iconografia feminista" como se fosse rótulo oficial do Iconclass — usar 44/11M44 para citações Iconclass. (verificado iconclass.org, 2026-06-26) |
 | **"ciberfeminismo"** | NEVER use in thesis text. Reservado para paper derivado pós-defesa. Operadores Haraway/Latour/Descola entram como matriz ferramental de Purificação Clássica, não como filiação a tradição |
 
 ---


### PR DESCRIPTION
## Desambiguação do código Iconclass 48C51

Corrige a nota do `CLAUDE.md` que afirmava "Iconclass 48C51 = key code for feminist iconography".

### Contexto
Investigando, `48C51` está embutido como **convenção interna** em todo o repo (script `extract_feminist_network.py` → `feminist_network_48C51_pt.json`, README, docs, itens do corpus). Por isso **não** foi feita uma "correção" destrutiva, e sim uma **nota de desambiguação** que:
- mantém `48C51` como rótulo interno do projeto (não quebra script/dataset/pipeline);
- registra que o rótulo **oficial** do Iconclass para `48C51` é *"painting (incl. book-illumination, miniature-painting)"* (verificado em iconclass.org);
- indica os códigos oficiais do recorte jurídico — **44** (*state; law; political life*) e **11M44** (*Justitia*) — para citações Iconclass no manuscrito.

### Não incluído (decisão da autora)
Uma eventual **refatoração ampla** (renomear 48C51→44/11M44 em script, dataset, docs e itens do corpus) ficou de fora por ser grande e mexer em código e dados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SyshkfP7XLUTszpgbeWLM

---
_Generated by [Claude Code](https://claude.ai/code/session_013SyshkfP7XLUTszpgbeWLM)_