### PR TITLE
fix: clean up E1/E3 acquisition scripts (follow-up to #78 review)

### DIFF
--- a/tools/scripts/e1_pathosformel_batch.py
+++ b/tools/scripts/e1_pathosformel_batch.py
@@ -17,13 +17,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import time
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 REPO = Path(__file__).resolve().parent.parent.parent
 RECORDS_PATH = REPO / "data" / "processed" / "records.jsonl"
@@ -270,12 +268,29 @@ def code_item(record: dict, corpus_url_map: dict[str, dict]) -> dict | None:
 
 
 def write_output(results: list[dict], output_path: Path):
-    """Append results to pathosformel_index.jsonl."""
-    mode = "a" if output_path.exists() else "w"
-    with open(output_path, mode) as f:
-        for r in results:
-            f.write(json.dumps(r, ensure_ascii=False) + "\n")
-    print(f"\nWrote {len(results)} items to {output_path}")
+    """Merge results into pathosformel_index.jsonl, deduped by item_id.
+
+    Idempotent: re-running with the same results does not duplicate entries.
+    Existing items are preserved; matching item_ids are overwritten.
+    """
+    merged: dict[str, dict] = {}
+    if output_path.exists():
+        with open(output_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    item = json.loads(line)
+                    merged[item["item_id"]] = item
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    for r in results:
+        merged[r["item_id"]] = r
+    with open(output_path, "w") as f:
+        for item in merged.values():
+            f.write(json.dumps(item, ensure_ascii=False) + "\n")
+    print(f"\nWrote {len(results)} items to {output_path} ({len(merged)} total)")
 
 
 def list_uncoded(records: list[dict], corpus_url_map: dict[str, dict]):

--- a/tools/scripts/e1_recode_zeros.py
+++ b/tools/scripts/e1_recode_zeros.py
@@ -7,14 +7,12 @@ usando descrições enriquecidas das notas do vault (SCOUT-XXX) + thumbnails.
 from __future__ import annotations
 
 import json
-import os
 import re
 import sys
 import time
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 REPO = Path(__file__).resolve().parent.parent.parent
 RECORDS_PATH = REPO / "data" / "processed" / "records.jsonl"
@@ -273,10 +271,9 @@ def main():
             all_items[k] = v
         
         for u in updated:
-            uid = u["item_id"]
-            old_score = all_items.get(uid, {}).get("purificacao_composto", 0)
-            if old_score == 0.0 or True:  # replace all recoded
-                all_items[uid] = u
+            # `updated` only holds re-coded items (all started at score 0.0),
+            # so replacing them unconditionally is the intended behavior.
+            all_items[u["item_id"]] = u
         
         # Write
         with open(PATHOS_INDEX, "w") as f:

--- a/tools/scripts/e3_firecrawl_recode.py
+++ b/tools/scripts/e3_firecrawl_recode.py
@@ -10,7 +10,6 @@ Uso:
 from __future__ import annotations
 
 import json
-import os
 import re
 import subprocess
 import sys
@@ -18,7 +17,6 @@ import time
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 REPO = Path(__file__).resolve().parent.parent.parent
 RECORDS_PATH = REPO / "data" / "processed" / "records.jsonl"
@@ -61,7 +59,7 @@ def load_pathos() -> dict[str, dict]:
             try:
                 item = json.loads(l)
                 items[item["item_id"]] = item
-            except:
+            except (json.JSONDecodeError, KeyError):
                 pass
         return items
 
@@ -82,7 +80,10 @@ def firecrawl_extract(url: str, sigla: str) -> str | None:
             ["npx", "-y", "firecrawl-cli@latest", "scrape", url, "--format", "markdown"],
             capture_output=True, text=True, timeout=30
         )
-        text = (result.stdout or "") + (result.stderr or "")
+        if result.returncode != 0:
+            print(f"    FC exit {result.returncode}: {(result.stderr or '').strip()[:200]}", file=sys.stderr)
+            return None
+        text = result.stdout or ""
         # Clean up
         text = re.sub(r'\s+', ' ', text).strip()
         if len(text) > 50:


### PR DESCRIPTION
## Summary

Resolves the non-blocking quality follow-up flagged in PR #77 (from the Copilot review of the merged #78). Behavior-preserving cleanup of three acquisition/recoding scripts in `tools/scripts/`. No corpus data is touched, so the `validate` consistency gate is unaffected.

## Surface

- [ ] Corpus/data
- [x] Coding/analysis
- [ ] Writing/docs
- [ ] Infra/publishing

## Checks

- [ ] `python tools/scripts/validate_schemas.py data/processed/records.jsonl --schema master-record --verbose` — N/A (no data files changed)
- [ ] `python tools/scripts/code_purification.py --status` if coding-related — N/A (no coding ledger changed)
- [ ] `python tools/scripts/vault_sync.py status` or `diff` if vault-facing — N/A (not vault-facing)
- [x] `python -m py_compile` on all three scripts → OK
- [x] `ruff check` on the three scripts → all 7 targeted defects gone (remaining warnings are pre-existing style noise, left out of scope)
- [x] Smoke: `e1_pathosformel_batch.py --list` runs (read-only path)

## Changes

- **`e1_recode_zeros.py`** — drop the dead `if old_score == 0.0 or True` branch (always true; `updated` only holds re-coded zero-score items, so the unconditional replace it already performed is the intended behavior); remove unused `os` / `typing.Any` imports.
- **`e3_firecrawl_recode.py`** — stop treating subprocess `stderr` as scraped content: check `returncode`, use `stdout` only, log stderr to the error stream and return `None` on failure; narrow the bare `except:` in `load_pathos()` to `(json.JSONDecodeError, KeyError)`; remove unused `os` / `typing.Any` imports.
- **`e1_pathosformel_batch.py`** — make `write_output()` idempotent: merge into `pathosformel_index.jsonl` deduped by `item_id` instead of blind append (blind append duplicated `item_id`s on re-runs); remove unused `os` / `typing.Any` imports.

## Notes

- No corpus/data files changed; the records↔corpus consistency gate is not exercised by this PR.
- The E1 recode / E3 firecrawl main paths require Ollama + `npx` (network) and were verified by inspection; only the read-only `--list` path was run.
- `ruff` reports pre-existing `W293` / `E741` / `F541` style warnings across these files — intentionally left untouched to keep this diff scoped to the reviewed defects.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UoWXzBYsqPYubgWz6ujRk8)_