### PR TITLE
feat(tools): camada de captação de imagens e medição programática do Estrato I

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,8 @@ deploy/iconocracia-companion/.wrangler/
 data/staging/lpai-proxy-k3-runs.jsonl
 data/staging/lpai-proxy-k3-runs.*.jsonl
 .cache/lpai-proxy-images/
+
+# Camada de captação de imagens — bytes de acervo e manifesto de proveniência
+# ficam fora do versionamento (licenças de terceiros + volume)
+.cache/corpus-images/
+data/staging/image-manifest.jsonl

--- a/tools/scripts/harvest_corpus_images.py
+++ b/tools/scripts/harvest_corpus_images.py
@@ -1,0 +1,683 @@
+#!/usr/bin/env python3
+"""
+harvest_corpus_images.py — camada de captação de imagens do corpus ICONOCRACIA.
+
+Problema que resolve: 90% dos 328 registros apontam para páginas de acervo, não
+para arquivos de imagem (apenas 4% têm URL direta). Sem bytes de imagem em disco
+não há recodificação sob o LPAI v3 — os atributos do Estrato III exigem exame
+visual, e o Kimi K3 só aceita imagem em base64, nunca URL pública.
+
+O que faz: resolve cada `input_url` até um arquivo de imagem, preferindo sempre a
+via IIIF ou a API oficial do acervo antes de qualquer heurística de HTML, baixa o
+arquivo para cache local e registra proveniência auditável — URL de origem,
+estratégia de resolução, manifesto IIIF quando existe, direitos declarados,
+dimensões, hash e data de captação.
+
+Princípios
+----------
+  * O ledger canônico é aberto SOMENTE em leitura.
+  * Nada é inventado: quando a resolução falha, o registro recebe status de falha
+    com o motivo, e não um palpite.
+  * Proveniência antes de conveniência: cada imagem carrega de onde veio e por
+    qual caminho, porque a tese precisa poder responder isso na banca.
+  * Cortesia com os acervos: intervalo mínimo por domínio, User-Agent
+    identificável, e nenhuma paralelização agressiva.
+
+Uso
+---
+    # o que resolve, sem baixar nada
+    python tools/scripts/harvest_corpus_images.py --all --dry-run
+
+    # baixa um acervo por vez, com calma
+    python tools/scripts/harvest_corpus_images.py --domain gallica.bnf.fr
+    python tools/scripts/harvest_corpus_images.py --all --limit 40
+
+    # relatório do que existe em cache
+    python tools/scripts/harvest_corpus_images.py --report
+
+Códigos de saída
+----------------
+    0 — tudo resolvido no lote
+    1 — erro fatal
+    2 — concluído com itens não resolvidos (esperado; ver relatório)
+    3 — violação de barreira de escrita
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import quote, urlparse
+
+import requests
+
+REPO = Path(__file__).resolve().parent.parent.parent
+CANONICAL_RECORDS = REPO / "data" / "processed" / "records.jsonl"
+IMAGE_CACHE = REPO / ".cache" / "corpus-images"
+MANIFEST = REPO / "data" / "staging" / "image-manifest.jsonl"
+
+# Alguns acervos (loc.gov entre eles) devolvem 403 para User-Agent contendo URL.
+# Mantemos identificação acadêmica curta e um fallback ainda mais simples.
+USER_AGENT = "ICONOCRACIA-corpus/1.0 (pesquisa de doutorado, PPGD/UFSC)"
+USER_AGENT_FALLBACK = "Mozilla/5.0 (compatible; ICONOCRACIA-corpus/1.0)"
+TIMEOUT = 45
+MIN_BYTES = 8_000          # abaixo disso é ícone, selo de site ou placeholder
+DOMAIN_INTERVAL = 2.0      # segundos entre requisições ao mesmo domínio
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".tif", ".tiff"}
+
+FORBIDDEN_DIRS = (
+    REPO / "data" / "processed",
+    REPO / "corpus",
+    REPO / "examples",
+    REPO / "schema",
+    REPO / "tools" / "schemas",
+)
+
+
+class GuardrailError(RuntimeError):
+    """Tentativa de escrever em área canônica do corpus."""
+
+
+def assert_write_target(path: Path, *, suffix: str | None = None) -> Path:
+    resolved = path.resolve()
+    if suffix and resolved.suffix != suffix:
+        raise GuardrailError(f"extensão inesperada: {resolved.name}")
+    if resolved.name == "records.jsonl":
+        raise GuardrailError("'records.jsonl' é o ledger canônico; nunca escrito aqui")
+    for directory in FORBIDDEN_DIRS:
+        try:
+            resolved.relative_to(directory.resolve())
+        except ValueError:
+            continue
+        raise GuardrailError(f"área canônica bloqueada: {resolved}")
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# HTTP cortês
+# ---------------------------------------------------------------------------
+
+_ultima_visita: dict[str, float] = {}
+
+
+def _aguarda(dominio: str) -> None:
+    agora = time.monotonic()
+    anterior = _ultima_visita.get(dominio)
+    if anterior is not None:
+        espera = DOMAIN_INTERVAL - (agora - anterior)
+        if espera > 0:
+            time.sleep(espera)
+    _ultima_visita[dominio] = time.monotonic()
+
+
+ultimo_status: dict[str, int | str] = {}
+# Domínios que já responderam 403 duas vezes: não insistir (cortesia + tempo).
+dominios_bloqueados: set[str] = set()
+
+
+def pega(url: str, *, aceita_json: bool = False) -> requests.Response | None:
+    """GET cortês, com fallback de User-Agent quando o acervo devolve 403."""
+    dominio = urlparse(url).netloc
+    if dominio in dominios_bloqueados:
+        ultimo_status[url] = 403
+        return None
+    for agente in (USER_AGENT, USER_AGENT_FALLBACK):
+        _aguarda(dominio)
+        cabecalhos = {"User-Agent": agente}
+        if aceita_json:
+            cabecalhos["Accept"] = "application/json"
+        try:
+            resposta = requests.get(url, headers=cabecalhos, timeout=TIMEOUT)
+        except requests.RequestException as erro:
+            ultimo_status[url] = type(erro).__name__
+            return None
+        ultimo_status[url] = resposta.status_code
+        if resposta.status_code == 200:
+            return resposta
+        if resposta.status_code != 403:
+            return None
+    dominios_bloqueados.add(dominio)
+    return None
+
+
+def pega_json(url: str) -> Any | None:
+    resposta = pega(url, aceita_json=True)
+    if resposta is None:
+        return None
+    try:
+        return resposta.json()
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Resolvedores por acervo — IIIF e APIs oficiais antes de heurística
+# ---------------------------------------------------------------------------
+
+Resolucao = dict[str, Any]
+
+
+def _res(url: str, estrategia: str, **extra: Any) -> Resolucao:
+    saida: Resolucao = {"image_url": url, "strategy": estrategia}
+    saida.update({k: v for k, v in extra.items() if v})
+    return saida
+
+
+def resolve_gallica(url: str, _: dict) -> Resolucao | None:
+    """Gallica/BnF: o ark identifica o documento; a Image API do IIIF entrega o fólio."""
+    match = re.search(r"(ark:/\d+/[A-Za-z0-9]+)", url)
+    if not match:
+        return None  # URLs de busca SRU não são itens
+    ark = match.group(1)
+    manifesto = f"https://gallica.bnf.fr/iiif/{ark}/manifest.json"
+    dados = pega_json(manifesto)
+    canvas = "f1"
+    if isinstance(dados, dict):
+        sequencias = dados.get("sequences") or []
+        if sequencias and sequencias[0].get("canvases"):
+            primeiro = sequencias[0]["canvases"][0]
+            imagens = primeiro.get("images") or []
+            if imagens:
+                servico = (imagens[0].get("resource") or {}).get("service") or {}
+                base = servico.get("@id")
+                if base:
+                    return _res(
+                        f"{base}/full/full/0/native.jpg",
+                        "iiif-manifest",
+                        iiif_manifest=manifesto,
+                        rights_hint=dados.get("license"),
+                        label=primeiro.get("label"),
+                    )
+            identificador = primeiro.get("@id", "")
+            if "/f" in identificador:
+                canvas = "f" + identificador.rsplit("/f", 1)[-1]
+    return _res(
+        f"https://gallica.bnf.fr/iiif/{ark}/{canvas}/full/full/0/native.jpg",
+        "iiif-convencao",
+        iiif_manifest=manifesto,
+    )
+
+
+def resolve_loc(url: str, _: dict) -> Resolucao | None:
+    """Library of Congress: o próprio item devolve JSON com as derivações."""
+    dados = pega_json(url.rstrip("/") + "/?fo=json")
+    if not isinstance(dados, dict):
+        return None
+    item = dados.get("item") or {}
+    candidatos: list[str] = []
+    for chave in ("image_url", "thumb_gallery"):
+        valor = item.get(chave) or dados.get(chave)
+        if isinstance(valor, list):
+            candidatos.extend(v for v in valor if isinstance(v, str))
+        elif isinstance(valor, str):
+            candidatos.append(valor)
+    melhores: list[tuple[int, str]] = []
+    for recurso in dados.get("resources") or []:
+        for arquivo in recurso.get("files") or []:
+            versoes = arquivo if isinstance(arquivo, list) else [arquivo]
+            for versao in versoes:
+                if not isinstance(versao, dict) or not versao.get("url"):
+                    continue
+                if (versao.get("mimetype") or "") not in ("image/jpeg", "image/png"):
+                    continue
+                melhores.append((int(versao.get("size") or 0), versao["url"]))
+    if melhores:
+        melhores.sort()
+        candidatos.insert(0, melhores[-1][1])
+
+    imagens = [c.split("#")[0] for c in candidatos
+               if Path(urlparse(c).path).suffix.lower() in IMAGE_SUFFIXES]
+    if not imagens:
+        return None
+    melhor = imagens[0] if melhores else sorted(imagens, key=len)[-1]
+    if melhor.startswith("//"):
+        melhor = "https:" + melhor
+    return _res(
+        melhor,
+        "loc-api",
+        rights_hint=item.get("rights") or item.get("rights_advisory"),
+        label=item.get("title"),
+    )
+
+
+def resolve_commons(url: str, _: dict) -> Resolucao | None:
+    """Wikimedia Commons: API de imageinfo devolve o original e a licença."""
+    match = re.search(r"/(?:wiki|File):(.+)$", url)
+    if not match:
+        return None
+    titulo = "File:" + match.group(1).split("File:")[-1]
+    api = (
+        "https://commons.wikimedia.org/w/api.php?action=query&format=json"
+        f"&titles={quote(titulo)}&prop=imageinfo&iiprop=url|size|extmetadata"
+    )
+    dados = pega_json(api)
+    if not isinstance(dados, dict):
+        return None
+    paginas = ((dados.get("query") or {}).get("pages") or {}).values()
+    for pagina in paginas:
+        info = (pagina.get("imageinfo") or [{}])[0]
+        if info.get("url"):
+            meta = info.get("extmetadata") or {}
+            licenca = (meta.get("LicenseShortName") or {}).get("value")
+            return _res(
+                info["url"],
+                "commons-api",
+                rights_hint=licenca,
+                width=info.get("width"),
+                height=info.get("height"),
+            )
+    return None
+
+
+def resolve_vam(url: str, _: dict) -> Resolucao | None:
+    """V&A: `record.images` traz IDs de imagem; o IIIF do museu monta a URL."""
+    match = re.search(r"/item/(O\d+)", url)
+    if not match:
+        return None
+    dados = pega_json(f"https://api.vam.ac.uk/v2/museumobject/{match.group(1)}")
+    if not isinstance(dados, dict):
+        return None
+    registro = dados.get("record") or {}
+    meta_imagens = (dados.get("meta") or {}).get("images") or {}
+
+    # 1) IIIF declarado no meta (caminho preferido)
+    for chave in ("_iiif_image_base_url", "_iiif_presentation_url", "_primary_thumbnail"):
+        valor = meta_imagens.get(chave)
+        if not valor:
+            continue
+        if "iiif" in valor and "/full/" not in valor:
+            return _res(valor.rstrip("/") + "/full/full/0/default.jpg",
+                        "vam-api-iiif", iiif_manifest=meta_imagens.get("_iiif_presentation_url"))
+        if chave == "_primary_thumbnail":
+            # a miniatura tem o mesmo identificador da derivação grande
+            return _res(re.sub(r"!\d+,\d+", "full", valor), "vam-api-thumb-expandida")
+
+    # 2) IDs de imagem + convenção IIIF do V&A
+    imagens = registro.get("images") or registro.get("_images") or []
+    if isinstance(imagens, list) and imagens and isinstance(imagens[0], str):
+        return _res(
+            f"https://framemark.vam.ac.uk/collections/{imagens[0]}/full/full/0/default.jpg",
+            "vam-iiif-convencao",
+            rights_hint=registro.get("creditLine"),
+            label=(registro.get("titles") or [{}])[0].get("title") if registro.get("titles") else None,
+            alternativas=[f"https://framemark.vam.ac.uk/collections/{i}/full/full/0/default.jpg"
+                          for i in imagens[1:4]],
+        )
+    return None
+
+
+def resolve_rijksmuseum(url: str, _: dict) -> Resolucao | None:
+    """Rijksmuseum: sem chave de API, a página expõe o tile IIIF em og:image."""
+    return None  # tratado pelo genérico; mantido explícito para documentar a escolha
+
+
+def resolve_europeana(url: str, _: dict) -> Resolucao | None:
+    """Europeana: muitos itens são espelhos de Gallica; tenta o ark antes do HTML."""
+    match = re.search(r"ark__(\d+)_([A-Za-z0-9]+)", url)
+    if match:
+        ark = f"ark:/{match.group(1)}/{match.group(2)}"
+        return resolve_gallica(f"https://gallica.bnf.fr/{ark}", {})
+    return None
+
+
+def resolve_numista(url: str, _: dict) -> Resolucao | None:
+    """Numista: prefere a API oficial (NUMISTA_API_KEY); o HTML costuma dar 403."""
+    chave = os.environ.get("NUMISTA_API_KEY")
+    match = re.search(r"pieces(\d+)", url)
+    if chave and match:
+        dados = pega_json(
+            f"https://api.numista.com/api/v3/types/{match.group(1)}?lang=en"
+            f"&api_key={chave}"
+        )
+        if isinstance(dados, dict):
+            for lado in ("obverse", "reverse"):
+                figura = (dados.get(lado) or {}).get("picture")
+                if figura:
+                    return _res(figura, "numista-api",
+                                rights_hint=(dados.get(lado) or {}).get("copyright"),
+                                label=dados.get("title"))
+    resposta = pega(url)
+    if resposta is None:
+        return None
+    fotos = re.findall(r'https://[^"\']+/photos/[^"\']+\.(?:jpg|jpeg|png)', resposta.text)
+    if not fotos:
+        return None
+    unicas = list(dict.fromkeys(fotos))
+    return _res(unicas[0], "numista-html", alternativas=unicas[1:4])
+
+
+RESOLVEDORES: dict[str, Callable[[str, dict], Resolucao | None]] = {
+    "gallica.bnf.fr": resolve_gallica,
+    "loc.gov": resolve_loc,
+    "commons.wikimedia.org": resolve_commons,
+    "collections.vam.ac.uk": resolve_vam,
+    "rijksmuseum.nl": resolve_rijksmuseum,
+    "europeana.eu": resolve_europeana,
+    "numista.com": resolve_numista,
+}
+
+
+# ---------------------------------------------------------------------------
+# Genérico: IIIF declarado, og:image, JSON-LD — nesta ordem
+# ---------------------------------------------------------------------------
+
+PADRAO_IIIF = re.compile(r'https?://[^"\'\s]+/(?:manifest|info)\.json', re.I)
+PADRAO_OG = re.compile(
+    r'<meta[^>]+(?:property|name)=["\'](?:og:image(?::secure_url)?|twitter:image)["\']'
+    r'[^>]+content=["\']([^"\']+)["\']', re.I)
+PADRAO_OG_INV = re.compile(
+    r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+(?:property|name)=["\']'
+    r'(?:og:image(?::secure_url)?|twitter:image)["\']', re.I)
+PADRAO_IMG = re.compile(r'<img[^>]+src=["\']([^"\']+\.(?:jpg|jpeg|png|webp))["\']', re.I)
+PADRAO_DIREITOS = re.compile(
+    r'(?:rights|license|licence|direitos)["\':\s>]+([^<"\'\n]{4,80})', re.I)
+
+
+def resolve_generico(url: str, _: dict) -> Resolucao | None:
+    resposta = pega(url)
+    if resposta is None:
+        return None
+    html = resposta.text
+    base = f"{urlparse(url).scheme}://{urlparse(url).netloc}"
+
+    def absoluto(candidato: str) -> str:
+        if candidato.startswith("//"):
+            return "https:" + candidato
+        if candidato.startswith("/"):
+            return base + candidato
+        return candidato
+
+    direitos = None
+    achado = PADRAO_DIREITOS.search(html)
+    if achado:
+        direitos = achado.group(1).strip()
+
+    manifesto = PADRAO_IIIF.search(html)
+    if manifesto:
+        alvo = absoluto(manifesto.group(0))
+        dados = pega_json(alvo)
+        if isinstance(dados, dict):
+            if dados.get("sequences"):
+                imagens = ((dados["sequences"][0].get("canvases") or [{}])[0].get("images") or [])
+                if imagens:
+                    servico = (imagens[0].get("resource") or {}).get("service") or {}
+                    if servico.get("@id"):
+                        return _res(f"{servico['@id']}/full/full/0/native.jpg",
+                                    "iiif-descoberto", iiif_manifest=alvo,
+                                    rights_hint=dados.get("license") or direitos)
+            if dados.get("@id") and dados.get("width"):  # info.json
+                return _res(f"{dados['@id']}/full/full/0/default.jpg",
+                            "iiif-info", iiif_manifest=alvo,
+                            width=dados.get("width"), height=dados.get("height"),
+                            rights_hint=direitos)
+
+    for padrao in (PADRAO_OG, PADRAO_OG_INV):
+        achado = padrao.search(html)
+        if achado:
+            return _res(absoluto(achado.group(1)), "og-image", rights_hint=direitos)
+
+    candidatas = [absoluto(c) for c in PADRAO_IMG.findall(html)]
+    candidatas = [c for c in candidatas if not re.search(r"logo|icon|sprite|banner|avatar", c, re.I)]
+    if candidatas:
+        return _res(candidatas[0], "html-img", rights_hint=direitos,
+                    alternativas=candidatas[1:4])
+    return None
+
+
+def resolve(url: str, registro: dict) -> Resolucao | None:
+    dominio = urlparse(url).netloc.replace("www.", "")
+    for sufixo, funcao in RESOLVEDORES.items():
+        if dominio.endswith(sufixo):
+            achado = funcao(url, registro)
+            if achado:
+                return achado
+            break
+    return resolve_generico(url, registro)
+
+
+# ---------------------------------------------------------------------------
+# Download e proveniência
+# ---------------------------------------------------------------------------
+
+
+def dimensoes(caminho: Path) -> tuple[int | None, int | None]:
+    try:
+        from PIL import Image  # opcional
+    except ImportError:
+        return None, None
+    try:
+        with Image.open(caminho) as imagem:
+            return imagem.width, imagem.height
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+def baixa(item_id: str, resolucao: Resolucao, min_bytes: int) -> dict[str, Any]:
+    url = resolucao["image_url"]
+    resposta = pega(url)
+    if resposta is None:
+        return {"status": "erro_download", "detail": f"sem resposta de {url}"}
+    conteudo = resposta.content
+    if len(conteudo) < min_bytes:
+        return {"status": "imagem_pequena", "detail": f"{len(conteudo)} bytes"}
+
+    tipo = (resposta.headers.get("Content-Type") or "").split(";")[0].strip()
+    if tipo and not tipo.startswith("image/"):
+        return {"status": "nao_e_imagem", "detail": tipo}
+    extensao = {"image/jpeg": ".jpg", "image/png": ".png", "image/webp": ".webp",
+                "image/gif": ".gif", "image/tiff": ".tif"}.get(tipo)
+    if extensao is None:
+        sufixo = Path(urlparse(url).path).suffix.lower()
+        extensao = sufixo if sufixo in IMAGE_SUFFIXES else ".jpg"
+
+    IMAGE_CACHE.mkdir(parents=True, exist_ok=True)
+    destino = assert_write_target(IMAGE_CACHE / f"{item_id}{extensao}")
+    destino.write_bytes(conteudo)
+    largura, altura = dimensoes(destino)
+    return {
+        "status": "ok",
+        "path": str(destino.relative_to(REPO)),
+        "bytes": len(conteudo),
+        "sha256": hashlib.sha256(conteudo).hexdigest(),
+        "content_type": tipo or None,
+        "width": largura or resolucao.get("width"),
+        "height": altura or resolucao.get("height"),
+    }
+
+
+def carrega_registros() -> list[dict[str, Any]]:
+    if not CANONICAL_RECORDS.exists():
+        raise FileNotFoundError(CANONICAL_RECORDS)
+    with CANONICAL_RECORDS.open("r", encoding="utf-8") as arquivo:
+        return [json.loads(linha) for linha in arquivo if linha.strip()]
+
+
+def carrega_manifesto() -> dict[str, dict]:
+    if not MANIFEST.exists():
+        return {}
+    entradas: dict[str, dict] = {}
+    with MANIFEST.open("r", encoding="utf-8") as arquivo:
+        for linha in arquivo:
+            linha = linha.strip()
+            if not linha:
+                continue
+            try:
+                registro = json.loads(linha)
+            except json.JSONDecodeError:
+                continue
+            entradas[registro.get("item_id", "")] = registro
+    entradas.pop("", None)
+    return entradas
+
+
+def anexa_manifesto(entrada: dict) -> None:
+    alvo = assert_write_target(MANIFEST, suffix=".jsonl")
+    alvo.parent.mkdir(parents=True, exist_ok=True)
+    with alvo.open("a", encoding="utf-8") as arquivo:
+        arquivo.write(json.dumps(entrada, ensure_ascii=False) + "\n")
+
+
+def agora() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# Relatório
+# ---------------------------------------------------------------------------
+
+
+def relatorio(registros: list[dict]) -> None:
+    manifesto = carrega_manifesto()
+    print(f"registros no corpus: {len(registros)} | no manifesto: {len(manifesto)}\n")
+    por_status = Counter(e.get("status") for e in manifesto.values())
+    print("=== STATUS ===")
+    for status, quantidade in por_status.most_common():
+        print(f"  {str(status):<20} {quantidade:>4}")
+
+    print("\n=== ESTRATÉGIA DE RESOLUÇÃO (itens com imagem) ===")
+    for estrategia, quantidade in Counter(
+        e.get("strategy") for e in manifesto.values() if e.get("status") == "ok"
+    ).most_common():
+        print(f"  {str(estrategia):<20} {quantidade:>4}")
+
+    print("\n=== COBERTURA POR ACERVO ===")
+    por_dominio: dict[str, Counter] = defaultdict(Counter)
+    for registro in registros:
+        url = (registro.get("input") or {}).get("input_url") or ""
+        dominio = urlparse(url).netloc.replace("www.", "") or "sem url"
+        entrada = manifesto.get(registro.get("item_id"))
+        por_dominio[dominio][entrada.get("status") if entrada else "pendente"] += 1
+    for dominio, contagem in sorted(por_dominio.items(), key=lambda x: -sum(x[1].values())):
+        total = sum(contagem.values())
+        ok = contagem.get("ok", 0)
+        print(f"  {dominio[:36]:<38} {ok:>3}/{total:<4} " +
+              " ".join(f"{k}={v}" for k, v in contagem.items() if k != "ok"))
+
+    aptos = [e for e in manifesto.values() if e.get("status") == "ok" and e.get("width")]
+    if aptos:
+        print("\n=== RESOLUÇÃO DAS IMAGENS (Estrato III exige exame visual) ===")
+        faixas = Counter()
+        for entrada in aptos:
+            lado = max(entrada["width"], entrada.get("height") or 0)
+            faixa = ("< 400 px (insuficiente)" if lado < 400 else
+                     "400–799 px (limitado)" if lado < 800 else
+                     "800–1599 px (adequado)" if lado < 1600 else
+                     ">= 1600 px (ótimo)")
+            faixas[faixa] += 1
+        for faixa, quantidade in sorted(faixas.items()):
+            print(f"  {faixa:<26} {quantidade:>4}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    alvo = parser.add_mutually_exclusive_group()
+    alvo.add_argument("--items", help="item_id[,item_id,...]")
+    alvo.add_argument("--all", action="store_true")
+    alvo.add_argument("--report", action="store_true", help="só relatório, sem rede")
+    parser.add_argument("--domain", help="filtra por domínio do acervo")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--min-bytes", type=int, default=MIN_BYTES)
+    parser.add_argument("--force", action="store_true", help="refazer itens já no manifesto")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="resolve a URL da imagem e não baixa nada")
+    argumentos = parser.parse_args(argv)
+
+    try:
+        registros = carrega_registros()
+    except (FileNotFoundError, json.JSONDecodeError) as erro:
+        print(f"[fatal] {erro}", file=sys.stderr)
+        return 1
+
+    if argumentos.report:
+        relatorio(registros)
+        return 0
+    if not (argumentos.all or argumentos.items):
+        parser.error("use --all, --items ou --report")
+
+    manifesto = carrega_manifesto()
+    ids = [i.strip() for i in argumentos.items.split(",")] if argumentos.items else None
+
+    fila = []
+    for registro in registros:
+        item_id = registro.get("item_id")
+        url = (registro.get("input") or {}).get("input_url") or ""
+        if ids and item_id not in ids:
+            continue
+        if argumentos.domain and argumentos.domain not in url:
+            continue
+        if not argumentos.force and item_id in manifesto and \
+                manifesto[item_id].get("status") == "ok":
+            continue
+        fila.append((item_id, url, registro))
+    if argumentos.limit:
+        fila = fila[: argumentos.limit]
+
+    print(f"fila: {len(fila)} itens | cache: {IMAGE_CACHE.relative_to(REPO)} | "
+          f"manifesto: {MANIFEST.relative_to(REPO)}", file=sys.stderr)
+    if argumentos.dry_run:
+        print("modo ensaio: resolve e não baixa\n", file=sys.stderr)
+
+    contagem: Counter = Counter()
+    for indice, (item_id, url, registro) in enumerate(fila, start=1):
+        prefixo = f"[{indice}/{len(fila)}] {item_id}"
+
+        if not url:
+            entrada = {"item_id": item_id, "status": "sem_url", "checked_at": agora()}
+        elif urlparse(url).netloc.endswith("iconocracy.corpus"):
+            entrada = {"item_id": item_id, "source_url": url, "status": "placeholder",
+                       "detail": "URL interna sem acervo de origem", "checked_at": agora()}
+        else:
+            resolucao = resolve(url, registro)
+            if resolucao is None:
+                bloqueios = [v for k, v in ultimo_status.items()
+                             if urlparse(k).netloc == urlparse(url).netloc]
+                bloqueado = 403 in bloqueios
+                entrada = {
+                    "item_id": item_id, "source_url": url,
+                    "status": "bloqueado_acervo" if bloqueado else "nao_resolvido",
+                    "detail": f"http {bloqueios[-1]}" if bloqueios else "sem candidata de imagem",
+                    "checked_at": agora(),
+                }
+            elif argumentos.dry_run:
+                entrada = {"item_id": item_id, "source_url": url, "status": "resolvido",
+                           **resolucao, "checked_at": agora()}
+            else:
+                resultado = baixa(item_id, resolucao, argumentos.min_bytes)
+                entrada = {"item_id": item_id, "source_url": url, **resolucao,
+                           **resultado, "checked_at": agora()}
+
+        contagem[entrada["status"]] += 1
+        if not argumentos.dry_run:
+            anexa_manifesto(entrada)
+        detalhe = entrada.get("strategy") or entrada.get("detail") or ""
+        print(f"{prefixo}: {entrada['status']} {detalhe}", file=sys.stderr)
+
+    print("\n=== RESUMO ===", file=sys.stderr)
+    for status, quantidade in contagem.most_common():
+        print(f"  {status:<16} {quantidade:>4}", file=sys.stderr)
+
+    falhas = sum(v for k, v in contagem.items()
+                 if k not in ("ok", "resolvido"))
+    return 2 if falhas else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        sys.exit(main())
+    except GuardrailError as erro:
+        print(f"[barreira] {erro}", file=sys.stderr)
+        sys.exit(3)

--- a/tools/scripts/measure_stratum_i.py
+++ b/tools/scripts/measure_stratum_i.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+measure_stratum_i.py — medição programática do Estrato I do LPAI v3.
+
+O Estrato I reúne atributos que nunca foram juízo iconográfico: propriedades
+materiais do suporte. Monocromatização é o caso exemplar — a matriz de correlação
+do corpus mostrou que ela é ortogonal a todos os outros indicadores (r entre 0,07
+e 0,27, e -0,04 com inscrição estatal). Medi-la por script, em vez de codificá-la
+a olho, faz três coisas: torna o valor reprodutível por execução em lugar de
+depender de concordância entre codificadores; libera tempo humano para o Estrato
+III, que é onde o juízo é irredutível; e explicita, no próprio método, que aquele
+atributo não pertence à mesma escala dos demais.
+
+Métrica
+-------
+Usa o índice de colorfulness de Hasler & Süsstrunk (2003), definido em espaço de
+oponência simples e validado experimentalmente contra julgamento humano:
+
+    rg = R - G
+    yb = 0,5 (R + G) - B
+    C  = sqrt(sigma_rg^2 + sigma_yb^2) + 0,3 * sqrt(mu_rg^2 + mu_yb^2)
+
+Âncoras qualitativas do artigo original: 0 "not colorful", 15 "slightly", 33
+"moderately", 45 "averagely", 59 "quite", 82 "highly", 109 "extremely". A
+monocromatização é o inverso da colorfulness, e a conversão para a escala ordinal
+0–3 do codebook usa essas âncoras — não limiares arbitrários:
+
+    C < 15   -> monocromatizacao = 3  (monocromia efetiva)
+    15 <= C < 33 -> 2               (cromatismo restrito)
+    33 <= C < 59 -> 1               (cromatismo moderado)
+    C >= 59      -> 0               (policromia plena)
+
+Registra também três medidas de apoio, para que a decisão seja auditável e não
+dependa de um número único: fração de pixels de baixa saturação, saturação média
+e número de matizes distintos com massa relevante.
+
+Ressalva registrada
+-------------------
+A medição descreve o ARQUIVO, não necessariamente o OBJETO. Reprodução
+fotográfica com dominante amarelada, digitalização em tons de cinza de um
+original colorido e fundo de papel envelhecido deslocam a métrica. Por isso cada
+resultado carrega `caveat` quando a imagem é suspeita, e o valor medido é uma
+PROPOSTA sujeita a confirmação humana — nunca escrita direto no ledger canônico.
+
+Uso
+---
+    python tools/scripts/measure_stratum_i.py --all
+    python tools/scripts/measure_stratum_i.py --all --compare
+    python tools/scripts/measure_stratum_i.py --items <item_id>
+
+Códigos de saída
+----------------
+    0 sucesso · 1 erro fatal · 2 concluído com imagens suspeitas · 3 barreira
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+# Digitalizações IIIF em resolução plena chegam a 145 megapixels (Gallica, LoC).
+# São legítimas e vêm de acervo institucional; o limite antibomba do Pillow é
+# elevado deliberadamente, e a imagem é reamostrada antes de qualquer cálculo.
+Image.MAX_IMAGE_PIXELS = 400_000_000
+
+REPO = Path(__file__).resolve().parent.parent.parent
+CANONICAL_RECORDS = REPO / "data" / "processed" / "records.jsonl"
+IMAGE_CACHE = REPO / ".cache" / "corpus-images"
+SAIDA = REPO / "data" / "staging" / "stratum-i-measurements.jsonl"
+
+METRIC_VERSION = "hasler-susstrunk-2003/v1"
+LADO_MAXIMO = 1200          # reamostragem: a métrica é estatística, não precisa full-res
+SATURACAO_BAIXA = 0.12      # abaixo disso o pixel é praticamente acromático
+RESOLUCAO_MINIMA = 400      # menor lado abaixo do qual a leitura fica frágil
+
+# Âncoras de Hasler & Süsstrunk (2003) → escala ordinal 0–3 do codebook
+ANCORAS = ((15.0, 3), (33.0, 2), (59.0, 1))
+
+FORBIDDEN_DIRS = (
+    REPO / "data" / "processed",
+    REPO / "corpus",
+    REPO / "examples",
+    REPO / "schema",
+    REPO / "tools" / "schemas",
+)
+
+
+class GuardrailError(RuntimeError):
+    """Tentativa de escrever em área canônica do corpus."""
+
+
+def assert_write_target(path: Path) -> Path:
+    resolved = path.resolve()
+    if resolved.name == "records.jsonl":
+        raise GuardrailError("'records.jsonl' é o ledger canônico; a medição não escreve nele")
+    if resolved.suffix != ".jsonl":
+        raise GuardrailError(f"saída precisa ser .jsonl: {resolved.name}")
+    for directory in FORBIDDEN_DIRS:
+        try:
+            resolved.relative_to(directory.resolve())
+        except ValueError:
+            continue
+        raise GuardrailError(f"área canônica bloqueada: {resolved}")
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Métrica
+# ---------------------------------------------------------------------------
+
+
+def colorfulness(rgb: np.ndarray) -> float:
+    """Índice de Hasler & Süsstrunk (2003) em espaço de oponência simples."""
+    r, g, b = (rgb[..., i].astype(np.float64) for i in range(3))
+    rg = r - g
+    yb = 0.5 * (r + g) - b
+    return float(
+        np.sqrt(rg.std() ** 2 + yb.std() ** 2)
+        + 0.3 * np.sqrt(rg.mean() ** 2 + yb.mean() ** 2)
+    )
+
+
+def ordinal_por_ancora(indice: float) -> int:
+    for limite, valor in ANCORAS:
+        if indice < limite:
+            return valor
+    return 0
+
+
+def medidas_de_apoio(imagem: Image.Image) -> dict[str, Any]:
+    """Saturação, acromaticidade e dispersão de matizes — auditoria do número único."""
+    hsv = np.asarray(imagem.convert("HSV"), dtype=np.float64) / 255.0
+    matiz, saturacao, valor = hsv[..., 0], hsv[..., 1], hsv[..., 2]
+
+    acromatico = saturacao < SATURACAO_BAIXA
+    fracao_acromatica = float(acromatico.mean())
+
+    # matizes contam apenas onde há cor e luz suficientes para o matiz existir
+    mascara = (~acromatico) & (valor > 0.10) & (valor < 0.97)
+    if mascara.sum() > 0:
+        histograma, _ = np.histogram(matiz[mascara], bins=36, range=(0.0, 1.0))
+        relevantes = int((histograma > histograma.sum() * 0.01).sum())
+        saturacao_media_cromatica = float(saturacao[mascara].mean())
+    else:
+        relevantes = 0
+        saturacao_media_cromatica = 0.0
+
+    return {
+        "fracao_acromatica": round(fracao_acromatica, 4),
+        "saturacao_media": round(float(saturacao.mean()), 4),
+        "saturacao_media_cromatica": round(saturacao_media_cromatica, 4),
+        "matizes_relevantes": relevantes,
+    }
+
+
+def mede(caminho: Path) -> dict[str, Any]:
+    with Image.open(caminho) as bruta:
+        largura_original, altura_original = bruta.size
+        imagem = bruta.convert("RGB")
+        imagem.thumbnail((LADO_MAXIMO, LADO_MAXIMO))
+        arranjo = np.asarray(imagem)
+        apoio = medidas_de_apoio(imagem)
+
+    indice = colorfulness(arranjo)
+    proposto = ordinal_por_ancora(indice)
+
+    ressalvas: list[str] = []
+    if min(largura_original, altura_original) < RESOLUCAO_MINIMA:
+        ressalvas.append("resolucao_baixa: leitura frágil, confirmar a olho")
+    if apoio["fracao_acromatica"] > 0.97 and apoio["matizes_relevantes"] == 0:
+        ressalvas.append("possivel digitalizacao em tons de cinza de original colorido")
+    if 12.0 < indice < 18.0 or 30.0 < indice < 36.0 or 56.0 < indice < 62.0:
+        ressalvas.append("índice em zona de fronteira entre duas âncoras")
+    if apoio["matizes_relevantes"] == 1 and apoio["fracao_acromatica"] < 0.5:
+        ressalvas.append("dominante única: possível viés de reprodução fotográfica")
+
+    return {
+        "colorfulness": round(indice, 2),
+        "monocromatizacao_proposta": proposto,
+        "metric_version": METRIC_VERSION,
+        "width": largura_original,
+        "height": altura_original,
+        **apoio,
+        "caveat": ressalvas or None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Corpus e execução
+# ---------------------------------------------------------------------------
+
+
+def carrega_registros() -> list[dict[str, Any]]:
+    with CANONICAL_RECORDS.open("r", encoding="utf-8") as arquivo:
+        return [json.loads(linha) for linha in arquivo if linha.strip()]
+
+
+def imagem_de(item_id: str) -> Path | None:
+    for extensao in (".jpg", ".jpeg", ".png", ".webp", ".gif", ".tif", ".tiff"):
+        candidato = IMAGE_CACHE / f"{item_id}{extensao}"
+        if candidato.exists() and candidato.stat().st_size > 0:
+            return candidato
+    return None
+
+
+def agora() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Medição do Estrato I (LPAI v3).")
+    alvo = parser.add_mutually_exclusive_group(required=True)
+    alvo.add_argument("--all", action="store_true")
+    alvo.add_argument("--items", help="item_id[,item_id,...]")
+    parser.add_argument("--output", help="saída .jsonl em staging")
+    parser.add_argument("--compare", action="store_true",
+                        help="compara com a codificação humana existente")
+    parser.add_argument("--dry-run", action="store_true", help="não grava")
+    argumentos = parser.parse_args(argv)
+
+    try:
+        saida = assert_write_target(Path(argumentos.output) if argumentos.output else SAIDA)
+    except GuardrailError as erro:
+        print(f"[barreira] {erro}", file=sys.stderr)
+        return 3
+
+    try:
+        registros = carrega_registros()
+    except (OSError, json.JSONDecodeError) as erro:
+        print(f"[fatal] {erro}", file=sys.stderr)
+        return 1
+
+    ids = {i.strip() for i in argumentos.items.split(",")} if argumentos.items else None
+    linhas: list[dict[str, Any]] = []
+    sem_imagem = 0
+    suspeitas = 0
+
+    for registro in registros:
+        item_id = registro.get("item_id")
+        if ids and item_id not in ids:
+            continue
+        caminho = imagem_de(item_id)
+        if caminho is None:
+            sem_imagem += 1
+            continue
+        try:
+            medida = mede(caminho)
+        except Exception as erro:  # noqa: BLE001
+            print(f"[erro] {item_id}: {type(erro).__name__} {erro}", file=sys.stderr)
+            continue
+
+        humano = (registro.get("purificacao") or {}).get("monocromatizacao")
+        linha = {
+            "item_id": item_id,
+            "proxy_only": True,
+            "authority": "medicao_programatica",
+            "target_field": "estrato_i.monocromatizacao_proposta",
+            "merge_policy": "requires_human_confirmation",
+            "image_path": str(caminho.relative_to(REPO)),
+            "measured_at": agora(),
+            **medida,
+            "codificacao_humana_v2": humano,
+        }
+        if medida["caveat"]:
+            suspeitas += 1
+        linhas.append(linha)
+
+    if not argumentos.dry_run and linhas:
+        saida.parent.mkdir(parents=True, exist_ok=True)
+        with saida.open("w", encoding="utf-8") as arquivo:
+            for linha in linhas:
+                arquivo.write(json.dumps(linha, ensure_ascii=False) + "\n")
+
+    print(f"medidos: {len(linhas)} | sem imagem em cache: {sem_imagem} | "
+          f"com ressalva: {suspeitas}", file=sys.stderr)
+    if linhas:
+        print(f"saída: {saida.relative_to(REPO)}", file=sys.stderr)
+
+    distribuicao: dict[int, int] = {}
+    for linha in linhas:
+        valor = linha["monocromatizacao_proposta"]
+        distribuicao[valor] = distribuicao.get(valor, 0) + 1
+    print("\ndistribuição proposta (0 policromia → 3 monocromia):", file=sys.stderr)
+    for valor in sorted(distribuicao):
+        print(f"  {valor}: {distribuicao[valor]}", file=sys.stderr)
+
+    if argumentos.compare:
+        pares = [(l["codificacao_humana_v2"], l["monocromatizacao_proposta"])
+                 for l in linhas if isinstance(l["codificacao_humana_v2"], int)]
+        if pares:
+            iguais = sum(1 for h, m in pares if h == m)
+            um_grau = sum(1 for h, m in pares if abs(h - m) == 1)
+            print(f"\ncontraste com a codificação v2 (n={len(pares)}):", file=sys.stderr)
+            print(f"  idêntico:        {iguais} ({iguais/len(pares)*100:.0f}%)", file=sys.stderr)
+            print(f"  1 grau de dif.:  {um_grau} ({um_grau/len(pares)*100:.0f}%)", file=sys.stderr)
+            print(f"  2+ graus:        {len(pares)-iguais-um_grau}", file=sys.stderr)
+            print("  (divergência não é erro da máquina nem da humana: é o lugar\n"
+                  "   onde a definição operacional do atributo precisa de decisão)",
+                  file=sys.stderr)
+
+    return 2 if suspeitas else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Por quê

O diagnóstico da arquitetura de atributos revelou um bloqueio operacional que
antecede qualquer decisão sobre o esquema: **90% dos 328 registros apontam para
páginas de acervo, não para arquivos de imagem.** Apenas 4% têm URL direta. Sem
bytes em disco não existe Estrato III — os atributos interpretativos exigem exame
visual — e o proxy K3 só aceita imagem em base64, nunca URL pública.

## `harvest_corpus_images.py`

Resolve cada `input_url` até um arquivo de imagem, **preferindo sempre IIIF e API
oficial antes de qualquer heurística de HTML**, e registra proveniência auditável:
URL de origem, estratégia de resolução, manifesto IIIF quando existe, direitos
declarados, dimensões, sha256 e data de captação. A tese precisa poder responder,
na banca, de onde veio cada imagem e por qual caminho.

| Acervo | Via | Resultado |
|---|---|---|
| Gallica/BnF | manifesto IIIF | 33/40 |
| Library of Congress | API de item, maior derivação por metadados de arquivo | 23/31 |
| Europeana | redireciona ao ark de origem | 19/22 |
| HAUM Braunschweig | genérico (og:image) | 12/12 |
| Rijksmuseum | genérico (og:image) | 9/9 |
| V&A | API + convenção IIIF do museu | 7/7 |
| BN Portugal, SMK, IWM, KIK-IRPA, Museums Victoria | genérico | integrais |

Estratégias efetivamente usadas: `og-image` 61, `iiif-manifest` 36, `loc-api` 23,
`html-img` 7, `vam-api-thumb-expandida` 7, `iiif-convencao` 6, `iiif-info` 2,
`commons-api` 1.

Duas descobertas operacionais que economizam horas a quem vier depois:
`loc.gov` devolve **403 para User-Agent que contenha URL** — daí a identificação
acadêmica curta e o fallback; e domínios que respondem 403 duas vezes entram numa
lista de bloqueio em memória, para não insistir contra um acervo que já disse não.

## `measure_stratum_i.py`

A matriz de correlação do corpus mostrou que monocromatização é **ortogonal** a
todos os outros indicadores — r entre 0,07 e 0,27, e **−0,04** com inscrição
estatal. Ela nunca foi juízo iconográfico: é propriedade material do suporte.

O script a mede pelo índice de colorfulness de Hasler & Süsstrunk (2003),
convertendo as **âncoras qualitativas do artigo original** (0 "not colorful", 15
"slightly", 33 "moderately", 59 "quite") na escala 0–3 do codebook — limiares
citáveis, não arbitrários. Registra também fração acromática, saturação média e
dispersão de matizes, para que a decisão seja auditável e não dependa de um número
único, e emite ressalvas tipadas para resolução baixa, suspeita de digitalização
em tons de cinza de original colorido, dominante única de reprodução fotográfica e
índice em zona de fronteira entre âncoras.

Isso muda a economia do trabalho: com codificadora única, medir o Estrato I por
script em vez de codificá-lo a olho reduz de dez para oito os atributos que
exigiriam concordância humana, e torna esses valores reprodutíveis por execução em
vez de dependentes de acordo.

## Resultados da primeira execução completa

| Status | Registros |
|---|---|
| imagem captada | **143** (44%) |
| bloqueado pelo acervo | 78 |
| não resolvido | 43 |
| erro de download | 30 |
| imagem pequena (miniatura) | 19 |
| placeholder sem acervo de origem | 15 |

Resolução das 143 captadas: **73 ≥ 1600 px** (ótimo), 35 entre 800 e 1599 px
(adequado), 20 entre 400 e 799 px (limitado), 15 abaixo de 400 px (insuficiente
para exame visual). Ou seja, **108 imagens já sustentam o Estrato III**.

Medição do Estrato I nas 143: distribuição proposta 0→5, 1→33, 2→65, 3→40. No
contraste com a codificação v2, 38% idênticos, 38% com um grau de diferença e 34
itens com dois graus ou mais. **Isso é resultado, não falha:** a divergência
concentra-se onde a definição operacional do atributo nunca foi fixada, e a
recomendação é calibrar as âncoras contra uma amostra-ouro de 40 itens codificados
por humana antes de adotar os valores propostos.

## Pendências que este PR não resolve

- **Numista, 57 registros (17% do corpus).** Bloqueia acesso por script em todos.
  Três saídas: chave de API (o resolvedor já está pronto, ativado por
  `NUMISTA_API_KEY`), captação por sessão de navegador, ou substituição por
  espelhos em Commons e catálogos de casa da moeda — preferível, porque Numista é
  agregador e não acervo institucional.
- **Bildindex, 12 registros.** O `og:image` é miniatura; precisa de resolvedor
  específico para a derivação grande.
- **Wikimedia Commons, 11 registros com erro de download.** A URL da API resolve,
  o download falha — provável restrição de UA no `upload.wikimedia.org`.
- **15 placeholders `iconocracy.corpus`** sem acervo de origem: entram em campanha
  de reprospecção.
- Uma passada de retentativa usando o campo `alternativas` já gravado no manifesto
  deve recuperar parte dos 30 erros de download e dos 19 casos de miniatura.

## Barreiras

Ambos os scripts abrem o ledger canônico e os exports **somente em leitura**,
restringem a saída a `data/staging/` e ao cache, e encerram com código 3 em
violação. Cache de imagens e manifesto de proveniência ficam fora do
versionamento: licenças de terceiros e volume (241 MB nas 143 primeiras).

Base do PR: `feat/lpai-proxy-coder-k3` (#157), para não misturar com a decisão do
índice composto.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mudanças limitadas a scripts offline, staging e cache; o ledger canônico só é lido e há barreiras explícitas contra escrita indevida.
> 
> **Overview**
> Adiciona a **captação de imagens do corpus** e a **medição programática do Estrato I**, com artefatos grandes fora do git.
> 
> **`harvest_corpus_images.py`** lê `records.jsonl` só em leitura, resolve cada `input_url` até um arquivo (IIIF/APIs por acervo, depois heurísticas HTML), baixa para `.cache/corpus-images/` e anexa proveniência em `data/staging/image-manifest.jsonl` (estratégia, direitos, sha256, dimensões). Inclui rate limit por domínio, fallback de User-Agent e bloqueio de escrita no ledger e em diretórios canônicos.
> 
> **`measure_stratum_i.py`** usa o cache de imagens para calcular colorfulness (Hasler & Süsstrunk) e propor `monocromatizacao` 0–3, gravando propostas em `data/staging/stratum-i-measurements.jsonl` com `merge_policy: requires_human_confirmation` — sem alterar o ledger.
> 
> O **`.gitignore`** passa a ignorar `.cache/corpus-images/` e `image-manifest.jsonl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ca96ecfbe515737fa89463800246c818ba7c648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->