### PR TITLE
docs: enquadramento interdisciplinar (jurídico + antropologia + sociologia)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,7 +110,7 @@ Update the canonical ledger first and derive public exports from it. Do not trea
 - Keep **Contrato Sexual Visual** and **Feminilidade de Estado** as thesis-native concepts.
 - Keep **Pathosformel**, **Zwischenraum**, and **Nachleben** in German.
 - Use **ABNT NBR 6023:2025** for citations.
-- Maintain the repository's juridico-penal framing; do not recast thesis material in anthropological or sociological terms.
+- Keep the thesis's **interdisciplinary** framing: legal history and theory in explicit dialogue with anthropology and sociology (e.g. Lévi-Strauss, Bourdieu). The juridical register does not exclude anthropological or sociological readings — do not strip them from the material.
 
 ### Release gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ Every corpus item must exist in three places:
 - Thesis original files (`*_original`) are protected — use `vault/tese/` for revised drafts
 - SSD `/media/ana/SSD_DATA` stores raw images, Zotero PDFs, and backups
 - Automatic vault backups must not land on `main` (use `vault_backup.py`)
-- Academic voice: formal Portuguese with jurídico-penal framing (legal-criminal history, NOT anthropological/sociological)
+- Academic voice: formal Portuguese; história e teoria do direito em diálogo **explícito e legítimo** com antropologia e sociologia (p.ex. Lévi-Strauss, Bourdieu). Enquadramento **interdisciplinar** — o registro jurídico NÃO exclui os registros antropológico e sociológico; são complementares, não concorrentes
 
 ---
 

--- a/Text/AGENTS.md
+++ b/Text/AGENTS.md
@@ -38,7 +38,7 @@
 
 ## Estilo e terminologia obrigatórios
 - Sempre use os termos originais da tese: **endurecimento** (nunca "hardening"/"embrutecimento"), **Contrato Sexual Visual** (autoral — Vanzin 2026, NÃO atribuir a Pateman), **Feminilidade de Estado** (autoral — NÃO atribuir a Mondzain), **Purificação Clássica**, **Pathosformel**, **Zwischenraum**, **Nachleben**, **Iconclass 48C51**.
-- Citações em ABNT NBR 6023:2025; Mondzain = edição 2002. Texto acadêmico em português jurídico-penal, não antropológico/sociológico.
+- Citações em ABNT NBR 6023:2025; Mondzain = edição 2002. Texto acadêmico em português formal, com enquadramento jurídico **em diálogo com antropologia e sociologia** (p.ex. Lévi-Strauss, Bourdieu) — interdisciplinar, não jurídico-exclusivo.
 
 ## Guardrails finais
 - `tese/manuscrito/*_original` é somente leitura — trabalhe nas versões `*_rev`.

--- a/Text/CLAUDE.md
+++ b/Text/CLAUDE.md
@@ -177,7 +177,7 @@ Every corpus item must exist in three places:
 - Thesis original files (`*_original`) are protected — use `vault/tese/` for revised drafts
 - SSD `/Volumes/ICONOCRACIA` stores raw images, Zotero PDFs, and backups
 - Automatic vault backups must not land on `main` (use `vault_backup.py`)
-- Academic voice: formal Portuguese with jurídico-penal framing (legal-criminal history, NOT anthropological/sociological)
+- Academic voice: formal Portuguese; história e teoria do direito em diálogo **explícito e legítimo** com antropologia e sociologia (p.ex. Lévi-Strauss, Bourdieu). Enquadramento **interdisciplinar** — o registro jurídico NÃO exclui os registros antropológico e sociológico; são complementares, não concorrentes
 
 ---
 

--- a/atlas/README.md
+++ b/atlas/README.md
@@ -110,4 +110,4 @@ python atlas/_generate_stubs.py   # regenera atlas/stubs/ por inteiro (idempoten
 - **Contagens não são fixadas neste grafo** — derivam a cada sync. Para o estado
   atual, ver [`../CLAUDE.md`](../CLAUDE.md) §*Known Data Issues* e
   `python tools/scripts/validate_schemas.py` / `records_to_corpus.py --diff`.
-- Voz acadêmica: português formal, enquadramento jurídico-penal.
+- Voz acadêmica: português formal, enquadramento jurídico em diálogo com antropologia e sociologia.

--- a/vault/tese/plano-capitulos-2026-04-11.md
+++ b/vault/tese/plano-capitulos-2026-04-11.md
@@ -116,7 +116,7 @@
 - **A fazer**: Escrever do zero, integrando os artigos. Ancorar cada seção num dispositivo jurídico concreto
 - **Dependências**: Cap. 2 (regimes iconocráticos é pressuposto)
 - **Trilho**: A (teórico) — **CAMINHO CRÍTICO**
-- **Risco**: Alto — mais original e menos maduro; manter voz jurídico-penal (não antropológica)
+- **Risco**: Alto — mais original e menos maduro; ancorar cada seção em dispositivo jurídico concreto, em diálogo com os registros antropológico e sociológico (não abrir mão deles)
 - **Stress test**: Não "descobrir" a colonialidade — a contribuição é a dimensão visual do contrato racial no Direito
 
 ---

--- a/wiki/tese/plano-capitulos-2026-04-11.md
+++ b/wiki/tese/plano-capitulos-2026-04-11.md
@@ -116,7 +116,7 @@
 - **A fazer**: Escrever do zero, integrando os artigos. Ancorar cada seção num dispositivo jurídico concreto
 - **Dependências**: Cap. 2 (regimes iconocráticos é pressuposto)
 - **Trilho**: A (teórico) — **CAMINHO CRÍTICO**
-- **Risco**: Alto — mais original e menos maduro; manter voz jurídico-penal (não antropológica)
+- **Risco**: Alto — mais original e menos maduro; ancorar cada seção em dispositivo jurídico concreto, em diálogo com os registros antropológico e sociológico (não abrir mão deles)
 - **Stress test**: Não "descobrir" a colonialidade — a contribuição é a dimensão visual do contrato racial no Direito
 
 ---


### PR DESCRIPTION
## Summary

Remove a regra que restringia a voz acadêmica da tese a um registro "jurídico-penal, **NÃO** antropológico/sociológico". O enfoque da tese é **interdisciplinar** — história e teoria do direito em diálogo explícito com antropologia e sociologia (Lévi-Strauss, Bourdieu). O registro jurídico não exclui os registros antropológico e sociológico; são complementares, não concorrentes.

## Surface

- [ ] Corpus/data
- [ ] Coding/analysis
- [x] Writing/docs
- [ ] Infra/publishing

## Checks

- [ ] `python tools/scripts/validate_schemas.py …` — não aplicável (mudança só em prosa de instrução/docs, sem tocar em `records.jsonl`)
- [ ] `python tools/scripts/code_purification.py --status` — não aplicável
- [ ] `python tools/scripts/vault_sync.py status` — recomendável rodar: um dos arquivos editados é `vault/tese/plano-capitulos-2026-04-11.md`
- [x] Release/docs updated — não afeta GitHub Pages nem Hugging Face

## Notes

**Guardrails vivos corrigidos:** `CLAUDE.md` (fonte da regra), `.github/copilot-instructions.md`, `vault/tese/plano-capitulos-2026-04-11.md`, `atlas/README.md`.

**Espelhos de instrução sincronizados com o canônico:** `Text/CLAUDE.md`, `Text/AGENTS.md`, `wiki/tese/plano-capitulos-2026-04-11.md`.

**Preservados como histórico (intencionalmente não tocados):** registros datados em `docs/decisions/dialectic-corpus-2026-06-19/`, `docs/superpowers/specs/2026-04-11-*` e as cópias de plano datadas em `Text/*`; e a prosa autoral em `iconocracy-dialectics/monge-hegeliano-argumento*.md` (a distinção "ontológica, não sociológica" é argumento da tese, não guardrail).


---
_Generated by [Claude Code](https://claude.ai/code/session_01V1rkmcEgFDA8Fi5M4ZEp3k)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-instruction prose only; no runtime, data contracts, or auth paths affected. Main effect is how future AI-assisted drafting is steered.
> 
> **Overview**
> This PR **replaces** the old academic-voice rule that told agents to keep thesis material in a **jurídico-penal** register and **not** recast it in anthropological or sociological terms. The new guidance states an **interdisciplinary** frame: legal history and theory in explicit dialogue with anthropology and sociology (e.g. Lévi-Strauss, Bourdieu), with juridical, anthropological, and sociological registers as **complementary**, not mutually exclusive.
> 
> **Canonical guardrails** updated in `.github/copilot-instructions.md` (terminology/writing), root `CLAUDE.md`, `vault/tese/plano-capitulos-2026-04-11.md` (Cap. 3 risk: anchor in concrete legal devices **and** keep anthropological/sociological registers), and `atlas/README.md` (academic voice line).
> 
> **Mirrors** aligned to the same wording: `Text/CLAUDE.md`, `Text/AGENTS.md`, and `wiki/tese/plano-capitulos-2026-04-11.md`. No corpus schemas, pipelines, or manuscript body text change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ddd215c1505ff111a5d79277f27793f8cf960db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->