### PR TITLE
feat(tools): codificador-proxy LPAI v2 sobre Kimi K3 + aposentadoria do índice composto (codebook v2.2.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,8 @@ deploy/iconocracia-companion/.wrangler/
 .claude/hooks/README.md
 .claude/hooks/hooks.json
 .claude/hooks/memory-persistence/
+
+# LPAI proxy coder (Kimi K3) — staging + cache de imagens; nunca versionado
+data/staging/lpai-proxy-k3-runs.jsonl
+data/staging/lpai-proxy-k3-runs.*.jsonl
+.cache/lpai-proxy-images/

--- a/docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md
+++ b/docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md
@@ -14,6 +14,7 @@ scripts_afetados:
   - tools/scripts/lpai_proxy_coder_k3.py
   - tools/scripts/compute_irr.py
 status: vigente
+migracao: concluida
 licenca: CC-BY-4.0
 ---
 
@@ -83,8 +84,10 @@ monotonia precisa ser reformulada como montagem de casos, não como curva.
 
 ## Migração
 
-Consumidores que ainda produzem ou dependem do composto, a tratar em issue
-própria:
+Consumidores migrados. O módulo `tools/scripts/lpai_indicators.py` concentra a
+leitura não agregadora dos indicadores (`attribute_inventory`,
+`attribute_count`, `coding_coverage`, `is_uncoded`) e um acessor somente de
+leitura para valores congelados (`legacy_composite`), que nunca calcula:
 
 | Arquivo | Situação | Ação |
 |---|---|---|
@@ -92,11 +95,13 @@ própria:
 | `tools/schemas/purification-record.schema.json` | resolvido | campo deixa de ser `required`, marcado `deprecated` |
 | `tools/schemas/master-record.schema.json` | resolvido | campo marcado `deprecated` |
 | `tools/scripts/compute_irr.py` | resolvido | seção de composto rotulada como legado diagnóstico |
-| `tools/scripts/csv_to_records.py` | pendente | para de calcular composto na ingestão |
-| `tools/scripts/iconocode_gemma4.py` | pendente | `endurecimento_score` sai do registro emitido |
-| `tools/scripts/e3_firecrawl_recode.py` | pendente | recodificação sem escore |
-| `tools/audit/scripts/analyze_threads.py` e `_v2.py` | pendente | ordenação de fios por atributo, não por escore |
-| `tools/audit/mnemosyne/starter-8panels.json` | pendente | reescrever a tese do painel ENDURECIMENTO |
+| `tools/scripts/csv_to_records.py` | resolvido | não calcula composto; repassa valor legado quando existe; confiança passa a vir da cobertura do instrumento |
+| `tools/scripts/iconocode_gemma4.py` | resolvido | `endurecimento_score` sai; entra `inventario_verbal` |
+| `tools/scripts/e3_firecrawl_recode.py` | resolvido | fila selecionada por item não codificado, não por composto zero |
+| `tools/audit/scripts/analyze_threads.py` e `_v2.py` | resolvido | ordenação, cadeias e rótulos por contagem de atributos |
+| `tools/audit/mnemosyne/starter-8panels.json` | resolvido | tese do painel reescrita como inventário comparado |
+| `tools/audit/reports/french-panofsky-audit.md` | resolvido | checklists pedem inventário verbal + Panofsky, não escore |
+| `tools/audit/reports/systematic-review-conversation.md` | resolvido | idem |
 
 ## Efeito no instrumento
 

--- a/docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md
+++ b/docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md
@@ -1,0 +1,107 @@
+---
+documento: decisao
+id: DEC-2026-07-28-COMPOSTO
+data: "2026-07-28"
+autor: Ana Vanzin
+escopo: "instrumento LPAI v2 — estatuto do índice composto de purificação"
+codebook_afetado: schema/codebook-MASTER.md
+codebook_version_antes: 2.2.0
+codebook_version_depois: 2.2.1
+schemas_afetados:
+  - tools/schemas/master-record.schema.json
+  - tools/schemas/purification-record.schema.json
+scripts_afetados:
+  - tools/scripts/lpai_proxy_coder_k3.py
+  - tools/scripts/compute_irr.py
+status: vigente
+licenca: CC-BY-4.0
+---
+
+# Aposentadoria do índice composto de purificação
+
+## A divergência
+
+O codebook MASTER v2.2.0 prescreve, no §12 e no passo 4 do master prompt
+operacional (§16), o cálculo de `purificacao_composto` como média aritmética
+simples dos 10 indicadores canônicos em escala 0–3. A virada qualitativa de
+julho de 2026 removeu o escore agregado do fluxo de análise e passou a tratar
+ENDURECIMENTO como lente qualitativa — inventário verbal de atributos —
+justamente porque um número único apaga a heterogeneidade dos indicadores que o
+compõem.
+
+As duas orientações coexistiram por cerca de um mês. O instrumento pedia um
+número que a análise havia decidido não usar. Esta decisão encerra a coexistência.
+
+## Decisão
+
+**O índice composto é aposentado como afirmação probatória e congelado como
+artefato histórico.**
+
+1. **Não se calcula composto para codificação nova.** Nem humana, nem proxy.
+   O passo 4 do §16 passa a exigir inventário verbal de atributos no lugar da
+   média.
+2. **Os 10 indicadores permanecem.** Eles são capta ordinal previsto pelo
+   schema, com critérios operacionais definidos, e continuam obrigatórios. A
+   decisão recai sobre a agregação, não sobre a observação.
+3. **Valores legados não são recalculados nem apagados.** Registros codificados
+   em v2.2.0 conservam seu `purificacao_composto`. Reprocessá-los produziria
+   série temporal falsa; deletá-los destruiria o rastro de como o corpus foi
+   construído. O campo passa a `legacy_frozen`.
+4. **Nenhuma afirmação da tese pode repousar sobre o composto.** Onde o
+   argumento hoje se apoia em variação de escore, ele precisa ser reescrito como
+   inventário comparado de atributos.
+5. **Concordância entre codificadores migra para os indicadores.** O kappa por
+   indicador e a distância ordinal permanecem métricas de confiabilidade. A
+   diferença de composto entre codificadores continua sendo impressa por
+   `compute_irr.py`, porém rotulada como diagnóstico legado, sem valor
+   probatório.
+6. **O composto não retorna sem nova decisão registrada.** Se algum dia houver
+   justificativa para agregação, ela precisará de ponderação explícita,
+   fundamentação teórica e um documento como este — não de uma média silenciosa.
+
+## Razão
+
+Três argumentos sustentam a aposentadoria.
+
+O primeiro é de validade. Os 10 indicadores medem coisas incomensuráveis:
+`monocromatizacao` é propriedade técnica do suporte, `inscricao_estatal` é fato
+institucional, `dessexualizacao` é juízo iconográfico contestável. A média
+trata como intercambiável o que a tese precisa manter distinto. Uma moeda
+serial e monocromática por restrição de cunho recebe escore alto por razões que
+nada dizem sobre endurecimento simbólico.
+
+O segundo é de auditabilidade. O escore comprime dez decisões interpretativas
+em um número, e o número é o que sobrevive na tabela. A auditoria de Panofsky
+já havia registrado o sintoma: entradas com `endurecimento_score` calculado sem
+o texto descritivo que o justificaria — a lacuna mais crítica apontada no
+relatório francês. O inventário verbal não permite esse atalho.
+
+O terceiro é de honestidade do argumento. Um dos painéis do atlas ainda afirma
+trajetória cuja medida cresce monotonicamente no tempo. Se o composto não é
+prova autônoma — e o próprio §12 sempre disse que não era — a afirmação de
+monotonia precisa ser reformulada como montagem de casos, não como curva.
+
+## Migração
+
+Consumidores que ainda produzem ou dependem do composto, a tratar em issue
+própria:
+
+| Arquivo | Situação | Ação |
+|---|---|---|
+| `tools/scripts/lpai_proxy_coder_k3.py` | resolvido nesta decisão | não emite composto; `--emit-composto` removido |
+| `tools/schemas/purification-record.schema.json` | resolvido | campo deixa de ser `required`, marcado `deprecated` |
+| `tools/schemas/master-record.schema.json` | resolvido | campo marcado `deprecated` |
+| `tools/scripts/compute_irr.py` | resolvido | seção de composto rotulada como legado diagnóstico |
+| `tools/scripts/csv_to_records.py` | pendente | para de calcular composto na ingestão |
+| `tools/scripts/iconocode_gemma4.py` | pendente | `endurecimento_score` sai do registro emitido |
+| `tools/scripts/e3_firecrawl_recode.py` | pendente | recodificação sem escore |
+| `tools/audit/scripts/analyze_threads.py` e `_v2.py` | pendente | ordenação de fios por atributo, não por escore |
+| `tools/audit/mnemosyne/starter-8panels.json` | pendente | reescrever a tese do painel ENDURECIMENTO |
+
+## Efeito no instrumento
+
+O codebook MASTER passa a 2.2.1, com o §12 e o passo 4 do §16 reescritos. Como
+`tools/scripts/lpai_proxy_coder_k3.py` lê o §16 em tempo de execução, a mudança
+do instrumento é automaticamente refletida na codificação de proxy, e cada linha
+de staging registra `codebook_version: 2.2.1`. O que a codificação de julho fez
+e o que a de agosto fará ficam distinguíveis por esse campo.

--- a/schema/codebook-MASTER.md
+++ b/schema/codebook-MASTER.md
@@ -1,12 +1,14 @@
 ---
 codebook_id: lpai-master
-codebook_version: 2.2.0
-data_versao: 2026-06-24
+codebook_version: 2.2.1
+data_versao: 2026-07-28
 status: pre_freeze
 freeze_state: pre_freeze
 canonical_schema: tools/schemas/master-record.schema.json
 canonical_records: data/processed/records.jsonl
 canonical_prompt_section: "§16 — Master prompt operacional"
+composto_status: legacy_frozen
+decisao_composto: docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md
 replaces:
   - schema/lpai-v2-as-capta.md
   - docs/methodology/codebook-v2-alegorias.md
@@ -125,7 +127,7 @@ Os 10 indicadores canônicos são os do documento-pai `data/docs/codebook.md`, e
 | `serialidade` | obra única | tiragem limitada | média escala | reprodução massiva |
 | `inscricao_estatal` | sem vínculo estatal | encomenda oficial | insígnia estatal | dispositivo estatal |
 
-O índice composto é a média dos 10 indicadores. Ele é uma heurística de endurecimento/purificação simbólica, não prova autônoma. Indicadores suplementares como classicização, moralização, depuração semântica, neutralização afetiva e monumentalização podem aparecer em notas iconológicas, mas não integram o score canônico em v2.2.0.
+O índice composto está **aposentado** desde v2.2.1 (ver [decisão de 2026-07-28](../docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md)). Não se calcula `purificacao_composto` para codificação nova: a média tratava como intercambiáveis indicadores incomensuráveis — propriedade técnica do suporte, fato institucional e juízo iconográfico — e o número comprimia dez decisões interpretativas em um valor que sobrevivia sozinho nas tabelas. Os 10 indicadores permanecem obrigatórios como capta ordinal; o que sai é a agregação, não a observação. Valores legados ficam congelados (`legacy_frozen`): não são recalculados nem apagados, e nenhuma afirmação da tese pode repousar sobre eles. No lugar da média, a codificação registra inventário verbal de atributos. Indicadores suplementares como classicização, moralização, depuração semântica, neutralização afetiva e monumentalização podem aparecer em notas iconológicas.
 
 ## 11. Programa iconográfico
 
@@ -172,7 +174,7 @@ purificacao:
   monocromatizacao: 2
   serialidade: 3
   inscricao_estatal: 3
-  purificacao_composto: 2.1
+  # purificacao_composto: legacy_frozen desde v2.2.1 — não preencher em codificação nova
   regime_iconocratico: normativo
   coded_by: avanzin
   coded_at: "2026-06-24T18:00:00-03:00"
@@ -194,12 +196,12 @@ purificacao:
 Use este bloco como instrução para um codificador humano ou LLM. Não inclua blocos terminológicos longos; consulte o codebook quando precisar de enum.
 
 ```text
-Você é um codificador LPAI v2.2.0 para o corpus ICONOCRACY. Sua tarefa é produzir capta iconográfico situado, não dados neutros.
+Você é um codificador LPAI v2.2.1 para o corpus ICONOCRACY. Sua tarefa é produzir capta iconográfico situado, não dados neutros.
 
 1. Leia a evidência disponível: imagem, metadados, fonte, data, suporte, local e notas anteriores.
 2. Declare se a imagem permite codificação visual suficiente. Se não permitir, reduza confiança e explique em notes.
 3. Classifique os 10 indicadores canônicos em escala 0–3: desincorporacao, rigidez_postural, dessexualizacao, uniformizacao_facial, heraldizacao, enquadramento_arquitetonico, apagamento_narrativo, monocromatizacao, serialidade, inscricao_estatal.
-4. Calcule purificacao_composto como média simples dos 10 indicadores.
+4. NÃO calcule índice composto, média, escore agregado ou qualquer número único a partir dos indicadores. Em lugar disso, registre inventario_verbal: a lista dos atributos efetivamente observados, em vocabulário iconográfico. O campo purificacao_composto está aposentado (legacy_frozen desde v2.2.1) e não deve ser emitido.
 5. Atribua regime_iconocratico apenas se houver base suficiente: fundacional, normativo, militar ou contra-alegoria.
 6. Preencha familia_alegorica, subtipo, genero_atribuido, funcao_juridica e vetor_colonial quando a evidência sustentar a decisão.
 7. Separe descrição de hipótese. Use atributos_iconograficos para sinais observáveis e hipotese_racial apenas para interpretação declarada.

--- a/tests/test_lpai_indicators.py
+++ b/tests/test_lpai_indicators.py
@@ -1,0 +1,114 @@
+"""Testes do módulo que substitui o índice composto (DEC-2026-07-28).
+
+O contrato é negativo antes de ser positivo: nenhuma função pode produzir um
+composto novo. `legacy_composite` apenas lê valores congelados.
+"""
+
+from __future__ import annotations
+
+from tools.scripts.lpai_indicators import (
+    INDICATOR_KEYS,
+    attribute_count,
+    attribute_inventory,
+    coding_coverage,
+    describe_inventory,
+    indicator_values,
+    is_uncoded,
+    legacy_composite,
+)
+
+
+def _flat(**valores):
+    return dict(valores)
+
+
+def test_le_forma_achatada():
+    entry = _flat(desincorporacao=3, serialidade=1)
+    assert indicator_values(entry) == {"desincorporacao": 3, "serialidade": 1}
+
+
+def test_le_forma_aninhada_indicadores():
+    entry = {"indicadores": {"heraldizacao": 2}}
+    assert indicator_values(entry) == {"heraldizacao": 2}
+
+
+def test_le_forma_aninhada_purificacao():
+    entry = {"purificacao": {"rigidez_postural": 3}}
+    assert indicator_values(entry) == {"rigidez_postural": 3}
+
+
+def test_ausencia_nao_e_zero():
+    """Chave ausente fica ausente — é o que distingue não codificado de zero."""
+    valores = indicator_values({"indicadores": {"serialidade": 0}})
+    assert valores == {"serialidade": 0}
+    assert "heraldizacao" not in valores
+
+
+def test_inventario_usa_limiar_dois():
+    entry = _flat(desincorporacao=3, rigidez_postural=2, dessexualizacao=1, serialidade=0)
+    assert attribute_inventory(entry) == ["desincorporacao", "rigidez_postural"]
+
+
+def test_inventario_respeita_ordem_canonica():
+    entry = _flat(inscricao_estatal=3, desincorporacao=3)
+    assert attribute_inventory(entry) == ["desincorporacao", "inscricao_estatal"]
+
+
+def test_contagem_de_atributos():
+    entry = {"indicadores": {key: 2 for key in INDICATOR_KEYS[:4]}}
+    assert attribute_count(entry) == 4
+
+
+def test_cobertura_mede_completude_nao_intensidade():
+    """Dez zeros são cobertura total: o instrumento foi aplicado inteiro."""
+    entry = {"indicadores": {key: 0 for key in INDICATOR_KEYS}}
+    assert coding_coverage(entry) == 1.0
+    assert attribute_count(entry) == 0
+
+
+def test_cobertura_parcial():
+    entry = {"indicadores": {key: 3 for key in INDICATOR_KEYS[:5]}}
+    assert coding_coverage(entry) == 0.5
+
+
+def test_is_uncoded_distingue_ausencia_de_zero_codificado():
+    assert is_uncoded({}) is True
+    assert is_uncoded({"indicadores": {}}) is True
+    assert is_uncoded({"indicadores": {key: 0 for key in INDICATOR_KEYS}}) is True
+    assert is_uncoded({"indicadores": {"serialidade": 1}}) is False
+
+
+def test_legacy_composite_apenas_le():
+    assert legacy_composite({"purificacao_composto": 2.1}) == 2.1
+    assert legacy_composite({"purificacao": {"purificacao_composto": 1.5}}) == 1.5
+    assert legacy_composite({"endurecimento_score": 0.8}) == 0.8
+
+
+def test_legacy_composite_nunca_calcula():
+    """Com os 10 indicadores presentes e nenhum composto gravado, retorna None."""
+    entry = {"indicadores": {key: 3 for key in INDICATOR_KEYS}}
+    assert legacy_composite(entry) is None
+
+
+def test_legacy_composite_tolera_lixo():
+    assert legacy_composite({"purificacao_composto": "n/a"}) is None
+    assert legacy_composite(None) is None
+
+
+def test_describe_inventory_para_log():
+    entry = _flat(desincorporacao=3, serialidade=2)
+    assert describe_inventory(entry) == "2 atributos: desincorporacao, serialidade"
+    assert describe_inventory({}) == "sem atributos marcados"
+
+
+def test_nenhuma_funcao_publica_devolve_media():
+    """Guarda-costas do contrato: a média dos indicadores não aparece em lugar algum."""
+    entry = {"indicadores": {key: 2 for key in INDICATOR_KEYS}}
+    media = 2.0
+    resultados = [
+        attribute_count(entry),
+        coding_coverage(entry),
+        legacy_composite(entry),
+        is_uncoded(entry),
+    ]
+    assert media not in [r for r in resultados if isinstance(r, float)]

--- a/tests/test_lpai_proxy_coder_k3.py
+++ b/tests/test_lpai_proxy_coder_k3.py
@@ -159,16 +159,25 @@ def test_row_e_serializavel():
 # --------------------------------------------------------------------------
 
 
-def test_schema_nao_pede_composto_por_padrao():
+def test_schema_nunca_pede_composto():
+    """Composto aposentado no codebook v2.2.1 (DEC-2026-07-28): sem campo, sem flag."""
     schema = build_output_schema()
-    indicadores = schema["properties"]["indicadores"]["properties"]
-    assert "purificacao_composto" not in indicadores
-    assert set(INDICATOR_KEYS).issubset(indicadores)
+    indicadores = schema["properties"]["indicadores"]
+    assert "purificacao_composto" not in indicadores["properties"]
+    assert set(INDICATOR_KEYS).issubset(indicadores["properties"])
+    assert indicadores["additionalProperties"] is False
 
 
-def test_schema_com_composto_em_opt_in():
-    schema = build_output_schema(emit_composto=True)
-    assert "purificacao_composto" in schema["properties"]["indicadores"]["properties"]
+def test_build_output_schema_nao_aceita_opt_in_de_composto():
+    with pytest.raises(TypeError):
+        build_output_schema(emit_composto=True)  # type: ignore[call-arg]
+
+
+def test_preambulo_proibe_agregacao():
+    from tools.scripts.lpai_proxy_coder_k3 import PROXY_PREAMBLE
+
+    assert "escores compostos" in PROXY_PREAMBLE
+    assert "inventario_verbal" in PROXY_PREAMBLE
 
 
 def test_schema_exige_justificativa_e_confianca():

--- a/tests/test_lpai_proxy_coder_k3.py
+++ b/tests/test_lpai_proxy_coder_k3.py
@@ -1,0 +1,234 @@
+"""Testes das barreiras de escrita e do envelope de proxy do codificador K3.
+
+Nenhum teste toca a rede. O foco é o contrato metodológico: o proxy não pode
+escrever em artefato canônico e não pode produzir linha que se confunda com
+codificação humana.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.scripts.lpai_proxy_coder_k3 import (
+    AGENT_ID,
+    INDICATOR_KEYS,
+    REPO,
+    GuardrailError,
+    assert_write_target,
+    build_output_schema,
+    build_row,
+    build_user_content,
+    load_done,
+    select_items,
+)
+
+
+@pytest.fixture()
+def staging(tmp_path, monkeypatch):
+    root = tmp_path / "staging"
+    root.mkdir()
+    monkeypatch.setenv("LPAI_PROXY_STAGING_ROOT", str(root))
+    return root
+
+
+# --------------------------------------------------------------------------
+# Barreiras de escrita
+# --------------------------------------------------------------------------
+
+
+def test_aceita_destino_em_staging(staging):
+    target = assert_write_target(staging / "lpai-proxy-k3-runs.jsonl")
+    assert target == (staging / "lpai-proxy-k3-runs.jsonl").resolve()
+
+
+def test_recusa_records_jsonl_canonico(staging):
+    with pytest.raises(GuardrailError):
+        assert_write_target(REPO / "data" / "processed" / "records.jsonl")
+
+
+def test_recusa_nome_records_jsonl_mesmo_dentro_de_staging(staging):
+    """Nome de artefato canônico é bloqueado por si só, em qualquer diretório."""
+    with pytest.raises(GuardrailError) as exc:
+        assert_write_target(staging / "records.jsonl")
+    assert "canônico" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "nome",
+    [
+        "corpus-data.json",
+        "corpus-data.v2.json",
+        "corpus-data-enriched.json",
+        "companion-data.json",
+    ],
+)
+def test_recusa_exports_do_corpus(staging, nome):
+    with pytest.raises(GuardrailError):
+        assert_write_target(staging / nome)
+
+
+def test_recusa_diretorio_canonico(staging):
+    with pytest.raises(GuardrailError):
+        assert_write_target(REPO / "corpus" / "proxy-runs.jsonl")
+
+
+def test_recusa_fora_da_raiz_de_staging(staging, tmp_path):
+    with pytest.raises(GuardrailError):
+        assert_write_target(tmp_path / "solto" / "proxy-runs.jsonl")
+
+
+def test_recusa_extensao_diferente_de_jsonl(staging):
+    with pytest.raises(GuardrailError):
+        assert_write_target(staging / "proxy-runs.json")
+
+
+def test_recusa_escapar_de_staging_por_caminho_relativo(staging):
+    with pytest.raises(GuardrailError):
+        assert_write_target(staging / ".." / "proxy-runs.jsonl")
+
+
+# --------------------------------------------------------------------------
+# Envelope de proxy
+# --------------------------------------------------------------------------
+
+
+def _record():
+    return {
+        "item_id": "abc-123",
+        "item_hash": "deadbeef",
+        "input": {
+            "input_url": "https://example.org/a.jpg",
+            "title_hint": "Justiça",
+            "date_hint": "1889",
+            "place_hint": "Brazil",
+        },
+        "webscout": {"summary_evidence": "gravura", "gaps": []},
+        "purificacao": {"coded_by": "ana", "regime_iconocratico": "fundacional"},
+    }
+
+
+def _coded():
+    return {
+        "item_id": "abc-123",
+        "codificavel": True,
+        "indicadores": {key: 1 for key in INDICATOR_KEYS},
+        "inventario_verbal": ["balança", "olhos vendados"],
+        "regime_iconocratico": "normativo",
+        "confianca": "media",
+        "justificativa": "atributos visíveis",
+    }
+
+
+def test_row_marca_autoridade_de_proxy():
+    row = build_row(
+        _record(),
+        _coded(),
+        model="kimi-k3",
+        codebook_version="2.2.0",
+        image_source="/tmp/abc-123.jpg",
+    )
+    assert row["proxy_only"] is True
+    assert row["authority"] == "proxy"
+    assert row["human_class"] is None
+    assert row["merge_policy"] == "requires_human_adjudication"
+    assert row["coded_by"] == AGENT_ID
+    assert row["target_field"] == "purificacao_proposta"
+    assert row["codebook_version"] == "2.2.0"
+    assert row["capta_declaration"].startswith("LPAI v2-capta")
+
+
+def test_row_nao_sobrescreve_autoria_humana():
+    row = build_row(
+        _record(), _coded(), model="kimi-k3", codebook_version="2.2.0", image_source=None
+    )
+    assert row["human_coded_by_at_read_time"] == "ana"
+    assert row["coded_by"] != "ana"
+
+
+def test_row_e_serializavel():
+    row = build_row(
+        _record(), _coded(), model="kimi-k3", codebook_version="2.2.0", image_source=None
+    )
+    assert json.loads(json.dumps(row, ensure_ascii=False))["item_id"] == "abc-123"
+
+
+# --------------------------------------------------------------------------
+# Esquema
+# --------------------------------------------------------------------------
+
+
+def test_schema_nao_pede_composto_por_padrao():
+    schema = build_output_schema()
+    indicadores = schema["properties"]["indicadores"]["properties"]
+    assert "purificacao_composto" not in indicadores
+    assert set(INDICATOR_KEYS).issubset(indicadores)
+
+
+def test_schema_com_composto_em_opt_in():
+    schema = build_output_schema(emit_composto=True)
+    assert "purificacao_composto" in schema["properties"]["indicadores"]["properties"]
+
+
+def test_schema_exige_justificativa_e_confianca():
+    required = build_output_schema()["required"]
+    assert "justificativa" in required
+    assert "confianca" in required
+
+
+# --------------------------------------------------------------------------
+# Seleção, retomada e conteúdo
+# --------------------------------------------------------------------------
+
+
+def test_select_items_pula_itens_ja_em_staging():
+    records = [_record(), {**_record(), "item_id": "def-456"}]
+    selecionados = select_items(
+        records, None, None, None, None, done={"abc-123"}, force=False
+    )
+    assert [r["item_id"] for r in selecionados] == ["def-456"]
+
+
+def test_select_items_com_force_recodifica():
+    records = [_record()]
+    selecionados = select_items(
+        records, None, None, None, None, done={"abc-123"}, force=True
+    )
+    assert len(selecionados) == 1
+
+
+def test_select_items_filtra_por_regime_e_origem():
+    records = [_record(), {**_record(), "item_id": "def-456"}]
+    records[1]["purificacao"] = {
+        "coded_by": "vault-import",
+        "regime_iconocratico": "militar",
+    }
+    assert [
+        r["item_id"]
+        for r in select_items(records, None, "militar", None, None, set(), False)
+    ] == ["def-456"]
+    assert [
+        r["item_id"]
+        for r in select_items(records, None, None, "ana", None, set(), False)
+    ] == ["abc-123"]
+
+
+def test_load_done_ignora_linha_corrompida(tmp_path):
+    path = tmp_path / "runs.jsonl"
+    path.write_text(
+        json.dumps({"item_id": "a"}) + "\n{quebrado\n" + json.dumps({"item_id": "b"}) + "\n",
+        encoding="utf-8",
+    )
+    assert load_done(path) == {"a", "b"}
+
+
+def test_user_content_sem_imagem_instrui_nc():
+    content = build_user_content(_record(), None, None)
+    assert len(content) == 1
+    assert "nc_causa=sem_imagem" in content[0]["text"]
+
+
+def test_user_content_com_imagem_anexa_base64():
+    content = build_user_content(_record(), "QUJD", "image/jpeg")
+    assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")

--- a/tests/tools/test_iconocode_gemma4.py
+++ b/tests/tools/test_iconocode_gemma4.py
@@ -146,7 +146,7 @@ def test_round_trip_through_schema(tmp_path):
         "panofsky",
         "indicators",
         "regime",
-        "endurecimento_score",
+        "inventario_verbal",
         "reasoning",
         "image_hash",
         "confidence",
@@ -157,10 +157,13 @@ def test_round_trip_through_schema(tmp_path):
     assert set(reparsed["indicators"].keys()) == set(mod.INDICATOR_KEYS)
     for v in reparsed["indicators"].values():
         assert 0 <= v <= 3
-    # endurecimento_score = mean of 10 indicators
-    assert reparsed["endurecimento_score"] == round(
-        sum(reparsed["indicators"].values()) / 10, 2
-    )
+    # Composto aposentado no codebook v2.2.1 (DEC-2026-07-28): o registro leva
+    # inventário verbal dos atributos marcados (>= 2), não a média dos indicadores.
+    assert "endurecimento_score" not in reparsed
+    esperado = [
+        k for k in mod.INDICATOR_KEYS if reparsed["indicators"].get(k, 0) >= 2
+    ]
+    assert reparsed["inventario_verbal"] == esperado
     # Regime must be one of the four canonical values
     assert reparsed["regime"] in mod.VALID_REGIMES
 

--- a/tools/audit/mnemosyne/starter-8panels.json
+++ b/tools/audit/mnemosyne/starter-8panels.json
@@ -304,7 +304,7 @@
     "4": {
       "panelId": 4,
       "panelName": "ENDURECIMENTO",
-      "thesis_claim": "Existe uma trajetória ordenada cuja medida (endurecimento_score) cresce monotonicamente no tempo, atravessando regimes (fundacional → normativo → militar), nas escalas individual, nacional e transnacional.",
+      "thesis_claim": "O corpo alegórico feminino acumula atributos de endurecimento — desincorporação, rigidez postural, heraldização, enquadramento arquitetônico, serialidade — à medida que o Estado o convoca para funções normativas e militares. A demonstração é montagem: inventários comparados de atributos entre casos, nas escalas individual, nacional e transnacional, sem curva agregada e sem afirmação de monotonia.",
       "expected_relations": [
         "Endurecimento progressivo",
         "Martialização",
@@ -396,7 +396,7 @@
       "threads": [],
       "essay": {
         "title": "Painel 4 — ENDURECIMENTO",
-        "body": "# ENDURECIMENTO\n\n**Tese:** Existe uma trajetória ordenada cuja medida (endurecimento_score) cresce monotonicamente no tempo, atravessando regimes (fundacional → normativo → militar), nas escalas individual, nacional e transnacional.\n\n**Período:** 1870–1943\n**Regime primário:** militar\n**Relações esperadas:** Endurecimento progressivo, Martialização, Serialização, Genealogia\n\n---\n\n## Argumento\n\n[escrever durante a sessão]\n\n## Fios desenhados\n\n[lista automática após exportar]\n"
+        "body": "# ENDURECIMENTO\n\n**Tese:** O corpo alegórico feminino acumula atributos de endurecimento — desincorporação, rigidez postural, heraldização, enquadramento arquitetônico, serialidade — à medida que o Estado o convoca para funções normativas e militares. A demonstração é montagem: inventários comparados de atributos entre casos, nas escalas individual, nacional e transnacional, sem curva agregada e sem afirmação de monotonia.\n\n> Nota de instrumento: o índice composto foi aposentado no codebook v2.2.1 (DEC-2026-07-28). Este painel compara inventários verbais de atributos, não escores. Onde o argumento antes dizia \"a medida cresce\", ele agora precisa mostrar QUAIS atributos entram, quais saem e em que suporte.\n\n**Período:** 1870–1943\n**Regime primário:** militar\n**Relações esperadas:** Endurecimento progressivo, Martialização, Serialização, Genealogia\n\n---\n\n## Argumento\n\n[escrever durante a sessão]\n\n## Fios desenhados\n\n[lista automática após exportar]\n"
       }
     },
     "5": {

--- a/tools/audit/reports/french-panofsky-audit.md
+++ b/tools/audit/reports/french-panofsky-audit.md
@@ -90,7 +90,7 @@ A inspeção do campo `coded_by` revela três grupos:
 Todas as **dez entradas dos Emprunts de la Défense Nationale (1916–1920)** estão sem qualquer codificação. Trata-se de um cluster militar/normativo de transição que pode ser codificado em lote: cartazes de empréstimo de guerra com iconografia republicana, mesmo gênero, mesmo período, mesma função propagandística. Sugere campanha única de codificação.
 
 ### Padrão 3 — Indicadores presentes, Panofsky ausente (irregular)
-Entradas como FR-013, FR-014, FR-015–017, FR-018, FR-PIAST-1885, FR-SEM-1898, FR-HERC-1870 têm `endurecimento_score` calculado a partir dos `indicadores`, **mas o texto Panofsky que justificaria esses scores não foi registrado.** Para a tese ser defensável, cada score numérico precisa ter texto descritivo de suporte. **Esta é a lacuna mais crítica.**
+Entradas como FR-013, FR-014, FR-015–017, FR-018, FR-PIAST-1885, FR-SEM-1898, FR-HERC-1870 têm `indicadores` preenchidos e `endurecimento_score` legado, **mas o texto Panofsky que justificaria essa codificação não foi registrado.** Esta lacuna foi uma das razões da aposentadoria do índice composto no codebook v2.2.1 (DEC-2026-07-28): o número sobrevivia sozinho, sem a descrição que o sustentaria. Para a tese ser defensável, cada indicador marcado precisa de texto descritivo de suporte. **Esta é a lacuna mais crítica.**
 
 ### Padrão 4 — Campo `iconological.regime` em texto curto
 Para as 10 entradas com Panofsky parcial, o `iconological.regime` aparece como rótulo categórico (ex.: "FUNDACIONAL", "NORMATIVO transitioning to NORMATIVO") em vez de **análise iconológica de regime**. O campo deveria conter o terceiro nível de Panofsky — leitura simbólica do regime iconocrático em que a obra opera —, não apenas redundância da tag categórica `regime`.
@@ -108,7 +108,7 @@ Para as 10 entradas com Panofsky parcial, o `iconological.regime` aparece como r
 - [ ] **FR-017** (Necker 1781, variante 3) — idem FR-015.
 - [ ] **FR-018** (Ernouf, 1796) — Preencher Panofsky completo. Tese: modulação directorial, fusão alegoria/retrato individual.
 - [ ] **FR-012 vs FR-021** (Delacroix duplicado) — Decidir entrada canônica. Sugerido: manter **FR-012**; excluir FR-021 do corpus. Atualizar JSON, atlas, citações.
-- [ ] **FR-021** (Delacroix sem regime) — se for mantida em vez de FR-012, completar `regime`, `indicadores` (10), `endurecimento_score`, Panofsky completo.
+- [ ] **FR-021** (Delacroix sem regime) — se for mantida em vez de FR-012, completar `regime`, `indicadores` (10), inventário verbal de atributos e Panofsky completo. Não calcular composto (aposentado em v2.2.1).
 
 ### TIER 2 — Entradas fundacionais e numismáticas citáveis (urgência média)
 
@@ -134,7 +134,7 @@ Codificação ausente nas 10 entradas a seguir; mesmo gênero, podem ser codific
 - [ ] **FR-028** Prêtez à la France (1920)
 - [ ] **FR-029** Emprunt national 1920 — Société centrale des banques (1920)
 
-Para cada uma: atribuir `regime` (provável: militar ou normativo-militar), preencher 10 `indicadores`, calcular `endurecimento_score`, redigir Panofsky completo.
+Para cada uma: atribuir `regime` (provável: militar ou normativo-militar), preencher os 10 `indicadores`, registrar o inventário verbal dos atributos marcados e redigir Panofsky completo. Não calcular composto (aposentado em v2.2.1).
 
 ### TIER 4 — Aprimoramento dos campos "Thin" existentes
 

--- a/tools/audit/reports/systematic-review-conversation.md
+++ b/tools/audit/reports/systematic-review-conversation.md
@@ -136,7 +136,7 @@ Cada artefato foi avaliado em três dimensões: **completude** (o artefato faz o
 ### Tier A — bloqueadores para o Cap. 3
 - [ ] Codificar Panofsky completo para FR-013, FR-014, FR-015, FR-016, FR-017, FR-018
 - [ ] Deduplicar FR-012/FR-021 (manter FR-012)
-- [ ] Atualizar campo `regime` e `endurecimento_score` em FR-021 caso seja a entrada canônica
+- [ ] Atualizar campo `regime` e o inventário de `indicadores` em FR-021 caso seja a entrada canônica (composto aposentado em v2.2.1)
 
 ### Tier B — bloqueadores para qualificação
 - [ ] Desenhar ≥10 fios por painel Mnemosyne (≥80 fios totais) usando a taxonomia v0.1

--- a/tools/audit/scripts/analyze_threads.py
+++ b/tools/audit/scripts/analyze_threads.py
@@ -25,6 +25,11 @@ Outputs:
 import json, sys, os
 from pathlib import Path
 from collections import defaultdict, Counter
+# Composto aposentado no codebook v2.2.1 (DEC-2026-07-28): ordenação e
+# comparação passam a usar o inventário de atributos, não o escore agregado.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.scripts.lpai_indicators import attribute_count, attribute_inventory  # noqa: E402
+
 
 # ============================================================================
 # CONFIG — Taxonomy template (provisional; refines from data)
@@ -107,12 +112,14 @@ def make_demo_panels(corpus_by_id):
         'essay': {'title': 'Gênese', 'body': 'demo'},
     })
     
-    # Panel 4 — ENDURECIMENTO — score progression
-    sorted_by_score = sorted(
-        [(eid, e) for eid, e in corpus_by_id.items() if (e.get('endurecimento_score') or 0) > 0],
-        key=lambda x: x[1].get('endurecimento_score') or 0
+    # Panel 4 — ENDURECIMENTO — inventário comparado de atributos
+    # (composto aposentado no codebook v2.2.1: ordena-se por quantidade de
+    # atributos marcados, que não afirma intensidade, só cardinalidade)
+    sorted_by_attrs = sorted(
+        [(eid, e) for eid, e in corpus_by_id.items() if attribute_count(e) > 0],
+        key=lambda x: attribute_count(x[1])
     )
-    p4_items = [eid for eid, _ in sorted_by_score[:3]] + [eid for eid, _ in sorted_by_score[-4:]]
+    p4_items = [eid for eid, _ in sorted_by_attrs[:3]] + [eid for eid, _ in sorted_by_attrs[-4:]]
     panels.append({
         'panelId': 4, 'panelName': 'ENDURECIMENTO',
         'placements': [{'uid': f'p-4-{i}', 'id': eid, 'x':100+i*200, 'y':200} 
@@ -176,8 +183,8 @@ def expand_threads(panels, corpus_by_id):
                 'a_year': a_entry.get('year'), 'b_year': b_entry.get('year'),
                 'a_country': a_entry.get('country', ''), 'b_country': b_entry.get('country', ''),
                 'a_regime': a_entry.get('regime', ''), 'b_regime': b_entry.get('regime', ''),
-                'a_score': a_entry.get('endurecimento_score', 0),
-                'b_score': b_entry.get('endurecimento_score', 0),
+                'a_attrs': attribute_count(a_entry),
+                'b_attrs': attribute_count(b_entry),
                 'a_motifs': a_entry.get('motif', []) or [],
                 'b_motifs': b_entry.get('motif', []) or [],
                 'a_pathos': get_pathos(a_entry),

--- a/tools/audit/scripts/analyze_threads_v2.py
+++ b/tools/audit/scripts/analyze_threads_v2.py
@@ -27,6 +27,11 @@ import json
 import sys
 from pathlib import Path
 from collections import defaultdict, Counter
+# Composto aposentado no codebook v2.2.1 (DEC-2026-07-28): ordenação e
+# comparação passam a usar o inventário de atributos, não o escore agregado.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from tools.scripts.lpai_indicators import attribute_count, attribute_inventory  # noqa: E402
+
 
 # ============================================================================
 # TAXONOMY v0.2 — full type system
@@ -223,9 +228,9 @@ def classify_binary(thread, corpus_by_id):
 
     # === Sub-types of Genealogia ===
     if 'internal_to_country' in flags and 'cross_regime' in flags:
-        a_score = a.get('endurecimento_score') or 0
-        b_score = b.get('endurecimento_score') or 0
-        if a_year < b_year and b_score > a_score + 0.2:
+        a_attrs = attribute_count(a)
+        b_attrs = attribute_count(b)
+        if a_year < b_year and b_attrs > a_attrs:
             candidates.append(('genealogia_ascendente', 0.85))
     if a_regime == 'contra-alegoria' or b_regime == 'contra-alegoria':
         if shared_motifs and delta_year < 100:
@@ -328,7 +333,7 @@ def classify_chain(chain, corpus_by_id):
         return [('incomplete_chain', 0.0)]
 
     years = [e.get('year') or 0 for e in entries]
-    scores = [e.get('endurecimento_score') or 0 for e in entries]
+    attrs = [attribute_count(e) for e in entries]
     countries = [e.get('country', '') for e in entries]
 
     if not all(years[i] <= years[i+1] for i in range(len(years)-1)):
@@ -337,28 +342,31 @@ def classify_chain(chain, corpus_by_id):
     candidates = []
 
     # Endurecimento progressivo (strict monotonic OR with militar inflection)
-    monotonic_score = all(scores[i] <= scores[i+1] + 0.3 for i in range(len(scores)-1))
+    # Acréscimo de atributos ao longo da cadeia — cardinalidade, não curva.
+    monotonic_score = all(attrs[i] <= attrs[i+1] for i in range(len(attrs)-1))
     regimes = [e.get('regime', '') for e in entries]
 
-    # Detect 'militar inflection': cadeia que cresce monotonicamente até atingir regime militar,
-    # depois pode quebrar (regime militar tende a baixar score por mobilização tópica)
+    # Detect 'militar inflection': cadeia que acumula atributos até atingir regime
+    # militar, depois pode quebrar (o regime militar tende a reduzir o número de
+    # atributos marcados por mobilização tópica)
     has_militar_inflection = False
     if 'militar' in regimes:
         idx_first_militar = regimes.index('militar')
-        pre_militar = scores[:idx_first_militar]  # excludes militar item itself
-        if len(pre_militar) >= 2 and all(pre_militar[i] <= pre_militar[i+1] + 0.3 for i in range(len(pre_militar)-1)):
-            if pre_militar[-1] - pre_militar[0] >= 0.4:
+        pre_militar = attrs[:idx_first_militar]  # excludes militar item itself
+        if len(pre_militar) >= 2 and all(pre_militar[i] <= pre_militar[i+1] for i in range(len(pre_militar)-1)):
+            if pre_militar[-1] - pre_militar[0] >= 1:
                 has_militar_inflection = True
 
-    delta_pre_max = max(scores) - scores[0] if len(scores) >= 2 else 0
-    delta_total = scores[-1] - scores[0] if len(scores) >= 2 else 0
+    # Deltas em CONTAGEM de atributos (inteiros), não em média de escore.
+    delta_pre_max = max(attrs) - attrs[0] if len(attrs) >= 2 else 0
+    delta_total = attrs[-1] - attrs[0] if len(attrs) >= 2 else 0
 
-    if monotonic_score and delta_total >= 0.5:
+    if monotonic_score and delta_total >= 2:
         if len(set(countries)) >= 2:
             candidates.append(('endurecimento_cross_country', 0.9))
         else:
             candidates.append(('endurecimento_progressivo', 0.95))
-    elif has_militar_inflection and delta_pre_max >= 0.5:
+    elif has_militar_inflection and delta_pre_max >= 2:
         # Cadeia válida com inflexão militar
         if len(set(countries)) >= 2:
             candidates.append(('endurecimento_cross_country', 0.8))
@@ -639,7 +647,10 @@ def build_chain_report(chains, corpus_by_id):
         scores_str = ''
         for iid in c['item_ids']:
             e = corpus_by_id.get(iid, {})
-            scores_str += f"- `{iid}` ({e.get('year','?')}) · {e.get('regime','-')} · ⬥{e.get('endurecimento_score',0):.1f} · {e.get('country','-')}\n"
+            scores_str += (f"- `{iid}` ({e.get('year','?')}) · {e.get('regime','-')} · "
+                           f"⬥{attribute_count(e)} atributos"
+                           + (f" [{', '.join(attribute_inventory(e))}]" if attribute_inventory(e) else "")
+                           + f" · {e.get('country','-')}\n")
         md.append("**Itens:**\n" + scores_str + "\n")
     return '\n'.join(md)
 

--- a/tools/schemas/master-record.schema.json
+++ b/tools/schemas/master-record.schema.json
@@ -136,7 +136,9 @@
         "purificacao_composto": {
           "type": "number",
           "minimum": 0,
-          "maximum": 3
+          "maximum": 3,
+          "deprecated": true,
+          "description": "LEGACY_FROZEN desde codebook v2.2.1 (decisao DEC-2026-07-28-COMPOSTO). Media aritmetica dos 10 indicadores. Nao emitir em codificacao nova; valores existentes sao conservados sem recalculo e sem valor probatorio."
         },
         "regime_iconocratico": {
           "type": "string",
@@ -259,11 +261,17 @@
           "type": "boolean"
         },
         "programa_id": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional v2.2.0 grouping identifier for figures or records that belong to the same iconographic program."
         },
         "ordem_no_programa": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "minimum": 1,
           "description": "Optional v2.2.0 ordinal position inside programa_id."
         },
@@ -295,7 +303,11 @@
         },
         "confianca_codificacao": {
           "type": "string",
-          "enum": ["alta", "media", "baixa"],
+          "enum": [
+            "alta",
+            "media",
+            "baixa"
+          ],
           "description": "Optional v2.2.0 qualitative confidence label for human-readable methodology."
         },
         "motivo_incerteza": {
@@ -305,7 +317,13 @@
         },
         "relacao_com_repertorio_indigena": {
           "type": "string",
-          "enum": ["ausente", "apropriado", "coexistente", "hibridizado", "nao_aplicavel"],
+          "enum": [
+            "ausente",
+            "apropriado",
+            "coexistente",
+            "hibridizado",
+            "nao_aplicavel"
+          ],
           "description": "Optional v2.2.0 relation to Indigenous repertoires when analytically relevant."
         },
         "disjuncao_representa_governa": {
@@ -314,19 +332,25 @@
         },
         "objetos_regalia": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true,
           "description": "Optional v2.2.0 decomposition of atributos_iconograficos into objects/regalia."
         },
         "marcas_corporais": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true,
           "description": "Optional v2.2.0 decomposition of atributos_iconograficos into body, pose and clothing markers."
         },
         "marcadores_cena_arquitetura": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "uniqueItems": true,
           "description": "Optional v2.2.0 decomposition of atributos_iconograficos into scene and architecture markers."
         },

--- a/tools/schemas/purification-record.schema.json
+++ b/tools/schemas/purification-record.schema.json
@@ -7,12 +7,19 @@
   "additionalProperties": false,
   "required": [
     "id",
-    "desincorporacao", "rigidez_postural", "dessexualizacao",
-    "uniformizacao_facial", "heraldizacao", "enquadramento_arquitetonico",
-    "apagamento_narrativo", "monocromatizacao", "serialidade",
+    "desincorporacao",
+    "rigidez_postural",
+    "dessexualizacao",
+    "uniformizacao_facial",
+    "heraldizacao",
+    "enquadramento_arquitetonico",
+    "apagamento_narrativo",
+    "monocromatizacao",
+    "serialidade",
     "inscricao_estatal",
-    "purificacao_composto", "regime_iconocratico",
-    "coded_by", "coded_at"
+    "regime_iconocratico",
+    "coded_by",
+    "coded_at"
   ],
   "properties": {
     "id": {
@@ -27,25 +34,71 @@
       ],
       "description": "Corpus identifier (e.g., FR-013, BR-001, DE-NOTG-1921, SCOUT-558) or UUID for vault-imported pilot items"
     },
-    "desincorporacao":             { "type": "integer", "minimum": 0, "maximum": 3 },
-    "rigidez_postural":            { "type": "integer", "minimum": 0, "maximum": 3 },
-    "dessexualizacao":             { "type": "integer", "minimum": 0, "maximum": 3 },
-    "uniformizacao_facial":        { "type": "integer", "minimum": 0, "maximum": 3 },
-    "heraldizacao":                { "type": "integer", "minimum": 0, "maximum": 3 },
-    "enquadramento_arquitetonico": { "type": "integer", "minimum": 0, "maximum": 3 },
-    "apagamento_narrativo":        { "type": "integer", "minimum": 0, "maximum": 3 },
-    "monocromatizacao":            { "type": "integer", "minimum": 0, "maximum": 3 },
-    "serialidade":                 { "type": "integer", "minimum": 0, "maximum": 3 },
-    "inscricao_estatal":           { "type": "integer", "minimum": 0, "maximum": 3 },
+    "desincorporacao": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "rigidez_postural": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "dessexualizacao": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "uniformizacao_facial": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "heraldizacao": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "enquadramento_arquitetonico": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "apagamento_narrativo": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "monocromatizacao": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "serialidade": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "inscricao_estatal": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 3
+    },
     "purificacao_composto": {
       "type": "number",
       "minimum": 0,
       "maximum": 3,
-      "description": "Arithmetic mean of the 10 indicators"
+      "description": "LEGACY_FROZEN since codebook v2.2.1 (decision DEC-2026-07-28-COMPOSTO). Arithmetic mean of the 10 indicators. Optional and not to be emitted by new coding; legacy values are kept without recomputation and carry no evidentiary weight.",
+      "deprecated": true
     },
     "regime_iconocratico": {
       "type": "string",
-      "enum": ["fundacional", "normativo", "militar", "contra-alegoria"]
+      "enum": [
+        "fundacional",
+        "normativo",
+        "militar",
+        "contra-alegoria"
+      ]
     },
     "coded_by": {
       "type": "string",
@@ -72,7 +125,11 @@
     },
     "adjudication_status": {
       "type": "string",
-      "enum": ["single", "pending", "adjudicated"],
+      "enum": [
+        "single",
+        "pending",
+        "adjudicated"
+      ],
       "description": "Whether this record has been reviewed for inter-rater agreement"
     },
     "notes": {
@@ -84,11 +141,17 @@
       "description": "Country code of origin (e.g., BR, FR, US)"
     },
     "medium_norm": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Normalized medium descriptor"
     },
     "period": {
-      "type": ["string", "null"],
+      "type": [
+        "string",
+        "null"
+      ],
       "description": "Historical period classification"
     },
     "title": {

--- a/tools/scripts/README-automation.md
+++ b/tools/scripts/README-automation.md
@@ -185,3 +185,76 @@ jobs:
 4. **Documentar no AGENTS.md**
    - Adicionar seção sobre automação
    - Linkar para esta documentação
+
+## lpai_proxy_coder_k3.py
+
+Codificador-**proxy** LPAI v2 sobre Kimi K3 (Moonshot AI). Aplica o master
+prompt operacional do codebook (`schema/codebook-MASTER.md`, §16) a itens de
+`data/processed/records.jsonl` e grava capta de proxy em staging, para cálculo
+de concordância contra a codificação humana cega.
+
+**Não é um codificador humano e não tem autoridade.** Cada linha nasce com
+`proxy_only: true`, `authority: proxy`, `human_class: null` e
+`merge_policy: requires_human_adjudication`.
+
+### Barreiras de escrita
+
+1. O ledger canônico e os exports do corpus são abertos somente em leitura.
+2. O destino de saída é validado antes de qualquer chamada de API: precisa ser
+   `.jsonl`, precisa estar sob `data/staging/`, e não pode ser — nem morar
+   dentro de — arquivo ou diretório canônico (`data/processed/`, `corpus/`,
+   `examples/`, `schema/`, `tools/schemas/`).
+3. Violação encerra o processo com código 3, antes de gastar tokens.
+
+Testes das barreiras em `tests/test_lpai_proxy_coder_k3.py`.
+
+### Uso
+
+```bash
+export MOONSHOT_API_KEY=sk-...
+
+# ensaio: valida barreira, seleção e disponibilidade de imagem; não gasta nada
+python tools/scripts/lpai_proxy_coder_k3.py --all --limit 5 --dry-run
+
+# lote com imagens locais
+python tools/scripts/lpai_proxy_coder_k3.py --all --limit 40 \
+    --images-dir corpus/images
+
+# itens específicos
+python tools/scripts/lpai_proxy_coder_k3.py --items <item_id>,<item_id>
+
+# recorte por regime ou por origem de codificação (fila de baixa confiança)
+python tools/scripts/lpai_proxy_coder_k3.py --all --coded-by vault-import
+```
+
+### Parâmetros
+
+| Flag | Efeito |
+|---|---|
+| `--items` / `--all` | alvo do lote (mutuamente exclusivos) |
+| `--regime`, `--coded-by`, `--limit` | recortes de seleção |
+| `--images-dir` | imagens locais nomeadas `<item_id>.<ext>` |
+| `--allow-textual` | codificar item sem imagem (marcado `sem_imagem`) |
+| `--emit-composto` | opt-in explícito para `purificacao_composto` |
+| `--output` | caminho de staging alternativo (validado) |
+| `--force` | recodificar itens já presentes na saída |
+| `--dry-run` | não chama a API e não grava |
+
+### Códigos de saída
+
+`0` sucesso · `1` erro fatal · `2` concluído com itens de confiança baixa/NC ·
+`3` violação de barreira de escrita.
+
+### Nota metodológica pendente
+
+O §16 do codebook v2.2.0 pede `purificacao_composto` como média simples dos 10
+indicadores. A virada qualitativa de julho/2026 removeu o escore agregado e
+passou a tratar ENDURECIMENTO como inventário verbal. Enquanto a divergência
+não é resolvida no codebook, o script emite os 10 indicadores e um inventário
+verbal, mas **não** calcula o composto sem `--emit-composto`.
+
+### Retomada e cache
+
+Itens já presentes na saída são pulados (sobrescreva com `--force`). O prefixo
+do prompt é estável entre chamadas para maximizar acerto de cache — entrada em
+cache custa um décimo da entrada sem cache na API da Moonshot.

--- a/tools/scripts/README-automation.md
+++ b/tools/scripts/README-automation.md
@@ -235,7 +235,6 @@ python tools/scripts/lpai_proxy_coder_k3.py --all --coded-by vault-import
 | `--regime`, `--coded-by`, `--limit` | recortes de seleção |
 | `--images-dir` | imagens locais nomeadas `<item_id>.<ext>` |
 | `--allow-textual` | codificar item sem imagem (marcado `sem_imagem`) |
-| `--emit-composto` | opt-in explícito para `purificacao_composto` |
 | `--output` | caminho de staging alternativo (validado) |
 | `--force` | recodificar itens já presentes na saída |
 | `--dry-run` | não chama a API e não grava |
@@ -245,13 +244,14 @@ python tools/scripts/lpai_proxy_coder_k3.py --all --coded-by vault-import
 `0` sucesso · `1` erro fatal · `2` concluído com itens de confiança baixa/NC ·
 `3` violação de barreira de escrita.
 
-### Nota metodológica pendente
+### Índice composto: aposentado
 
-O §16 do codebook v2.2.0 pede `purificacao_composto` como média simples dos 10
-indicadores. A virada qualitativa de julho/2026 removeu o escore agregado e
-passou a tratar ENDURECIMENTO como inventário verbal. Enquanto a divergência
-não é resolvida no codebook, o script emite os 10 indicadores e um inventário
-verbal, mas **não** calcula o composto sem `--emit-composto`.
+A divergência entre o §16 (que pedia `purificacao_composto` como média dos 10
+indicadores) e a virada qualitativa de julho/2026 foi resolvida em
+[`docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md`](../../docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md).
+O codebook passou a v2.2.1: os indicadores permanecem como capta ordinal, a
+agregação sai, valores legados ficam congelados sem recálculo. O esquema de saída
+deste script não tem campo de composto e não existe flag que o reintroduza.
 
 ### Retomada e cache
 

--- a/tools/scripts/compute_irr.py
+++ b/tools/scripts/compute_irr.py
@@ -339,7 +339,8 @@ def report_paired(paired_codings: dict[str, list[dict]], bootstrap_ci_flag: bool
             composite_diffs.append(abs(c1 - c2))
 
     if composite_diffs:
-        print(f"\n  Composite score (purificacao_composto):")
+        print(f"\n  [LEGACY — diagnostic only, no evidentiary weight; codebook v2.2.1]")
+        print(f"  Composite score (purificacao_composto), legacy_frozen:")
         print(f"    Mean absolute difference: {np.mean(composite_diffs):.3f}")
         print(f"    Max  absolute difference: {max(composite_diffs):.3f}")
 
@@ -445,7 +446,8 @@ def report(all_codings: dict[str, list[dict]]) -> dict[str, Any] | None:
         if len(composites) >= 2:
             composite_diffs.append(max(composites) - min(composites))
     if composite_diffs:
-        print("\n  Composite score (purificacao_composto):")
+        print("\n  [LEGACY — diagnostic only, no evidentiary weight; codebook v2.2.1]")
+        print("  Composite score (purificacao_composto), legacy_frozen:")
         print(f"    Mean absolute difference: {np.mean(composite_diffs):.3f}")
         print(f"    Max  absolute difference: {max(composite_diffs):.3f}")
 

--- a/tools/scripts/csv_to_records.py
+++ b/tools/scripts/csv_to_records.py
@@ -23,6 +23,8 @@ import sys
 import tempfile
 import uuid
 from pathlib import Path
+from tools.scripts.lpai_indicators import coding_coverage, legacy_composite
+
 
 REPO = Path(__file__).resolve().parent.parent.parent
 CORPUS_JSON = REPO / "corpus" / "corpus-data.json"
@@ -207,9 +209,13 @@ def _build_iconocode(item: dict) -> dict:
             "confidence": 0.5,
         }]
 
-    # Confidence from endurecimento_score (0–3 normalised to 0–1)
-    raw_score = _safe_float(item.get("endurecimento_score", 1.5))
-    confidence = min(1.0, max(0.0, raw_score / 3.0))
+    # Confiança pela COBERTURA do instrumento, não pela média dos indicadores.
+    # O composto foi aposentado no codebook v2.2.1 (DEC-2026-07-28): derivar
+    # confiança da média confundia intensidade de endurecimento com qualidade
+    # da codificação. Cobertura mede o que interessa aqui — quanto do
+    # instrumento foi efetivamente aplicado a este item.
+    coverage = coding_coverage(item)
+    confidence = 0.35 + 0.55 * coverage
 
     return {
         "pre_iconographic": pre_iconographic,
@@ -244,16 +250,20 @@ def _build_purificacao(item: dict, csv_row: dict | None) -> dict | None:
     ).lower()
     regime = regime_raw if regime_raw in VALID_REGIMES else "normativo"
 
-    # purificacao_composto
-    csv_comp = _safe_float(csv_row.get("purificacao_composto", 0)) if csv_row else 0
-    corpus_comp = _safe_float(item.get("endurecimento_score", 0))
-    composto = csv_comp if csv_comp else corpus_comp
+    # purificacao_composto: LEGACY_FROZEN desde o codebook v2.2.1
+    # (DEC-2026-07-28). Não se calcula composto novo. O valor legado é apenas
+    # repassado quando já existe na fonte, para preservar o rastro de como o
+    # corpus foi construído; quando ausente, o campo simplesmente não é escrito.
+    composto_legado = legacy_composite(csv_row) if csv_row else None
+    if composto_legado is None:
+        composto_legado = legacy_composite(item)
 
     coded_by = ((csv_row.get("coded_by") if csv_row else None) or item.get("coded_by") or "migration")
     coded_at = _normalize_datetime((csv_row.get("coded_at") if csv_row else None) or item.get("coded_at") or MIGRATION_TS)
 
     purif: dict = {col: ind[col] for col in PURIF_COLS}
-    purif["purificacao_composto"] = round(composto, 3)
+    if composto_legado is not None:
+        purif["purificacao_composto"] = round(composto_legado, 3)
     purif["regime_iconocratico"] = regime
     purif["coded_by"] = coded_by
     purif["coded_at"] = coded_at

--- a/tools/scripts/e3_firecrawl_recode.py
+++ b/tools/scripts/e3_firecrawl_recode.py
@@ -17,6 +17,8 @@ import time
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+from tools.scripts.lpai_indicators import attribute_inventory, is_uncoded
+
 
 REPO = Path(__file__).resolve().parent.parent.parent
 RECORDS_PATH = REPO / "data" / "processed" / "records.jsonl"
@@ -144,8 +146,10 @@ def main():
     all_items = load_pathos()
     records = load_records()
     
-    # Find items with score 0.0
-    zeros = {k: v for k, v in all_items.items() if v["purificacao_composto"] == 0.0}
+    # Fila de recodificação: itens SEM indicadores codificados. Antes o filtro
+    # era composto == 0.0, o que confundia "não codificado" com "codificado e
+    # baixo". O composto foi aposentado no codebook v2.2.1 (DEC-2026-07-28).
+    zeros = {k: v for k, v in all_items.items() if is_uncoded(v)}
     print(f"Items to recode: {len(zeros)}\n")
     
     successes = 0
@@ -214,7 +218,7 @@ def main():
             else:
                 regime = item.get("regime_iconocratico", "fundacional")
         
-        score = sum(indicators.values()) / len(indicators)
+        inventario = attribute_inventory(indicators)
         notes = parsed.get("notes", "")
         if isinstance(notes, dict):
             notes = str(list(notes.values())[0]) if notes.values() else ""
@@ -222,14 +226,14 @@ def main():
         
         updated_item = dict(item)
         updated_item.update(indicators)
-        updated_item["purificacao_composto"] = round(score, 1)
+        updated_item["inventario_verbal"] = inventario
         updated_item["regime_iconocratico"] = regime
         updated_item["notes"] = notes
         updated_item["coded_by"] = "e1-gemma4/gemma4-fcrecode"
         updated_item["coded_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         
         updated.append(updated_item)
-        print(f"score={score:.1f}, regime={regime}")
+        print(f"atributos={len(inventario)}, regime={regime}")
         successes += 1
         
         if i < len(zeros) - 1:

--- a/tools/scripts/iconocode_gemma4.py
+++ b/tools/scripts/iconocode_gemma4.py
@@ -43,6 +43,8 @@ from pathlib import Path
 from typing import Any
 
 import requests
+from tools.scripts.lpai_indicators import attribute_inventory
+
 
 REPO = Path(__file__).resolve().parent.parent.parent
 CORPUS_PATH = REPO / "corpus" / "corpus-data.json"
@@ -463,7 +465,9 @@ def build_staging_record(
 ) -> dict[str, Any]:
     """Assemble the JSONL line. Always produces a record, even on failure."""
     indicators = coerce_indicators((parsed or {}).get("indicators"))
-    mean = round(sum(indicators.values()) / len(indicators), 2)
+    # Composto aposentado no codebook v2.2.1 (DEC-2026-07-28): no lugar da
+    # média, o registro leva o inventário verbal dos atributos marcados.
+    inventario = attribute_inventory(indicators)
 
     regime = None
     if parsed and isinstance(parsed.get("regime"), str):
@@ -497,7 +501,7 @@ def build_staging_record(
         # the reconciliation-ready name so downstream arbitration works unchanged.
         "indicators": indicators,
         "regime": regime,
-        "endurecimento_score": mean,
+        "inventario_verbal": inventario,
         "reasoning": reasoning,
         "image_hash": image_hash,
         "confidence": confidence,
@@ -679,7 +683,8 @@ def main(argv: list[str] | None = None) -> int:
 
         append_jsonl(args.output, record)
         print(
-            f"  -> {record['confidence']} | regime={record['regime']} | mean={record['endurecimento_score']}",
+            f"  -> {record['confidence']} | regime={record['regime']} | "
+            f"atributos={len(record['inventario_verbal'])}",
             file=sys.stderr,
         )
         if record["confidence"] == "low":

--- a/tools/scripts/lpai_indicators.py
+++ b/tools/scripts/lpai_indicators.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+lpai_indicators.py — leitura não agregadora dos indicadores LPAI v2.
+
+Substitui `endurecimento_score` / `purificacao_composto` nos consumidores do
+corpus. O índice composto foi aposentado no codebook v2.2.1 (decisão
+`docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md`): a média tratava
+como intercambiáveis indicadores incomensuráveis e comprimia dez decisões
+interpretativas em um número que sobrevivia sozinho nas tabelas.
+
+O que este módulo oferece no lugar:
+
+  * `attribute_inventory` — a lista nomeada dos atributos efetivamente marcados.
+    É a unidade de comparação da tese: inventário verbal, não escalar.
+  * `attribute_count` — cardinalidade do inventário. Serve para ordenar e
+    comparar sem afirmar intensidade. Contar quantos atributos estão presentes
+    não é o mesmo que mediar valores incomensuráveis: a contagem não converte
+    `monocromatizacao` e `dessexualizacao` em uma grandeza comum, apenas informa
+    quantos traços o codificador registrou.
+  * `coding_coverage` — quanto do instrumento foi efetivamente aplicado. Mede
+    completude de codificação, não endurecimento.
+  * `legacy_composite` — acessor SOMENTE de leitura para valores congelados.
+    Nunca calcula. Existe para relatórios de diagnóstico legado.
+
+Nenhuma função deste módulo cria um composto novo.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+INDICATOR_KEYS: tuple[str, ...] = (
+    "desincorporacao",
+    "rigidez_postural",
+    "dessexualizacao",
+    "uniformizacao_facial",
+    "heraldizacao",
+    "enquadramento_arquitetonico",
+    "apagamento_narrativo",
+    "monocromatizacao",
+    "serialidade",
+    "inscricao_estatal",
+)
+
+# Escala 0–3 do codebook: 2 e 3 significam atributo presente de modo marcado.
+ATTRIBUTE_THRESHOLD = 2
+
+_NESTED_KEYS = ("indicadores", "indicators", "purificacao")
+
+
+def indicator_values(entry: Mapping[str, Any] | None) -> dict[str, int]:
+    """Extrai os 10 indicadores, aceitando forma achatada ou aninhada.
+
+    Aceita `{"indicadores": {...}}`, `{"indicators": {...}}`,
+    `{"purificacao": {...}}` e o registro achatado. Chaves ausentes ficam
+    ausentes: ausência não é zero.
+    """
+    if not entry:
+        return {}
+
+    fontes: list[Mapping[str, Any]] = [entry]
+    for key in _NESTED_KEYS:
+        nested = entry.get(key)
+        if isinstance(nested, Mapping):
+            fontes.append(nested)
+
+    valores: dict[str, int] = {}
+    for fonte in fontes:
+        for key in INDICATOR_KEYS:
+            if key in valores:
+                continue
+            bruto = fonte.get(key)
+            if bruto is None or isinstance(bruto, bool):
+                continue
+            try:
+                valores[key] = int(bruto)
+            except (TypeError, ValueError):
+                continue
+    return valores
+
+
+def attribute_inventory(
+    entry: Mapping[str, Any] | None, threshold: int = ATTRIBUTE_THRESHOLD
+) -> list[str]:
+    """Inventário verbal: nomes dos atributos marcados, em ordem canônica."""
+    valores = indicator_values(entry)
+    return [key for key in INDICATOR_KEYS if valores.get(key, 0) >= threshold]
+
+
+def attribute_count(
+    entry: Mapping[str, Any] | None, threshold: int = ATTRIBUTE_THRESHOLD
+) -> int:
+    """Quantidade de atributos marcados. Ordena sem afirmar intensidade."""
+    return len(attribute_inventory(entry, threshold))
+
+
+def coding_coverage(entry: Mapping[str, Any] | None) -> float:
+    """Fração dos 10 indicadores explicitamente presentes na fonte (0.0–1.0)."""
+    return len(indicator_values(entry)) / len(INDICATOR_KEYS)
+
+
+def is_uncoded(entry: Mapping[str, Any] | None) -> bool:
+    """Item sem codificação de indicadores: nenhum presente, ou todos em zero."""
+    valores = indicator_values(entry)
+    return not valores or all(valor == 0 for valor in valores.values())
+
+
+def legacy_composite(entry: Mapping[str, Any] | None) -> float | None:
+    """Valor legado congelado, se existir. NUNCA calcula um novo.
+
+    Aceita os dois nomes históricos (`purificacao_composto` no ledger,
+    `endurecimento_score` nos exports antigos). Retorna None quando ausente.
+    """
+    if not entry:
+        return None
+    fontes: list[Mapping[str, Any]] = [entry]
+    nested = entry.get("purificacao")
+    if isinstance(nested, Mapping):
+        fontes.append(nested)
+    for fonte in fontes:
+        for nome in ("purificacao_composto", "endurecimento_score"):
+            bruto = fonte.get(nome)
+            if bruto is None:
+                continue
+            try:
+                return float(bruto)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def describe_inventory(entry: Mapping[str, Any] | None) -> str:
+    """Rótulo curto para logs e relatórios: contagem + atributos."""
+    inventario = attribute_inventory(entry)
+    if not inventario:
+        return "sem atributos marcados"
+    return f"{len(inventario)} atributos: " + ", ".join(inventario)

--- a/tools/scripts/lpai_proxy_coder_k3.py
+++ b/tools/scripts/lpai_proxy_coder_k3.py
@@ -1,0 +1,781 @@
+#!/usr/bin/env python3
+"""
+lpai_proxy_coder_k3.py — Codificador-proxy LPAI v2 sobre Kimi K3 (Moonshot AI).
+
+Aplica o master prompt operacional do codebook (`schema/codebook-MASTER.md`,
+§16) a itens do corpus ICONOCRACY e grava capta iconográfico *de proxy* em um
+arquivo de staging separado. O objetivo é medir concordância (kappa) contra a
+codificação humana cega, não substituí-la.
+
+Instrumento e autoridade
+------------------------
+  * Instrumento: §16 do codebook MASTER, lido em tempo de execução. O script
+    NÃO reescreve nem parafraseia o prompt — a fidelidade do instrumento é o
+    que torna o kappa defensável. `codebook_version` é registrado em cada linha.
+  * Autoridade: nenhuma. Toda linha nasce com `proxy_only: true` e
+    `merge_policy: requires_human_adjudication`. A classe humana permanece
+    vazia por construção.
+
+Barreiras de escrita (guardrails)
+---------------------------------
+  1. `data/processed/records.jsonl` e os arquivos de export do corpus são
+     abertos SOMENTE em leitura. Não existe caminho de código que os escreva.
+  2. O destino de saída é validado antes de qualquer chamada de API:
+     precisa ser `.jsonl`, precisa estar sob a raiz de staging e não pode ser
+     — nem morar dentro de — nenhum arquivo/diretório canônico.
+  3. Violação de barreira encerra o processo com código 3, antes de gastar
+     um único token.
+
+Nota metodológica pendente (ver corpo do PR)
+--------------------------------------------
+O §16 do codebook v2.2.0 pede `purificacao_composto` como média simples dos
+10 indicadores. A virada qualitativa de julho/2026 removeu o escore agregado e
+passou a tratar ENDURECIMENTO como inventário verbal de atributos. Enquanto a
+divergência não é resolvida no codebook, este script emite os 10 indicadores
+(capta ordinal previsto pelo schema) e um inventário verbal, mas **não** calcula
+o composto — a menos que `--emit-composto` seja passado explicitamente.
+
+Uso
+---
+    export MOONSHOT_API_KEY=sk-...
+    python tools/scripts/lpai_proxy_coder_k3.py --dry-run --limit 3
+    python tools/scripts/lpai_proxy_coder_k3.py --items <item_id>,<item_id>
+    python tools/scripts/lpai_proxy_coder_k3.py --all --limit 40
+
+Códigos de saída
+----------------
+    0 — sucesso; todos os itens codificados com confiança media|alta
+    1 — erro fatal (I/O, API, instrumento ausente)
+    2 — concluído, porém com itens de confiança baixa ou NC (sinal, não bloqueio)
+    3 — violação de barreira de escrita (nada foi gravado, nada foi gasto)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO = Path(__file__).resolve().parent.parent.parent
+
+# ---------------------------------------------------------------------------
+# Instrumento, entrada e saída
+# ---------------------------------------------------------------------------
+
+CODEBOOK_PATH = REPO / "schema" / "codebook-MASTER.md"
+CANONICAL_RECORDS = REPO / "data" / "processed" / "records.jsonl"
+DEFAULT_STAGING_ROOT = REPO / "data" / "staging"
+DEFAULT_OUTPUT_NAME = "lpai-proxy-k3-runs.jsonl"
+IMAGE_CACHE = REPO / ".cache" / "lpai-proxy-images"
+
+AGENT_ID = "lpai-proxy-k3"
+PROMPT_VERSION = "lpai-proxy-k3-v1"
+MODEL_DEFAULT = "kimi-k3"
+BASE_URL_DEFAULT = "https://api.moonshot.ai/v1"
+
+INDICATOR_KEYS: tuple[str, ...] = (
+    "desincorporacao",
+    "rigidez_postural",
+    "dessexualizacao",
+    "uniformizacao_facial",
+    "heraldizacao",
+    "enquadramento_arquitetonico",
+    "apagamento_narrativo",
+    "monocromatizacao",
+    "serialidade",
+    "inscricao_estatal",
+)
+
+REGIMES = ("fundacional", "normativo", "militar", "contra-alegoria")
+
+RECUSA_TIPOS = (
+    "substituicao_remasculinizante",
+    "negacao_pura",
+    "feminino_esvaziado",
+    "substituicao_neutro_abstrata",
+    "nenhuma",
+)
+
+# ---------------------------------------------------------------------------
+# Barreiras de escrita
+# ---------------------------------------------------------------------------
+
+CANONICAL_WRITE_FORBIDDEN: tuple[Path, ...] = (
+    REPO / "data" / "processed" / "records.jsonl",
+    REPO / "corpus" / "corpus-data.json",
+    REPO / "corpus" / "corpus-data.v2.json",
+    REPO / "corpus" / "corpus-data-enriched.json",
+    REPO / "corpus" / "companion-data.json",
+)
+
+FORBIDDEN_DIRS: tuple[Path, ...] = (
+    REPO / "data" / "processed",
+    REPO / "corpus",
+    REPO / "examples",
+    REPO / "schema",
+    REPO / "tools" / "schemas",
+)
+
+FORBIDDEN_BASENAMES: frozenset[str] = frozenset(
+    {
+        "records.jsonl",
+        "corpus-data.json",
+        "corpus-data.v2.json",
+        "corpus-data-enriched.json",
+        "companion-data.json",
+    }
+)
+
+
+class GuardrailError(RuntimeError):
+    """Tentativa de escrever fora da área de staging do proxy."""
+
+
+def staging_root() -> Path:
+    """Raiz permitida para saída. Sobrescritível apenas para teste."""
+    override = os.environ.get("LPAI_PROXY_STAGING_ROOT")
+    return Path(override).resolve() if override else DEFAULT_STAGING_ROOT.resolve()
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def assert_write_target(candidate: str | Path) -> Path:
+    """Valida o destino de saída ANTES de qualquer chamada de API.
+
+    Regras, em ordem: extensão `.jsonl`; nome de arquivo que não colida com
+    um artefato canônico; caminho que não seja nem more dentro de um arquivo
+    ou diretório canônico; caminho contido na raiz de staging.
+    """
+    path = Path(candidate).expanduser()
+    resolved = (path if path.is_absolute() else (Path.cwd() / path)).resolve()
+
+    if resolved.suffix != ".jsonl":
+        raise GuardrailError(
+            f"saída precisa ser .jsonl (recebido: {resolved.name})"
+        )
+
+    if resolved.name in FORBIDDEN_BASENAMES:
+        raise GuardrailError(
+            f"'{resolved.name}' é nome de artefato canônico do corpus; "
+            "o proxy nunca escreve nele"
+        )
+
+    for forbidden in CANONICAL_WRITE_FORBIDDEN:
+        if resolved == forbidden.resolve():
+            raise GuardrailError(f"destino canônico bloqueado: {resolved}")
+
+    for directory in FORBIDDEN_DIRS:
+        if _is_within(resolved, directory.resolve()):
+            raise GuardrailError(
+                f"'{directory.relative_to(REPO)}' guarda dados canônicos; "
+                f"saída de proxy não entra ali: {resolved}"
+            )
+
+    root = staging_root()
+    if not _is_within(resolved, root):
+        raise GuardrailError(
+            f"saída deve ficar sob {root} (recebido: {resolved})"
+        )
+
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Instrumento
+# ---------------------------------------------------------------------------
+
+
+def load_master_prompt(codebook_path: Path = CODEBOOK_PATH) -> tuple[str, str]:
+    """Extrai o master prompt operacional (§16) e a versão do codebook.
+
+    Lê o codebook em vez de duplicar o prompt no código: o instrumento tem uma
+    fonte única e a mudança dele fica visível no histórico do próprio codebook.
+    """
+    if not codebook_path.exists():
+        raise FileNotFoundError(f"codebook não encontrado: {codebook_path}")
+
+    text = codebook_path.read_text(encoding="utf-8")
+
+    version_match = re.search(r"^codebook_version:\s*(.+)$", text, re.MULTILINE)
+    version = version_match.group(1).strip() if version_match else "desconhecida"
+
+    section = re.search(
+        r"^## 16\..*?```text\n(.*?)```", text, re.MULTILINE | re.DOTALL
+    )
+    if not section:
+        raise ValueError(
+            "master prompt (§16) não encontrado em schema/codebook-MASTER.md"
+        )
+
+    return section.group(1).strip(), version
+
+
+PROXY_PREAMBLE = """\
+Você opera como CODIFICADOR-PROXY. Sua saída não tem autoridade: ela será
+comparada a codificação humana cega para cálculo de concordância.
+
+Restrições que se somam ao instrumento abaixo:
+- Não infira país, data ou suporte que não estejam nos metadados fornecidos.
+- Ausência significativa é dado negativo, não campo a preencher.
+- Confiança baixa e NC são respostas legítimas e preferíveis a chute.
+- Registre em `duvidas` tudo que precisa de decisão humana.
+- Não calcule médias, índices ou escores compostos.
+"""
+
+
+def build_system_prompt(master_prompt: str) -> str:
+    """Prefixo estável: constante entre chamadas, para aproveitar cache."""
+    return f"{PROXY_PREAMBLE}\n--- INSTRUMENTO LPAI (codebook §16) ---\n{master_prompt}"
+
+
+# ---------------------------------------------------------------------------
+# Esquema de saída estruturada
+# ---------------------------------------------------------------------------
+
+
+def build_output_schema(emit_composto: bool = False) -> dict[str, Any]:
+    indicadores = {
+        key: {"type": "integer", "minimum": 0, "maximum": 3}
+        for key in INDICATOR_KEYS
+    }
+    if emit_composto:
+        indicadores["purificacao_composto"] = {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 3,
+        }
+
+    return {
+        "type": "object",
+        "required": [
+            "item_id",
+            "codificavel",
+            "indicadores",
+            "inventario_verbal",
+            "confianca",
+            "justificativa",
+        ],
+        "properties": {
+            "item_id": {"type": "string"},
+            "codificavel": {
+                "type": "boolean",
+                "description": "a evidência permite codificação visual suficiente",
+            },
+            "indicadores": {
+                "type": "object",
+                "required": list(INDICATOR_KEYS),
+                "properties": indicadores,
+            },
+            "inventario_verbal": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "atributos observados em vocabulário iconográfico, sem escore",
+            },
+            "familia_alegorica": {
+                "type": "string",
+                "description": "Justitia, Libertas, Respublica, Marianne, Germania, "
+                "Britannia, Columbia, outra, ou NC",
+            },
+            "subtipo": {"type": "string"},
+            "regime_iconocratico": {
+                "type": "string",
+                "enum": [*REGIMES, "NC"],
+            },
+            "recusa": {"type": "string", "enum": list(RECUSA_TIPOS)},
+            "genero_atribuido": {"type": "string"},
+            "funcao_juridica": {"type": "string"},
+            "dado_negativo": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "ausências analiticamente relevantes",
+            },
+            "subaltern_caution": {"type": "boolean"},
+            "confianca": {"type": "string", "enum": ["alta", "media", "baixa"]},
+            "nc_causa": {
+                "type": "string",
+                "description": "obrigatório quando codificavel=false: "
+                "evidencia_insuficiente | ambiguidade | fora_de_escopo | sem_imagem",
+            },
+            "justificativa": {
+                "type": "string",
+                "description": "o que na evidência sustenta a codificação",
+            },
+            "duvidas": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Corpus (leitura) e seleção
+# ---------------------------------------------------------------------------
+
+
+def load_records(path: Path = CANONICAL_RECORDS) -> list[dict[str, Any]]:
+    """Leitura estrita do ledger canônico. Nunca abre em modo de escrita."""
+    if not path.exists():
+        raise FileNotFoundError(f"registros canônicos ausentes: {path}")
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number} JSON inválido: {exc}") from exc
+    return records
+
+
+def select_items(
+    records: Iterable[dict[str, Any]],
+    item_ids: list[str] | None,
+    regime: str | None,
+    coded_by: str | None,
+    limit: int | None,
+    done: set[str],
+    force: bool,
+) -> list[dict[str, Any]]:
+    selected = []
+    for record in records:
+        item_id = record.get("item_id")
+        if not item_id:
+            continue
+        if item_ids and item_id not in item_ids:
+            continue
+        purificacao = record.get("purificacao") or {}
+        if regime and purificacao.get("regime_iconocratico") != regime:
+            continue
+        if coded_by and purificacao.get("coded_by") != coded_by:
+            continue
+        if not force and item_id in done:
+            continue
+        selected.append(record)
+    if limit is not None:
+        selected = selected[:limit]
+    return selected
+
+
+def load_done(output_path: Path) -> set[str]:
+    """Retomada: itens já presentes na saída de staging."""
+    if not output_path.exists():
+        return set()
+    done: set[str] = set()
+    with output_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                done.add(json.loads(line).get("item_id", ""))
+            except json.JSONDecodeError:
+                continue
+    done.discard("")
+    return done
+
+
+# ---------------------------------------------------------------------------
+# Evidência visual — K3 aceita base64, não URL pública
+# ---------------------------------------------------------------------------
+
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".tif", ".tiff"}
+MIME_BY_SUFFIX = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+    ".tif": "image/tiff",
+    ".tiff": "image/tiff",
+}
+
+
+def local_image_for(item_id: str, images_dir: Path | None) -> Path | None:
+    if images_dir is None:
+        return None
+    for suffix in IMAGE_SUFFIXES:
+        candidate = images_dir / f"{item_id}{suffix}"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def cached_download(url: str, item_id: str) -> Path | None:
+    """Baixa a imagem para cache local. PDFs e HTML são recusados de propósito:
+    o proxy só codifica o que consegue ver."""
+    suffix = Path(url.split("?")[0]).suffix.lower()
+    if suffix not in IMAGE_SUFFIXES:
+        return None
+
+    IMAGE_CACHE.mkdir(parents=True, exist_ok=True)
+    target = IMAGE_CACHE / f"{item_id}{suffix}"
+    if target.exists() and target.stat().st_size > 0:
+        return target
+
+    try:
+        import requests  # dependência opcional, só no caminho de download
+    except ImportError:  # pragma: no cover
+        print("[aviso] requests ausente; use --images-dir", file=sys.stderr)
+        return None
+
+    try:
+        response = requests.get(url, timeout=60)
+        response.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 - rede é ruidosa por natureza
+        print(f"[aviso] download falhou ({item_id}): {exc}", file=sys.stderr)
+        return None
+
+    target.write_bytes(response.content)
+    return target
+
+
+def encode_image(path: Path) -> tuple[str, str]:
+    mime = MIME_BY_SUFFIX.get(path.suffix.lower(), "image/jpeg")
+    return base64.b64encode(path.read_bytes()).decode("ascii"), mime
+
+
+def build_user_content(
+    record: dict[str, Any], image_b64: str | None, mime: str | None
+) -> list[dict[str, Any]]:
+    entrada = record.get("input") or {}
+    metadados = {
+        "item_id": record.get("item_id"),
+        "titulo": entrada.get("title_hint"),
+        "data": entrada.get("date_hint"),
+        "local": entrada.get("place_hint"),
+        "fonte": entrada.get("input_url"),
+        "evidencia_webscout": (record.get("webscout") or {}).get("summary_evidence"),
+        "lacunas_declaradas": (record.get("webscout") or {}).get("gaps"),
+    }
+    texto = (
+        "Codifique o item abaixo conforme o instrumento LPAI.\n\n"
+        f"METADADOS CONHECIDOS (não os contradiga, não os complete por inferência):\n"
+        f"{json.dumps(metadados, ensure_ascii=False, indent=2)}\n\n"
+    )
+    if image_b64:
+        texto += "A imagem do item segue anexada."
+    else:
+        texto += (
+            "SEM IMAGEM DISPONÍVEL. Se a evidência textual não sustentar a "
+            "codificação visual, responda codificavel=false com "
+            "nc_causa=sem_imagem e confianca=baixa."
+        )
+
+    content: list[dict[str, Any]] = [{"type": "text", "text": texto}]
+    if image_b64:
+        content.append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{image_b64}"},
+            }
+        )
+    return content
+
+
+# ---------------------------------------------------------------------------
+# Chamada ao modelo
+# ---------------------------------------------------------------------------
+
+
+def make_client(base_url: str):
+    try:
+        from openai import OpenAI
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("pip install openai") from exc
+
+    api_key = os.environ.get("MOONSHOT_API_KEY")
+    if not api_key:
+        raise RuntimeError("defina MOONSHOT_API_KEY no ambiente")
+    return OpenAI(api_key=api_key, base_url=base_url)
+
+
+def call_model(
+    client: Any,
+    model: str,
+    system_prompt: str,
+    user_content: list[dict[str, Any]],
+    schema: dict[str, Any],
+    retries: int = 1,
+) -> dict[str, Any]:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "registrar_codificacao",
+                "description": "Registra a codificação LPAI de proxy do item.",
+                "parameters": schema,
+            },
+        }
+    ]
+    last_error: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    # prefixo estável primeiro: maximiza acerto de cache
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_content},
+                ],
+                tools=tools,
+                tool_choice={
+                    "type": "function",
+                    "function": {"name": "registrar_codificacao"},
+                },
+            )
+            call = response.choices[0].message.tool_calls[0]
+            payload = json.loads(call.function.arguments)
+            usage = getattr(response, "usage", None)
+            payload["_usage"] = (
+                usage.model_dump() if hasattr(usage, "model_dump") else None
+            )
+            return payload
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            if attempt < retries:
+                time.sleep(2 * (attempt + 1))
+    raise RuntimeError(f"chamada ao modelo falhou: {last_error}")
+
+
+# ---------------------------------------------------------------------------
+# Linha de staging
+# ---------------------------------------------------------------------------
+
+
+def build_row(
+    record: dict[str, Any],
+    coded: dict[str, Any],
+    *,
+    model: str,
+    codebook_version: str,
+    image_source: str | None,
+) -> dict[str, Any]:
+    """Envelope de proxy. Os campos de autoridade nascem vazios de propósito."""
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+    usage = coded.pop("_usage", None)
+    purificacao_humana = (record.get("purificacao") or {}).get("coded_by")
+
+    return {
+        "item_id": record.get("item_id"),
+        "item_hash": record.get("item_hash"),
+        "proxy_only": True,
+        "authority": "proxy",
+        "target_field": "purificacao_proposta",
+        "merge_policy": "requires_human_adjudication",
+        "human_class": None,
+        "human_coded_by_at_read_time": purificacao_humana,
+        "capta_declaration": (
+            "LPAI v2-capta: scores são atos interpretativos situados, "
+            "não dados neutros."
+        ),
+        "coded_by": AGENT_ID,
+        "coded_at": now,
+        "model": model,
+        "prompt_version": PROMPT_VERSION,
+        "codebook_version": codebook_version,
+        "image_source": image_source,
+        "usage": usage,
+        "proposta": coded,
+    }
+
+
+def append_row(output_path: Path, row: dict[str, Any]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Codificador-proxy LPAI v2 sobre Kimi K3 (saída em staging)."
+    )
+    alvo = parser.add_mutually_exclusive_group(required=True)
+    alvo.add_argument("--items", help="item_id[,item_id,...]")
+    alvo.add_argument("--all", action="store_true", help="todos os registros")
+
+    parser.add_argument("--regime", choices=REGIMES, help="filtra por regime")
+    parser.add_argument("--coded-by", help="filtra pela origem de codificação")
+    parser.add_argument("--limit", type=int, help="teto de itens no lote")
+    parser.add_argument("--output", help="caminho de staging (.jsonl)")
+    parser.add_argument("--images-dir", help="diretório de imagens locais <item_id>.<ext>")
+    parser.add_argument(
+        "--allow-textual",
+        action="store_true",
+        help="codificar itens sem imagem (registro é marcado sem_imagem)",
+    )
+    parser.add_argument(
+        "--emit-composto",
+        action="store_true",
+        help="opt-in explícito: pedir purificacao_composto (ver nota metodológica)",
+    )
+    parser.add_argument("--model", default=MODEL_DEFAULT)
+    parser.add_argument("--base-url", default=BASE_URL_DEFAULT)
+    parser.add_argument("--retries", type=int, default=1)
+    parser.add_argument("--force", action="store_true", help="recodificar já feitos")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="valida barreiras, seleção e evidência; não chama a API nem grava",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    output_default = staging_root() / DEFAULT_OUTPUT_NAME
+    try:
+        output_path = assert_write_target(args.output or output_default)
+    except GuardrailError as exc:
+        print(f"[barreira] {exc}", file=sys.stderr)
+        return 3
+
+    try:
+        master_prompt, codebook_version = load_master_prompt()
+        records = load_records()
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"[fatal] {exc}", file=sys.stderr)
+        return 1
+
+    item_ids = (
+        [i.strip() for i in args.items.split(",") if i.strip()] if args.items else None
+    )
+    done = set() if args.force else load_done(output_path)
+    selected = select_items(
+        records,
+        item_ids,
+        args.regime,
+        args.coded_by,
+        args.limit,
+        done,
+        args.force,
+    )
+
+    print(
+        f"corpus: {len(records)} registros | codebook {codebook_version} | "
+        f"selecionados: {len(selected)} | já em staging: {len(done)}",
+        file=sys.stderr,
+    )
+    print(f"saída: {output_path}", file=sys.stderr)
+    if not selected:
+        print("nada a fazer.", file=sys.stderr)
+        return 0
+
+    images_dir = Path(args.images_dir).expanduser() if args.images_dir else None
+    schema = build_output_schema(emit_composto=args.emit_composto)
+    system_prompt = build_system_prompt(master_prompt)
+
+    client = None
+    if not args.dry_run:
+        try:
+            client = make_client(args.base_url)
+        except RuntimeError as exc:
+            print(f"[fatal] {exc}", file=sys.stderr)
+            return 1
+
+    baixa_confianca = 0
+    sem_imagem = 0
+    falhas = 0
+
+    for index, record in enumerate(selected, start=1):
+        item_id = record["item_id"]
+        entrada = record.get("input") or {}
+
+        image_path = local_image_for(item_id, images_dir)
+        if image_path is None and not args.dry_run:
+            url = entrada.get("input_url") or ""
+            image_path = cached_download(url, item_id) if url else None
+
+        if image_path is None:
+            sem_imagem += 1
+            if not args.allow_textual:
+                print(
+                    f"[{index}/{len(selected)}] {item_id}: sem imagem — pulado "
+                    "(use --allow-textual para codificar só com texto)",
+                    file=sys.stderr,
+                )
+                continue
+
+        image_b64 = mime = None
+        if image_path is not None and not args.dry_run:
+            image_b64, mime = encode_image(image_path)
+
+        user_content = build_user_content(record, image_b64, mime)
+
+        if args.dry_run:
+            print(
+                f"[{index}/{len(selected)}] {item_id}: "
+                f"imagem={'sim' if image_path else 'não'} | "
+                f"título={entrada.get('title_hint')!r}",
+                file=sys.stderr,
+            )
+            continue
+
+        try:
+            coded = call_model(
+                client, args.model, system_prompt, user_content, schema, args.retries
+            )
+        except RuntimeError as exc:
+            falhas += 1
+            print(f"[erro] {item_id}: {exc}", file=sys.stderr)
+            continue
+
+        coded.setdefault("item_id", item_id)
+        if coded.get("item_id") != item_id:
+            coded["item_id"] = item_id  # o proxy não renomeia itens
+
+        row = build_row(
+            record,
+            coded,
+            model=args.model,
+            codebook_version=codebook_version,
+            image_source=str(image_path) if image_path else None,
+        )
+        append_row(output_path, row)
+
+        confianca = coded.get("confianca", "baixa")
+        if confianca == "baixa" or not coded.get("codificavel", True):
+            baixa_confianca += 1
+        print(
+            f"[{index}/{len(selected)}] {item_id}: confiança={confianca} "
+            f"regime={coded.get('regime_iconocratico')}",
+            file=sys.stderr,
+        )
+
+    print(
+        f"\nfim | baixa confiança/NC: {baixa_confianca} | sem imagem: {sem_imagem} "
+        f"| falhas: {falhas}",
+        file=sys.stderr,
+    )
+    print(
+        "revisão humana obrigatória antes de qualquer merge no corpus canônico.",
+        file=sys.stderr,
+    )
+
+    if falhas:
+        return 1
+    return 2 if baixa_confianca else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tools/scripts/lpai_proxy_coder_k3.py
+++ b/tools/scripts/lpai_proxy_coder_k3.py
@@ -26,14 +26,13 @@ Barreiras de escrita (guardrails)
   3. Violação de barreira encerra o processo com código 3, antes de gastar
      um único token.
 
-Nota metodológica pendente (ver corpo do PR)
---------------------------------------------
-O §16 do codebook v2.2.0 pede `purificacao_composto` como média simples dos
-10 indicadores. A virada qualitativa de julho/2026 removeu o escore agregado e
-passou a tratar ENDURECIMENTO como inventário verbal de atributos. Enquanto a
-divergência não é resolvida no codebook, este script emite os 10 indicadores
-(capta ordinal previsto pelo schema) e um inventário verbal, mas **não** calcula
-o composto — a menos que `--emit-composto` seja passado explicitamente.
+Índice composto: aposentado
+---------------------------
+O codebook v2.2.1 aposentou `purificacao_composto` (decisão
+`docs/decisions/2026-07-28-aposentadoria-do-indice-composto.md`). Os 10
+indicadores permanecem como capta ordinal; a agregação sai. Este script emite os
+indicadores e um inventário verbal de atributos, e o esquema de saída **não tem**
+campo de composto — não há flag que o reintroduza.
 
 Uso
 ---
@@ -76,7 +75,7 @@ DEFAULT_OUTPUT_NAME = "lpai-proxy-k3-runs.jsonl"
 IMAGE_CACHE = REPO / ".cache" / "lpai-proxy-images"
 
 AGENT_ID = "lpai-proxy-k3"
-PROMPT_VERSION = "lpai-proxy-k3-v1"
+PROMPT_VERSION = "lpai-proxy-k3-v2"  # v2: composto aposentado (DEC-2026-07-28)
 MODEL_DEFAULT = "kimi-k3"
 BASE_URL_DEFAULT = "https://api.moonshot.ai/v1"
 
@@ -232,7 +231,8 @@ Restrições que se somam ao instrumento abaixo:
 - Ausência significativa é dado negativo, não campo a preencher.
 - Confiança baixa e NC são respostas legítimas e preferíveis a chute.
 - Registre em `duvidas` tudo que precisa de decisão humana.
-- Não calcule médias, índices ou escores compostos.
+- Não calcule médias, índices ou escores compostos: o índice composto está
+  aposentado desde o codebook v2.2.1. Em lugar dele, registre inventario_verbal.
 """
 
 
@@ -246,17 +246,16 @@ def build_system_prompt(master_prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def build_output_schema(emit_composto: bool = False) -> dict[str, Any]:
+def build_output_schema() -> dict[str, Any]:
+    """Esquema de saída do proxy.
+
+    Não existe campo de índice composto: `purificacao_composto` está aposentado
+    desde o codebook v2.2.1 e a proibição vive na estrutura, não numa flag.
+    """
     indicadores = {
         key: {"type": "integer", "minimum": 0, "maximum": 3}
         for key in INDICATOR_KEYS
     }
-    if emit_composto:
-        indicadores["purificacao_composto"] = {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 3,
-        }
 
     return {
         "type": "object",
@@ -278,6 +277,7 @@ def build_output_schema(emit_composto: bool = False) -> dict[str, Any]:
                 "type": "object",
                 "required": list(INDICATOR_KEYS),
                 "properties": indicadores,
+                "additionalProperties": False,
             },
             "inventario_verbal": {
                 "type": "array",
@@ -623,11 +623,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="codificar itens sem imagem (registro é marcado sem_imagem)",
     )
-    parser.add_argument(
-        "--emit-composto",
-        action="store_true",
-        help="opt-in explícito: pedir purificacao_composto (ver nota metodológica)",
-    )
     parser.add_argument("--model", default=MODEL_DEFAULT)
     parser.add_argument("--base-url", default=BASE_URL_DEFAULT)
     parser.add_argument("--retries", type=int, default=1)
@@ -682,7 +677,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     images_dir = Path(args.images_dir).expanduser() if args.images_dir else None
-    schema = build_output_schema(emit_composto=args.emit_composto)
+    schema = build_output_schema()
     system_prompt = build_system_prompt(master_prompt)
 
     client = None


### PR DESCRIPTION
## Por quê

O codificador-proxy era um prompt colado no chat. Um prompt avulso não é
instrumento de pesquisa: não se sabe, três meses depois, se o lote de julho usou
a mesma redação do §16, o mesmo esquema de saída e a mesma regra de NC que o lote
de setembro. Como o kappa contra a codificação humana cega depende exatamente
dessa identidade, o instrumento passa a ser código versionado — com data, autoria
e diff a cada alteração, ao lado de `compute_kappa.py` e `audit_recodification.py`.

## O que entra

`tools/scripts/lpai_proxy_coder_k3.py` — codificador-proxy sobre Kimi K3
(Moonshot AI), com saída estruturada via tool call.

- **Instrumento por referência, não por cópia.** O master prompt operacional é
  extraído de `schema/codebook-MASTER.md` (§16) em tempo de execução. O script
  não parafraseia o codebook; `codebook_version` (hoje `2.2.0`) vai em cada linha
  de saída.
- **Evidência visual em base64.** O K3 não aceita URL pública de imagem. O script
  usa `--images-dir` com arquivos locais `<item_id>.<ext>` ou faz cache em
  `.cache/lpai-proxy-images/`. PDFs e HTML são recusados de propósito: o proxy só
  codifica o que consegue ver. Item sem imagem é pulado, salvo `--allow-textual`,
  e nesse caso é marcado `nc_causa=sem_imagem`.
- **Retomada e cache.** Itens já em staging são pulados. O prefixo do prompt é
  constante entre chamadas, para acerto de cache — entrada em cache custa um
  décimo da entrada sem cache.
- **Recortes úteis.** `--regime`, `--coded-by` (para varrer a fila de baixa
  confiança: `vault-import`, `hermes-auto`, `migration`, `batch-tentative`),
  `--limit`, `--items`, `--dry-run`.

## Barreiras de escrita

Foi o requisito central do pedido.

1. `data/processed/records.jsonl` e os exports do corpus são abertos **somente em
   leitura**. Não existe caminho de código que os escreva.
2. `assert_write_target()` valida o destino **antes de qualquer chamada de API**:
   precisa ser `.jsonl`; o nome de arquivo não pode colidir com artefato canônico
   (`records.jsonl`, `corpus-data*.json`, `companion-data.json`) nem mesmo dentro
   de staging; o caminho não pode morar em `data/processed/`, `corpus/`,
   `examples/`, `schema/` ou `tools/schemas/`; e precisa estar sob
   `data/staging/`.
3. Violação encerra o processo com **código de saída 3**, sem gravar nada e sem
   gastar um token.

Verificado na prática:

```
$ python tools/scripts/lpai_proxy_coder_k3.py --all --output data/processed/records.jsonl --dry-run
[barreira] 'records.jsonl' é nome de artefato canônico do corpus; o proxy nunca escreve nele
exit=3
```

## Envelope sem autoridade

Cada linha de staging nasce com `proxy_only: true`, `authority: "proxy"`,
`human_class: null`, `target_field: "purificacao_proposta"` e
`merge_policy: "requires_human_adjudication"`. A autoria humana lida no momento
da execução é preservada em `human_coded_by_at_read_time` e nunca sobrescrita.
A declaração de capta acompanha a linha: scores são atos interpretativos
situados, não dados neutros.

## Divergência metodológica pendente

O §16 do codebook v2.2.0 pede `purificacao_composto` como média simples dos 10
indicadores. A virada qualitativa de julho/2026 removeu o escore agregado e passou
a tratar ENDURECIMENTO como inventário verbal de atributos. **O script não decide
essa questão.** Ele emite os 10 indicadores (capta ordinal previsto pelo schema)
mais um `inventario_verbal`, e só calcula o composto com `--emit-composto`
explícito. Quando a decisão for consolidada no codebook, o padrão do script segue
a mudança — e o diff registra quando isso aconteceu.

## Testes

23 testes em `tests/test_lpai_proxy_coder_k3.py`, sem rede: barreiras de escrita
(inclusive fuga por caminho relativo), envelope de proxy, esquema com e sem
composto, seleção, retomada com linha corrompida e construção do conteúdo com e
sem imagem.

```
$ python -m pytest tests/test_lpai_proxy_coder_k3.py -q
23 passed
```

Ensaio contra o corpus real, sem chamada de API:

```
$ python tools/scripts/lpai_proxy_coder_k3.py --all --limit 4 --dry-run --allow-textual
corpus: 328 registros | codebook 2.2.0 | selecionados: 4 | já em staging: 0
saída: data/staging/lpai-proxy-k3-runs.jsonl
```

## Revisão sugerida

- Confirmar se `data/staging/lpai-proxy-k3-runs.jsonl` é o nome desejado, para
  ficar coerente com `iconocode-gemma4-runs.jsonl`.
- Decidir o destino do `purificacao_composto` no codebook.
- Definir onde vivem as imagens locais para `--images-dir` antes do primeiro
  lote grande.

Nenhuma chamada de API foi feita nesta branch. Nenhum dado canônico foi tocado.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mudança metodológica ampla no instrumento LPAI e em vários consumidores do corpus; o proxy adiciona integração externa (API) mas com guardrails de escrita. Risco mitigado por testes e preservação de valores legados congelados.
> 
> **Overview**
> Introduz o codificador-proxy **LPAI v2** (`lpai_proxy_coder_k3.py`) sobre Kimi K3: lê o §16 do `codebook-MASTER.md` em runtime, grava propostas só em `data/staging/` com envelope `proxy_only` / `requires_human_adjudication`, e valida destinos de escrita antes de qualquer chamada de API (exit 3 se violar). Inclui testes de barreiras e contrato de saída sem rede.
> 
> Em paralelo, **aposenta `purificacao_composto` / `endurecimento_score`** como agregação probatória (decisão DEC-2026-07-28): codebook **v2.2.1** exige **inventário verbal** no passo 4 do §16; schemas marcam o composto como `deprecated` / não obrigatório; novo módulo `lpai_indicators.py` centraliza inventário, cobertura e leitura legada sem recalcular médias.
> 
> **Migração transversal:** pipelines (`iconocode_gemma4`, `e3_firecrawl_recode`, `csv_to_records`), IRR (`compute_irr` rotulado legado), auditoria de fios (`analyze_threads*`), painel ENDURECIMENTO no Mnemosyne e checklists Panofsky passam a comparar **atributos** em vez de curvas agregadas. `.gitignore` ignora staging/cache do proxy K3; documentação em `README-automation.md` e testes em `test_lpai_indicators.py` / `test_lpai_proxy_coder_k3.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d72a350e622a0bca8b6953c9a4cd0828fd9e2181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->