### PR TITLE
fix(hooks): skip ML stack during SessionStart

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -10,13 +10,18 @@ DIR="$CLAUDE_PROJECT_DIR"
 
 echo "=== Iconocracy Corpus — Environment Check ==="
 
-# 1. Python dependencies + test/lint tooling
+# 1. Python dependencies (core only) + test/lint tooling
 # Remote sessions have no conda env; install into the base interpreter via pip.
-# Idempotent: pip skips already-satisfied requirements. `ruff` is the configured
-# linter (pyproject.toml [tool.ruff]) invoked by the PostToolUse hooks; `pytest`
-# runs the suite in tests/. `pylint` kept for existing tooling.
-echo "[1/5] Installing Python dependencies (requirements + pylint + ruff + pytest)..."
-PIP_INSTALL=(python -m pip install -q -r "$DIR/requirements.txt" pylint ruff pytest)
+# Idempotent: pip skips already-satisfied requirements. requirements.txt also
+# includes the ML training stack (torch/transformers/peft/trl/datasets), which
+# is only needed by tools/scripts/{train_iconocracy_sft,run_iconocracy_eval}.py
+# and is too heavy for synchronous SessionStart setup.
+echo "[1/5] Installing core Python dependencies (ML training stack skipped; pylint + ruff + pytest + cffi included)..."
+CORE_REQUIREMENTS="$(mktemp)"
+trap 'rm -f "$CORE_REQUIREMENTS"' EXIT
+ML_REQUIREMENT_RE='^[[:space:]]*(torch|transformers|peft|trl|datasets)([[:space:]]*(=|<|>|!|~)|[[:space:]]*$)'
+grep -vE "$ML_REQUIREMENT_RE" "$DIR/requirements.txt" > "$CORE_REQUIREMENTS"
+PIP_INSTALL=(python -m pip install -q -r "$CORE_REQUIREMENTS" pylint ruff pytest cffi)
 if ! "${PIP_INSTALL[@]}" 2>/dev/null; then
   # Fallback for images that enforce PEP 668 (externally-managed-environment).
   "${PIP_INSTALL[@]}" --break-system-packages


### PR DESCRIPTION
## Summary
- Reapplies the hook fix from PR #125 on top of the current `origin/main` (`a82198a`), without carrying the older branch history/noise.
- Keeps the newer SessionStart structure from `main`, including `python -m pip` and the PEP 668 fallback.
- Filters `torch`, `transformers`, `peft`, `trl`, and `datasets` out of synchronous SessionStart dependency install, while keeping core requirements and explicit `pylint`, `ruff`, `pytest`, and `cffi`.

## Validation
- `bash -n .claude/hooks/session-start.sh`
- simulated `CLAUDE_CODE_REMOTE=true` SessionStart with fake `python -m pip`: `ML_LINES_AFTER_FILTER=0`, `pytest`/`pydantic` preserved, `cffi` and `ruff` present in install args
- `/Users/ana/.venvs/iconocracy/bin/python3.12 -c "import cffi, pydantic, pytest"`
- `/Users/ana/.venvs/iconocracy/bin/python3.12 tools/scripts/validate_schemas.py` -> `328/328 records valid`
- `/Users/ana/.venvs/iconocracy/bin/python3.12 -m pytest tests/test_validate_schemas.py tests/test_run_irr_pilot.py -q` -> `8 passed`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-environment hook only; no runtime auth, data, or production path changes.
> 
> **Overview**
> Remote **SessionStart** no longer runs `pip install` against the full `requirements.txt`. It builds a filtered temp requirements file that **excludes** `torch`, `transformers`, `peft`, `trl`, and `datasets`, then installs that core set plus **`pylint`**, **`ruff`**, **`pytest`**, and **`cffi`** (with the existing PEP 668 fallback unchanged).
> 
> The hook messaging and comments now state that the ML stack is deferred because it is only needed by training/eval scripts and is too heavy for synchronous session setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df23281f1bbdfd140b22787fc022569a5ad37b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->