### PR TITLE
Corrige a vinculação de Matthews ao Capítulo 7

### DIFF
--- a/data/research/consensus_sync_2026-07-15.json
+++ b/data/research/consensus_sync_2026-07-15.json
@@ -33,7 +33,7 @@
       "supports": [
         "genealogia_da_personificacao_nacional",
         "comparacao_britannia_john_bull",
-        "capitulo_5"
+        "capitulo_7"
       ],
       "research_status": "verificado_texto_integral",
       "note": "Sustenta a genealogia histórica de Britânia e John Bull e sua atuação como personificações complementares da identidade britânica. Não sustenta, por si só, equivalência entre alegoria feminina e mulheres reais."

--- a/docs/research/consensus-sync-2026-07-15.md
+++ b/docs/research/consensus-sync-2026-07-15.md
@@ -13,7 +13,7 @@ Esta sincronização registra literatura recuperada no Consensus e a vincula às
 
 | Chave | Verificação | Papel sustentado | Limite |
 |---|---|---|---|
-| `Matthews2000Britannia` | DOI, fascículo e texto integral verificados | Genealogia e comparação entre Britânia e John Bull no Capítulo 5 | Não equivale alegoria feminina a mulheres reais |
+| `Matthews2000Britannia` | DOI, fascículo e texto integral verificados | Genealogia e comparação entre Britânia e John Bull no Capítulo 7 | Não equivale alegoria feminina a mulheres reais |
 | `Baylis2014GenderFrame` | DOI, autoria e metadados verificados; texto integral pendente | Comparador para fotografia, gênero e narrativa nacional no Capítulo 4 | A afirmação sobre arquivos “conservarem contradições” é não verificável sem leitura integral |
 | `Carvalho2012FormationSouls` | Editora, ISBN e funções autorais verificados | Símbolos, alegorias, imaginário e legitimação da República brasileira | Landers é tradutor; Maria Alice Rezende de Carvalho é autora do prefácio, não coautora |
 | `Cusack2005TinyTransmitters` | DOI, resumo editorial e texto localizado verificados | Selos como circulação estatal de nacionalismo/colonialismo e análise de gênero | Não transfere automaticamente categorias portuguesas ao Brasil |
@@ -47,6 +47,7 @@ PRIETO-ANDRÉS, Antonio; FERNÁNDEZ-ROMERO, Cayetano; SIERRA-HUEDO, María Luisa
 4. A afirmação específica de que arquivos visuais “conservam contradições” não foi confirmada para Baylis.
 5. O texto integral de Prieto-Andrés et al. está disponível e verificado; o status provisório anterior estava desatualizado.
 6. Contagens de citação do Consensus são apenas instantâneos da coleta e não demonstram qualidade ou adequação argumentativa.
+7. Matthews foi remapeado do Capítulo 5 para o Capítulo 7, que concentra a análise iconológica das personificações nacionais; o Capítulo 5 trata da construção e da auditoria do corpus.
 
 ## Implicações operacionais
 


### PR DESCRIPTION
## Correção de mapeamento bibliográfico

- remapeia `Matthews2000Britannia` de `capitulo_5` para `capitulo_7`;
- atualiza a tabela de auditoria e registra o motivo metodológico da correção;
- preserva todos os registros do corpus visual, snapshots e dados canônicos.

## Motivo

O Capítulo 5 concentra a construção e a auditoria do corpus. A genealogia de Britânia e John Bull é mobilizada na análise iconológica das personificações nacionais, desenvolvida no Capítulo 7.

## Validação

- manifesto JSON analisado com sucesso;
- tag de Matthews confirmada como `capitulo_7`;
- referência cruzada da nota confirmada como Capítulo 7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Apenas metadados bibliográficos e documentação de pesquisa; sem impacto em código, corpus ou dados probatórios das peças.
> 
> **Overview**
> **Corrige o vínculo de capítulo** da referência `Matthews2000Britannia` no manifesto de sincronização Consensus e na documentação de auditoria.
> 
> No JSON estruturado, a tag `supports` passa de `capitulo_5` para `capitulo_7`. A tabela de auditoria em `consensus-sync-2026-07-15.md` reflete o **Capítulo 7** como destino da genealogia Britânia/John Bull, e um novo item na lista de claims corrigidas registra que o Capítulo 5 cobre construção/auditoria do corpus, enquanto a análise iconológica das personificações fica no Capítulo 7.
> 
> Não há alteração em corpus visual, snapshots ou dados canônicos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8d8f33cd435986ed12da579d09e01110fc5c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->