### PR TITLE
fix(hooks): session-start não instala mais o stack ML; adiciona ruff e cffi

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -10,10 +10,20 @@ DIR="$CLAUDE_PROJECT_DIR"
 
 echo "=== Iconocracy Corpus — Environment Check ==="
 
-# 1. Python dependencies
-echo "[1/5] Installing Python dependencies..."
-pip install -q -r "$DIR/requirements.txt"
-pip install -q pylint pytest
+# 1. Python dependencies (core only)
+# requirements.txt inclui o stack de treino ML (torch/transformers/peft/trl/
+# datasets, ~GBs) que nenhum teste ou validador importa — só
+# tools/scripts/{train_iconocracy_sft,run_iconocracy_eval}.py. Instalar isso
+# sincronamente estourava o startup e o `set -e` matava o hook antes do
+# pytest/pydantic, deixando a sessão sem deps. Filtramos o bloco pesado;
+# quem for treinar instala à parte: pip install -r requirements.txt
+echo "[1/5] Installing core Python dependencies (ML training stack skipped)..."
+grep -vE '^(torch|transformers|peft|trl|datasets)[><=]' "$DIR/requirements.txt" \
+  | pip install -q -r /dev/stdin
+pip install -q ruff  # linter configurado em pyproject.toml [tool.ruff]
+# cffi: a cryptography do sistema (/usr/lib) exige _cffi_backend; sem ele,
+# qualquer import via google-genai -> google.auth explode com panic do pyo3.
+pip install -q cffi
 
 # 2. Verify required directories exist
 echo "[2/5] Checking directory structure..."


### PR DESCRIPTION
## O problema

O SessionStart hook fazia `pip install -r requirements.txt` **completo** — puxando torch/transformers/peft/trl/datasets (~GBs) sincronamente. O hook estourava o startup e, com `set -e`, **morria antes de instalar pytest/pydantic**, deixando sessões web sem dependências (sintoma real observado: sessão iniciada sem `pytest` nem `pydantic`).

## O conserto (só o passo 1 do hook; passos 2–5 estavam saudáveis)

1. **Filtra o bloco de treino ML** do install — nenhum teste ou validador o importa (verificado: só `tools/scripts/{train_iconocracy_sft,run_iconocracy_eval}.py`); quem for treinar instala `requirements.txt` à parte
2. **Troca `pylint` (não usado) por `ruff`** — o linter que o `pyproject.toml` realmente configura
3. **Adiciona `cffi`** — a `cryptography` do sistema exige `_cffi_backend`; sem ele, imports via `google-genai → google.auth` quebram com panic do pyo3 (`test_run_irr_pilot` nem coletava)

## Validação

| Check | Resultado |
|---|---|
| Hook (1.ª rodada) | ✅ exit 0 em **20s** (antes: minutos/timeout) |
| Hook (idempotente) | ✅ exit 0 em **2.7s** |
| `ruff check` (1 arquivo) | ✅ executa (apontamentos restantes = estilo pré-existente na `main`) |
| `pytest tests/` **completo** | ✅ **181 passed, 0 failed** — incluindo `test_run_irr_pilot` e `test_ingest_fichas_lpai`, que antes nem coletavam |

Modo de execução: **síncrono** (garante deps prontas antes de a sessão começar; custo = startup espera os ~20s da primeira rodada). Dá para mudar a async se preferir startup mais rápido. Depois do merge na `main`, toda sessão web futura usa o hook consertado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5tquq1U7L8HPD1PUFr74J

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5tquq1U7L8HPD1PUFr74J)_