### PR TITLE
fix(hooks): install ruff + pytest in SessionStart hook for web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -10,10 +10,17 @@ DIR="$CLAUDE_PROJECT_DIR"
 
 echo "=== Iconocracy Corpus — Environment Check ==="
 
-# 1. Python dependencies
-echo "[1/5] Installing Python dependencies..."
-pip install -q -r "$DIR/requirements.txt"
-pip install -q pylint pytest
+# 1. Python dependencies + test/lint tooling
+# Remote sessions have no conda env; install into the base interpreter via pip.
+# Idempotent: pip skips already-satisfied requirements. `ruff` is the configured
+# linter (pyproject.toml [tool.ruff]) invoked by the PostToolUse hooks; `pytest`
+# runs the suite in tests/. `pylint` kept for existing tooling.
+echo "[1/5] Installing Python dependencies (requirements + pylint + ruff + pytest)..."
+PIP_INSTALL=(python -m pip install -q -r "$DIR/requirements.txt" pylint ruff pytest)
+if ! "${PIP_INSTALL[@]}" 2>/dev/null; then
+  # Fallback for images that enforce PEP 668 (externally-managed-environment).
+  "${PIP_INSTALL[@]}" --break-system-packages
+fi
 
 # 2. Verify required directories exist
 echo "[2/5] Checking directory structure..."
@@ -62,14 +69,16 @@ for f in "${KEY_FILES[@]}"; do
   fi
 done
 
-# 4. Validate corpus JSON
-echo "[4/5] Validating corpus data..."
+# 4. Validate corpus JSON + confirm test/lint tooling is runnable
+echo "[4/5] Validating corpus data and tooling..."
 if python -c "import json; json.load(open('$DIR/corpus/corpus-data.json'))" 2>/dev/null; then
   ITEMS=$(python -c "import json; print(len(json.load(open('$DIR/corpus/corpus-data.json'))))")
   echo "  corpus-data.json: $ITEMS items, valid JSON."
 else
   echo "  WARNING: corpus-data.json is invalid or missing."
 fi
+echo "  ruff:   $(ruff --version 2>&1 | head -1 || echo 'NOT FOUND')"
+echo "  pytest: $(python -m pytest --version 2>&1 | head -1 || echo 'NOT FOUND')"
 
 # 5. Check external tools
 echo "[5/5] Checking external tools..."


### PR DESCRIPTION
## Summary

The remote (Claude Code on the web) `SessionStart` hook (`.claude/hooks/session-start.sh`) installed `pylint`/`pytest`, but the repo's configured linter is **`ruff`** (`pyproject.toml [tool.ruff]`), which the `PostToolUse` hooks invoke via `ruff check`. Remote sessions have no conda env, so `ruff` was never installed and lint-on-edit silently no-op'd. This makes the hook install the tooling that tests and linters actually need.

## Surface

- [ ] Corpus/data
- [ ] Coding/analysis
- [ ] Writing/docs
- [x] Infra/publishing (dev tooling: SessionStart hook)

## Checks

- [ ] `validate_schemas.py` — n/a (no records/corpus change)
- [ ] `code_purification.py --status` — n/a
- [ ] `vault_sync.py status` — n/a
- [x] No effect on GitHub Pages / Hugging Face

## Changes

- Install `requirements.txt` + `pylint` + **`ruff`** + `pytest` via `python -m pip` (base interpreter; more robust than bare `pip`).
- Add a **PEP 668** (`--break-system-packages`) fallback for images that enforce externally-managed environments.
- Report `ruff`/`pytest` versions in the environment check so a broken toolchain is visible at session start.

## Validation (ran with `CLAUDE_CODE_REMOTE=true`)

1. ✅ **Hook execution** — exits 0; deps install; corpus validates (328 items).
2. ✅ **Linter** — `ruff check tools/scripts/validate_schemas.py` runs (flags 5 pre-existing style findings; linter works as intended, not a setup failure).
3. ✅ **Test** — `pytest tests/test_corpus_export_idempotent.py` → 7 passed.
4. ✅ Tooling confirmed runnable: `pylint 4.0.6`, `ruff 0.15.8`, `pytest 9.1.1`.

## Notes

- Rebased onto current `main`, so this PR is a single-file diff (the article from #111 is already merged).
- Out of scope (flagged, not changed): several `PostToolUse` hooks call `conda run -n iconocracy …`, but remote sessions have no conda env, so those steps won't run remotely; and `shellcheck` (used by one hook) is not installed in remote images. Worth a follow-up if remote parity matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcA7LFwqxQtBKtLQbVrtjD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcA7LFwqxQtBKtLQbVrtjD)_