### PR TITLE
chore(vercel): silencia preview deploy em branches claude/*

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,6 @@
   "framework": null,
   "buildCommand": null,
   "installCommand": null,
-  "outputDirectory": "corpus"
+  "outputDirectory": "corpus",
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in claude/*) exit 0 ;; *) exit 1 ;; esac"
 }


### PR DESCRIPTION
Adiciona `ignoreCommand` ao `vercel.json` que **cancela o build do Vercel em branches `claude/*`** (de agente), eliminando os previews/comentários irrelevantes nas PRs. O deploy de **produção** (`main` → `corpus/`) continua normal.

```json
"ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in claude/*) exit 0 ;; *) exit 1 ;; esac"
```

Obs.: passa a valer para branches `claude/*` criadas após o merge; PRs já abertas (ex.: #109) só param de comentar se rebaseadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SyshkfP7XLUTszpgbeWLM

---
_Generated by [Claude Code](https://claude.ai/code/session_013SyshkfP7XLUTszpgbeWLM)_