### PR TITLE
feat: hookify warn on version-pinned python paths

### DIFF
--- a/.claude/hookify.python-path.local.md
+++ b/.claude/hookify.python-path.local.md
@@ -1,0 +1,8 @@
+---
+name: python-path-version-agnostic
+enabled: true
+event: bash
+pattern: '(^|\s|/)python3\.\d{1,2}(\s|$)'
+action: warn
+---
+Version-pinned Python path detected. Use `/opt/homebrew/Caskroom/miniforge/base/envs/iconocracy/bin/python` (version-agnostic) instead — pin-paths break on version bumps.


### PR DESCRIPTION
## What

Adds a repo-scoped hookify rule (`.claude/hookify.python-path.local.md`) that emits a **warn** (non-blocking) when a Bash command *invokes* a version-pinned Python interpreter — `python3.11`, `python3.12`, etc. — instead of the version-agnostic conda env path `/opt/homebrew/Caskroom/miniforge/base/envs/iconocracy/bin/python`.

## Why

Version-pinned interpreter paths silently break on the next conda env rebuild — this already happened once (3.12→3.11 on 2026-06-22). CLAUDE.md documents the convention in prose; this makes it self-enforcing at the moment a command runs. Warn, not block, because pinned invocations are occasionally legitimate during an actual env rebuild.

## Pattern design

`(^|\s|/)python3\.\d{1,2}(\s|$)` — anchored to interpreter-invocation position (token boundary before, whitespace/end after). This deliberately avoids false positives on benign path *references* like `lib/python3.11/site-packages`, which are routine in a python3.11 conda env and would otherwise dilute the signal. Version-number-agnostic (`\d{1,2}`) so it survives future Python bumps without edits.

## Verification

Behavior confirmed end-to-end through hookify's actual parser + rule engine:
- `python3.12 x.py` → **warns** ✓
- `/usr/bin/python3.11` → **warns** ✓
- `cat lib/python3.11/os.py` (path ref) → silent ✓
- `export PYTHONPATH=$CONDA_PREFIX/lib/python3.11/...` → silent ✓
- version-agnostic conda path → silent ✓
- bare `python3 x.py` (no version) → silent ✓

Single new file, +8 lines. No code paths touched; existing pytest suite (189 passing) unaffected.