### PR TITLE
feat(coding): --draft-file na sessão interativa + workflow drafts→formal

### DIFF
--- a/docs/workflows/iconocode-drafts-to-formal.md
+++ b/docs/workflows/iconocode-drafts-to-formal.md
@@ -1,0 +1,63 @@
+# Workflow — Drafts IconoCode → Codificação Formal
+
+Como as análises visuais de IA (skill `iconocode-analyze`) alimentam a
+codificação formal manual sem contaminá-la. Formaliza o fluxo usado desde
+2026-07-02 (PRs #126/#128).
+
+## Princípios
+
+1. **Draft nunca vira codificação formal automaticamente.** O ledger
+   `data/processed/purification.jsonl` só recebe entradas da sessão
+   interativa (`code_purification.py`) ou de scripts auditados — `coded_by`
+   registra quem decidiu.
+2. **Só codificar o que se vê.** Drafts sem imagem acessível levam
+   `#análise-textual` e `confidence_score` baixo; não promover à codificação
+   formal antes de obter a imagem (norma estabelecida no PR #123).
+3. **Draft é sugestão exibida, não default pré-preenchido.** Na sessão
+   interativa a coder digita cada escore; a sugestão IA aparece ao lado,
+   nunca é aceita por Enter.
+
+## Fluxo
+
+```
+imagem/URL → skill iconocode-analyze (visão real)
+        ↓
+data/interim/iconocode-drafts/<lote>.json   ← 1 JSON por lote, commitado via PR
+        ↓
+python tools/scripts/code_purification.py --draft-file <lote>.json --item <chave>
+        ↓  (Ana vê "draft IA sugere: N" por indicador e decide o dela)
+data/processed/purification.jsonl           ← coded_by = humano
+```
+
+## Formato do arquivo de drafts
+
+`{"drafts": [...]}` ou lista plana. Cada draft segue o schema do skill
+`iconocode-analyze`: `id`, `draft_status`, `panofsky` (3 níveis),
+`purificacao` (10 indicadores int 0–3, `purificacao_composto`,
+`regime_iconocratico` minúsculo), `analyst_notes`, `coded_by`,
+`confidence_score`. Exemplo real:
+`data/interim/iconocode-drafts/iconocode-drafts-PR122-PR123-2026-07-02.json`.
+
+## Resolução de identidade
+
+`--item` e o casamento draft↔item aceitam **qualquer** chave — handle
+XX-NNN, slug descritivo, SCOUT-NNN ou UUID — resolvidos via
+`data/processed/id_crosswalk.jsonl` (`tools/scripts/id_crosswalk.py`).
+Não há regime único de ID: handles são estáveis, nunca renomeados; UUID é a
+chave de máquina (decisão de council, 2026-07-02, PR #128).
+
+## Vault
+
+Item com nota em `vault/candidatos/`: anexar a análise sob a seção
+`## IconoCode Analysis (draft)` preservando o conteúdo existente (regra do
+skill `iconocode-analyze`). Itens sem nota: o JSON do lote basta; criar nota
+é opcional.
+
+## Auditoria de drafts IA anteriores
+
+Segunda passada independente (outro modelo/sessão) sobre codificações
+`coded_by: iconocode-*` pendentes: gerar novo draft, comparar indicador a
+indicador e registrar divergências no JSON (`audit_vs_*`). Divergência
+documentada vale mais que concordância silenciosa — ver
+`iconocode-drafts-PR122-PR123-2026-07-02.json` (auditoria dos itens
+`iconocode-sonnet5` do PR #123).

--- a/tests/test_draft_flow.py
+++ b/tests/test_draft_flow.py
@@ -1,0 +1,62 @@
+"""Tests for --draft-file support in code_purification.py."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(script_name):
+    path = REPO_ROOT / "tools" / "scripts" / f"{script_name}.py"
+    spec = importlib.util.spec_from_file_location(script_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[script_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cp = _load("code_purification")
+xw = _load("id_crosswalk")
+
+
+@pytest.mark.unit
+def test_load_drafts_accepts_wrapped_and_plain(tmp_path):
+    # Arrange
+    wrapped = tmp_path / "wrapped.json"
+    wrapped.write_text(json.dumps({"drafts": [{"id": "A"}, {"id": "B"}]}), encoding="utf-8")
+    plain = tmp_path / "plain.json"
+    plain.write_text(json.dumps([{"id": "C"}, {"no_id": True}]), encoding="utf-8")
+
+    # Act / Assert
+    assert [d["id"] for d in cp.load_drafts(wrapped)] == ["A", "B"]
+    assert [d["id"] for d in cp.load_drafts(plain)] == ["C"]  # entries without id dropped
+
+
+@pytest.mark.unit
+def test_match_draft_exact_id():
+    drafts = [{"id": "BR-001", "purificacao": {"desincorporacao": 2}}]
+    item = {"id": "BR-001"}
+    assert cp.match_draft(drafts, item) is drafts[0]
+
+
+@pytest.mark.unit
+def test_match_draft_via_crosswalk(tmp_path, monkeypatch):
+    # Arrange: crosswalk maps handle SQ-XYZ (assigned) to the uuid derived from BR-009
+    item = {"id": "BR-009"}
+    item_uuid = xw.derive_uuid("BR-009")
+    crosswalk = tmp_path / "id_crosswalk.jsonl"
+    crosswalk.write_text(json.dumps(
+        {"handle": "SQ-XYZ", "uuid": item_uuid, "class": "assigned"}) + "\n",
+        encoding="utf-8")
+    monkeypatch.setattr(xw, "CROSSWALK_JSONL", crosswalk)
+
+    # Act: draft identified by the alias, item by its handle
+    draft = {"id": "SQ-XYZ", "purificacao": {}}
+    assert cp.match_draft([draft], item) is draft
+
+    # Assert: unknown key does not match
+    assert cp.match_draft([{"id": "NAO-EXISTE"}], item) is None

--- a/tools/scripts/code_purification.py
+++ b/tools/scripts/code_purification.py
@@ -179,11 +179,53 @@ def display_item(item):
     print("=" * 70)
 
 
-def prompt_indicator(name, label, scale):
+def load_drafts(path):
+    """Load IconoCode draft analyses ({"drafts": [...]} or plain list)."""
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    drafts = data.get("drafts", data) if isinstance(data, dict) else data
+    return [d for d in drafts if isinstance(d, dict) and d.get("id")]
+
+
+def match_draft(drafts, item):
+    """Find the draft for an item — by exact id, or via the id crosswalk."""
+    for draft in drafts:
+        if str(draft["id"]) == item["id"]:
+            return draft
+    try:
+        from id_crosswalk import derive_uuid, is_uuid, resolve_key
+    except ImportError:
+        return None
+    item_uuid = item["id"] if is_uuid(item["id"]) else derive_uuid(item["id"])
+    for draft in drafts:
+        target, entries = resolve_key(str(draft["id"]))
+        if target == item_uuid or any(e["handle"] == item["id"] for e in entries):
+            return draft
+    return None
+
+
+def display_draft(draft):
+    """Show an IconoCode draft alongside the item — suggestion, never decision."""
+    pur = draft.get("purificacao") or {}
+    print(f"\n  ── Draft IA ({draft.get('coded_by', 'draft')}, "
+          f"confiança {draft.get('confidence_score', '?')}) — sugestão, não decisão ──")
+    if not pur:
+        print("    (draft sem bloco purificacao — ver analyst_notes)")
+    else:
+        print(f"    composto={pur.get('purificacao_composto', '?')}  "
+              f"regime={pur.get('regime_iconocratico', '?')}")
+    notes = draft.get("analyst_notes")
+    if notes:
+        print(f"    notas: {notes[:300]}{'…' if len(notes) > 300 else ''}")
+
+
+def prompt_indicator(name, label, scale, draft_score=None):
     """Prompt for a single indicator. Returns int 0-3 or None to skip."""
     print(f"\n  [{name}] {label}")
     for line in scale:
         print(f"    {line}")
+    if draft_score is not None:
+        print(f"    (draft IA sugere: {draft_score})")
     while True:
         val = input("  → Score (0-3), 's' to skip item, 'q' to quit: ").strip().lower()
         if val == "q":
@@ -212,13 +254,17 @@ def prompt_regime():
         print(f"    ⚠ Enter 1-{len(REGIMES)}")
 
 
-def code_item(item, coder="ana"):
+def code_item(item, coder="ana", draft=None):
     """Interactive coding session for one item. Returns record dict or None."""
     display_item(item)
+    if draft:
+        display_draft(draft)
+    draft_scores = (draft or {}).get("purificacao") or {}
 
     scores = {}
     for name, label, scale in INDICATORS:
-        result = prompt_indicator(name, label, scale)
+        result = prompt_indicator(name, label, scale,
+                                  draft_score=draft_scores.get(name))
         if result == "quit":
             return "quit"
         if result == "skip":
@@ -425,6 +471,9 @@ def main():
                         help="Export merged corpus + purification to CSV")
     parser.add_argument("--coder", default="ana",
                         help="Coder name for audit trail (default: ana)")
+    parser.add_argument("--draft-file", metavar="JSON",
+                        help="IconoCode drafts JSON (data/interim/iconocode-drafts/) "
+                             "— mostra sugestões IA ao lado de cada indicador")
     parser.add_argument("--select-sample", type=int, metavar="N",
                         help="Generate stratified random sample of N items for double-coding")
     args = parser.parse_args()
@@ -469,10 +518,13 @@ def main():
     print(f"\n  📋 {len(queue)} items to code ({len(coded)} already done)")
     print("  Commands during coding: 0-3 = score, s = skip item, q = quit\n")
 
+    drafts = load_drafts(args.draft_file) if args.draft_file else []
+
     coded_this_session = 0
     for i, item in enumerate(queue):
         print(f"\n  [{i + 1}/{len(queue)}]", end="")
-        result = code_item(item, coder=args.coder)
+        draft = match_draft(drafts, item) if drafts else None
+        result = code_item(item, coder=args.coder, draft=draft)
         if result == "quit":
             print(f"\n  👋 Quitting. Coded {coded_this_session} items this session.")
             break


### PR DESCRIPTION
Fecha o ciclo drafts IA → codificação formal:

- `code_purification.py --draft-file <lote>.json` exibe a sugestão IA por indicador (`draft IA sugere: N`) durante a sessão interativa — sugestão exibida, nunca default; `coded_by` continua humano. Casamento draft↔item via id exato ou crosswalk (PR #128).
- `docs/workflows/iconocode-drafts-to-formal.md` formaliza o fluxo (nunca auto-promover; só codificar o que se vê; auditoria por 2ª passada).
- 3 testes novos; suite 189/189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QSuraJcrZkw8YG4g7GEdd