### PR TITLE
docs: iconometria como framework guarda-chuva (endurecimento = eixo de fixidez)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@ Every corpus item must exist in three places: (1) Google Drive + `data/raw/drive
 
 ## Canonical Terminology
 
-- **endurecimento** — NEVER "hardening" / "embrutecimento"
+- **iconometria** — framework guarda-chuva (medição/análise de padrões iconográficos); `iconometria ⊇ endurecimento` (decisão 2026-07-11)
+- **endurecimento** — eixo de fixidez dentro da iconometria; NEVER "hardening" / "embrutecimento"; campo de dados canônico `endurecimento_score` (chave estável)
 - **Contrato Sexual Visual**, **Feminilidade de Estado**, **Contrato Racial Visual**, **Purificação Clássica** — original thesis concepts (Vanzin 2026)
 - **Pathosformel**, **Zwischenraum**, **Nachleben** — always in German (Warburg)
 - Citations: ABNT NBR 6023:2025; Mondzain = 2002 edition

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ WebScout (archive discovery) → IconoCode (visual analysis) → master records
 ```
 
 - **WebScout** queries digital archives (Europeana, Gallica, LOC, BnF, Numista, Colnect)
-- **IconoCode** performs 3-level Panofsky analysis + 10 endurecimento indicators (0–3 scale)
+- **IconoCode** performs 3-level Panofsky analysis + iconometria measurement (endurecimento = fixity axis, 10 indicators 0–3 scale)
 - Output: `data/processed/records.jsonl` (canonical) → `corpus/corpus-data.json` (public export)
 
 ### Canonical Data Hierarchy (source-of-truth order)
@@ -112,7 +112,8 @@ Active automation:
 
 | Term | Reference note |
 |------|------|
-| **Endurecimento** | Always in Portuguese. NEVER "hardening" or "embrutecimento". Empirical operationalization of **Purificação Clássica** via 10 ordinal indicators (0–3) |
+| **Iconometria** | Framework metodológico **guarda-chuva** (decisão 2026-07-11): medição e análise de padrões iconográficos no corpus. **Contém** endurecimento como eixo de fixidez (`iconometria ⊇ endurecimento`). Ver `concepts/iconometria.md` + `docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md` |
+| **Endurecimento** | Always in Portuguese. NEVER "hardening" or "embrutecimento". **Eixo de fixidez dentro da iconometria** — operacionalização empírica da **Purificação Clássica** via 10 ordinal indicators (0–3). Campo de dados canônico permanece `endurecimento_score` (chave estável; não renomear sem migração coordenada) |
 | **Contrato Sexual Visual** | Original thesis concept #1 — do NOT attribute to Pateman (Pateman is the source of the non-visual contract; the visual extension is autoral) |
 | **Feminilidade de Estado** | Original thesis concept #2 — do NOT attribute to Mondzain. Genealogical roots: Legendre (juiz totêmico) + Carson (hystéra) |
 | **Contrato Racial Visual** | Original thesis concept #3 — branquitude constitutiva da alegoria "universal"; transferência transatlântica de modelos neoclássicos. Cap. 3 |

--- a/atlas/stubs/conceito/iconometria.md
+++ b/atlas/stubs/conceito/iconometria.md
@@ -22,7 +22,7 @@ updated: 2026-07-11
 > Resumo-âncora de [`concepts/iconometria.md`](../../../concepts/iconometria.md). **Edite a fonte**, não
 > este stub — ele é regenerado por `atlas/_generate_stubs.py`.
 
-da cultura jurídica (séc. XIX–XX). É uma abordagem quantitativa da imagem —
+A iconometria é o framework metodológico guarda-chuva da tese ICONOCRACIA: a medição e análise de padrões iconográficos num corpus de alegorias femininas da cultura jurídica (séc. XIX–XX) — uma abordagem quantitativa da imagem, articulada à
 
 - **Fonte:** [`concepts/iconometria.md`](../../../concepts/iconometria.md)
 - **MOC:** [[Conceitos — MOC]]

--- a/atlas/stubs/conceito/iconometria.md
+++ b/atlas/stubs/conceito/iconometria.md
@@ -12,8 +12,8 @@ related:
   - "[[Conceitos — MOC]]"
 sources:
   - ../../../concepts/iconometria.md
-created: 2026-06-22
-updated: 2026-06-22
+created: 2026-07-11
+updated: 2026-07-11
 ---
 
 # Iconometria
@@ -22,7 +22,7 @@ updated: 2026-06-22
 > Resumo-âncora de [`concepts/iconometria.md`](../../../concepts/iconometria.md). **Edite a fonte**, não
 > este stub — ele é regenerado por `atlas/_generate_stubs.py`.
 
-A quantitative approach to the analysis of images, focusing on measurable aspects and patterns within a corpus of visual data. In the context of Iconocracia, it involves the systematic counting and analysis of iconographic elements to ident
+da cultura jurídica (séc. XIX–XX). É uma abordagem quantitativa da imagem —
 
 - **Fonte:** [`concepts/iconometria.md`](../../../concepts/iconometria.md)
 - **MOC:** [[Conceitos — MOC]]

--- a/atlas/stubs/decisao/ICONOMETRIA-TRANSITION-2026-07-11.md
+++ b/atlas/stubs/decisao/ICONOMETRIA-TRANSITION-2026-07-11.md
@@ -1,0 +1,29 @@
+---
+title: "Decisão — Transição conceitual: *endurecimento* → *iconometria*"
+type: kg/stub
+generated: true
+generator: atlas/_generate_stubs.py
+tags:
+  - kg
+  - kg/stub
+  - kg/decisao
+  - projeto/iconocracia
+related:
+  - "[[ADRs e Decisões — MOC]]"
+sources:
+  - ../../../docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md
+created: 2026-07-11
+updated: 2026-07-11
+---
+
+# Decisão — Transição conceitual: *endurecimento* → *iconometria*
+
+> [!info] Nó-stub gerado automaticamente
+> Resumo-âncora de [`docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md`](../../../docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md). **Edite a fonte**, não
+> este stub — ele é regenerado por `atlas/_generate_stubs.py`.
+
+Até aqui, **endurecimento** era o eixo empírico central da metodologia: a *operacionalização da Purificação Clássica* por meio de **10 indicadores ordinais (0–3)**, com o objetivo de **quantificar a fixidez** de uma alegoria feminina (o gra
+
+- **Fonte:** [`docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md`](../../../docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md)
+- **MOC:** [[ADRs e Decisões — MOC]]
+- **Categoria:** `decisao`

--- a/concepts/iconometria.md
+++ b/concepts/iconometria.md
@@ -10,12 +10,9 @@ decision: docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md
 
 # Iconometria
 
-**Iconometria** é o framework metodológico guarda-chuva da tese ICONOCRACIA: a
-**medição e análise de padrões iconográficos** num corpus de alegorias femininas
-da cultura jurídica (séc. XIX–XX). É uma abordagem quantitativa da imagem —
-contagem e análise sistemática de elementos iconográficos para identificar
-tendências, agrupamentos e significância estatística —, articulada à leitura
-qualitativa (Panofsky, Warburg) e à genealogia jurídica.
+A iconometria é o framework metodológico guarda-chuva da tese ICONOCRACIA: a medição e análise de padrões iconográficos num corpus de alegorias femininas da cultura jurídica (séc. XIX–XX) — uma abordagem quantitativa da imagem, articulada à leitura qualitativa (Panofsky, Warburg) e à genealogia jurídica.
+
+Concretamente, envolve a **contagem e análise sistemática de elementos iconográficos** para identificar tendências, agrupamentos e significância estatística, sob um mesmo aparato de medição.
 
 ## Relação com endurecimento
 

--- a/concepts/iconometria.md
+++ b/concepts/iconometria.md
@@ -1,19 +1,49 @@
 ---
 title: Iconometria
 created: 2024-05-15
-updated: 2024-05-15
+updated: 2026-07-11
 type: concept
 tags: [methodology, quantitative-analysis, iconography, data-analysis]
 sources: [raw/articles/iconocracia-companion-web.md]
+decision: docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md
 ---
 
 # Iconometria
 
-A quantitative approach to the analysis of images, focusing on measurable aspects and patterns within a corpus of visual data. In the context of Iconocracia, it involves the systematic counting and analysis of iconographic elements to identify trends and statistical significance.
+**Iconometria** é o framework metodológico guarda-chuva da tese ICONOCRACIA: a
+**medição e análise de padrões iconográficos** num corpus de alegorias femininas
+da cultura jurídica (séc. XIX–XX). É uma abordagem quantitativa da imagem —
+contagem e análise sistemática de elementos iconográficos para identificar
+tendências, agrupamentos e significância estatística —, articulada à leitura
+qualitativa (Panofsky, Warburg) e à genealogia jurídica.
 
-## Related Concepts
+## Relação com endurecimento
+
+A iconometria **contém** o endurecimento como **um de seus eixos**, não o
+substitui:
+
+> **iconometria ⊇ endurecimento.** A iconometria é o *método de medição*; o
+> endurecimento é *o que se mede no eixo da fixidez alegórica*.
+
+- **Endurecimento** — eixo de **fixidez/purificação**: operacionalização empírica
+  da **Purificação Clássica** (conceito autoral #4) por meio de **10 indicadores
+  ordinais (0–3)**: desincorporação · rigidez_postural · dessexualização ·
+  uniformização_facial · heraldicização · enquadramento_arquitetônico ·
+  apagamento_narrativo · monocromatização · serialidade · inscrição_estatal.
+- A iconometria abre espaço para outros vetores mensuráveis sob o mesmo aparato
+  (p.ex. seriação, vetor colonial, densidade narrativa), sem que cada um colapse
+  no escore único de fixidez.
+
+> [!note] Estabilidade de dados
+> O campo canônico permanece **`endurecimento_score`** (`records.jsonl`,
+> `purification.jsonl`, `corpus-data.json`, CSV, schemas). A promoção de
+> "iconometria" a guarda-chuva é conceitual; **não** renomeia a chave de dados.
+> Ver plano faseado em [`docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md`](../docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md).
+
+## Conceitos relacionados
 
 - [[Iconocracia]]
+- [[Purificação Clássica]] — matriz teórica do eixo endurecimento
 - [[Methodology]]
 - [[Quantitative Analysis]]
 - [[Corpus]]

--- a/docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md
+++ b/docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md
@@ -35,7 +35,12 @@ Arquivos alterados **apenas na definição/documentação**:
 3. `CLAUDE.md` — entrada de terminologia + nota de arquitetura
 4. `AGENTS.md` — terminologia canônica + rótulo de codificação
 
-> O stub `atlas/stubs/conceito/iconometria.md` é **gerado** por `atlas/_generate_stubs.py` a partir de `concepts/iconometria.md`; será atualizado ao rodar o gerador (não editado à mão).
+> Os stubs do Atlas são **gerados** por `atlas/_generate_stubs.py`. Este PR versiona
+> apenas os **dois stubs cuja fonte muda aqui** — `atlas/stubs/conceito/iconometria.md`
+> (regenerado) e `atlas/stubs/decisao/ICONOMETRIA-TRANSITION-2026-07-11.md` (novo). A
+> regeneração da **árvore completa** (`python atlas/_generate_stubs.py`, que recarimba
+> data em todos os stubs e incorpora drift acumulado) é operação de manutenção separada,
+> mantida fora deste PR conceitual.
 
 ## 5. **NÃO** alterado nesta passada (pendente de aprovação de Ana)
 

--- a/docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md
+++ b/docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md
@@ -1,0 +1,66 @@
+# Decisão — Transição conceitual: *endurecimento* → *iconometria*
+
+- **Data:** 2026-07-11
+- **Autora:** Ana Vanzin
+- **Status:** Aceita (camada conceitual). Migração de dados/scripts/manuscrito **faseada e pendente de aprovação** (ver §5).
+- **Registros relacionados:** `docs/decisions/DIALETICA-N165-vs-265.md`, `docs/decisions/DESENHO-2-0-ICONOCRACIA-2026-06-23.md`
+- **Conceito-fonte:** [`concepts/iconometria.md`](../../concepts/iconometria.md)
+
+---
+
+## 1. Contexto
+
+Até aqui, **endurecimento** era o eixo empírico central da metodologia: a *operacionalização da Purificação Clássica* por meio de **10 indicadores ordinais (0–3)**, com o objetivo de **quantificar a fixidez** de uma alegoria feminina (o grau em que a figura histórica é extraída e imobilizada no eterno alegórico). O escore agregado vivia no campo `endurecimento_score` (canônico em `data/processed/records.jsonl` → `corpus/corpus-data.json`), com o *ledger* de codificação em `data/processed/purification.jsonl`.
+
+## 2. Decisão
+
+Promover **iconometria** a **framework metodológico guarda-chuva** da tese: a **medição e análise de padrões iconográficos** no corpus — abordagem mais ampla e matizada que a mera quantificação de fixidez.
+
+**Endurecimento não é abandonado nem renomeado 1:1.** Ele é **preservado como *um* eixo dentro da iconometria** — o **subíndice de fixidez/purificação** (os 10 indicadores). A iconometria comporta esse eixo e abre espaço para outros vetores mensuráveis (p.ex. seriação, vetor colonial, densidade narrativa) sob um mesmo aparato quantitativo.
+
+> Em uma frase: **iconometria ⊇ endurecimento.** A iconometria é o *método de medição*; o endurecimento é *o que se mede* no eixo da fixidez alegórica.
+
+## 3. Justificativa
+
+- Alarga o escopo de "quantificar a fixidez de uma alegoria" para "medir e analisar padrões iconográficos", posicionando o aparato quantitativo como método geral (não como um único escore).
+- Alinha-se ao nó conceitual `concepts/iconometria.md`, que já definia iconometria como *"quantitative approach to the analysis of images, focusing on measurable aspects and patterns"* — anterior a esta decisão, agora formalizado.
+- Não sacrifica a genealogia jurídica: o endurecimento permanece a *operacionalização empírica da Purificação Clássica* (conceito autoral #4), agora explicitamente como **um eixo** do método iconométrico.
+
+## 4. Escopo executado nesta passada (camada conceitual — reversível)
+
+Arquivos alterados **apenas na definição/documentação**:
+
+1. `docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md` (este registro)
+2. `concepts/iconometria.md` — definição canônica expandida (iconometria = guarda-chuva; endurecimento = eixo de fixidez)
+3. `CLAUDE.md` — entrada de terminologia + nota de arquitetura
+4. `AGENTS.md` — terminologia canônica + rótulo de codificação
+
+> O stub `atlas/stubs/conceito/iconometria.md` é **gerado** por `atlas/_generate_stubs.py` a partir de `concepts/iconometria.md`; será atualizado ao rodar o gerador (não editado à mão).
+
+## 5. **NÃO** alterado nesta passada (pendente de aprovação de Ana)
+
+Nada de dado canônico, schema, script ou prosa de manuscrito foi tocado. Preservados intencionalmente:
+
+- **Campo de dados `endurecimento_score`** — mantido como **chave estável** em `records.jsonl`, `purification.jsonl`, `corpus-data.json`, CSV e schemas. Renomear a chave é migração coordenada (schema + dados + 21 scripts + notebooks + CI) e exige decisão explícita.
+- **Manuscrito** (`vault/tese/**`, `tese/manuscrito/**`) — prosa é a voz autoral; troca de termo só como sugestão, perto da defesa.
+- **Snapshots congelados** — `Other/`, `data/training/*.jsonl` (SFT/eval): são registros históricos de *runs*; não se reescreve histórico.
+
+## 6. Plano de migração faseado (para aprovação)
+
+| Fase | Superfície | Ação | Risco | Reversão |
+|------|-----------|------|-------|----------|
+| **F0** ✅ | Conceito + docs | Esta passada | Baixo | git revert |
+| **F1** | Manuscrito | Introduzir "iconometria" como método; endurecimento como eixo. **Como sugestão**, preservando voz. | Médio | diff por capítulo |
+| **F2** | Notebooks 01–08 | Rótulos de exibição/prosa markdown → "iconometria (eixo endurecimento)"; **sem** renomear variáveis/colunas. | Médio | re-run |
+| **F3** | Campo de dados | *Opcional.* Se decidir renomear `endurecimento_score` → manter alias/retrocompat; migrar schema + dados + scripts + CI juntos, com `validate_schemas.py` + `records_to_corpus.py --diff` verdes. | Alto | branch dedicada |
+
+**Recomendação:** manter `endurecimento_score` como chave (estabilidade de dados/CI) e mudar apenas rótulos de exibição e prosa. F3 (renome de campo) só se houver ganho claro que justifique a migração coordenada.
+
+## 7. Critérios de verificação (antes de qualquer merge que toque dados)
+
+```bash
+conda activate iconocracy
+python tools/scripts/validate_schemas.py
+python tools/scripts/validate_schemas.py data/processed/purification.jsonl --schema purification-record
+python tools/scripts/records_to_corpus.py --diff   # deve reportar sincronizado
+```


### PR DESCRIPTION
## Summary

Formaliza a transição conceitual **endurecimento → iconometria**: iconometria passa a ser o framework metodológico guarda-chuva (medição e análise de padrões iconográficos), com **endurecimento preservado como *um* eixo** dentro dela (o subíndice de fixidez/purificação). `iconometria ⊇ endurecimento`. Esta é a **fase F0 (camada conceitual)** — nenhum dado canônico, schema, script ou prosa de manuscrito foi tocado.

## Surface

- [ ] Corpus/data
- [ ] Coding/analysis
- [x] Writing/docs
- [ ] Infra/publishing

## Checks

Não aplicáveis a esta passada — a mudança é puramente conceitual/documental. Nenhum arquivo sob `data/`, `corpus/`, `tools/schemas/` ou `tools/scripts/` foi alterado, então `validate_schemas.py` / `code_purification.py` / `vault_sync.py` não são atingidos por este diff.

## Notes

**O que mudou (4 arquivos):**
- `concepts/iconometria.md` — definição canônica expandida (iconometria = método de medição; endurecimento = eixo de fixidez; nota de estabilidade do campo de dados).
- `CLAUDE.md` / `AGENTS.md` — entrada de terminologia + nota de arquitetura do pipeline.
- `docs/decisions/ICONOMETRIA-TRANSITION-2026-07-11.md` — decision record + plano de migração faseado.

**O que NÃO mudou (pendente de decisão de Ana — ver §5/§6 do decision record):**
- Campo de dados **`endurecimento_score`** mantido como **chave estável** (records.jsonl, purification.jsonl, corpus-data.json, CSV, schemas). Renome de chave é migração coordenada (F3, opcional).
- **Manuscrito** (`vault/tese/**`, `tese/manuscrito/**`) — voz autoral; troca de termo só como sugestão (F1).
- **Snapshots congelados** (`Other/`, `data/training/*.jsonl`) — registros históricos, não reescritos.

**Contexto:** a mensagem original que disparou isto parecia truncada ("…padrões iconográficos. E"). Executei a interpretação conservadora e reversível; as fases arriscadas (manuscrito, notebooks, renome de campo) estão teed-up no decision record para aprovação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuvSQVNGsQS4cn4ooBjkiD)_