### PR TITLE
fix(audit): resolve 4 unaddressed Codex findings from #162

### DIFF
--- a/docs/metodologia/apendice-metodologico-corpus.md
+++ b/docs/metodologia/apendice-metodologico-corpus.md
@@ -82,15 +82,24 @@ predominância francesa não reflete a importância relativa dos casos no argume
 mas a densidade de digitalização da Gallica e da Europeana — observação que
 retorna em A.2 como viés de acervo.
 
-Quanto à codificação, 222 registros possuem inventário de atributos efetivamente
-constituído. Os 106 restantes receberam, em etapa de importação, valores nulos em
-todos os indicadores, o que os tornava indistinguíveis de objetos examinados e
-julgados desprovidos de atributo. Esses registros passaram a estado explícito de
-não codificação. A correção não é ornamento de rigor: sem ela, o regime militar
-— cujos registros estão majoritariamente por examinar — apareceria como o menos
-marcado do conjunto, quando o exame dos casos efetivamente lidos indica o
-contrário. Toda afirmação sobre o regime militar permanece suspensa até a
-conclusão da leitura.
+Quanto à codificação, 229 registros possuem inventário de atributos efetivamente
+constituído (335 no ledger atual, 106 ainda em zero de importação — números
+atualizados em 2026-08-05; ver `docs/metodologia/arquitetura-atributos-lpai-v3.md`
+para a re-execução completa). Os 106 restantes receberam, em etapa de importação,
+valores nulos em todos os indicadores, o que os torna indistinguíveis de objetos
+examinados e julgados desprovidos de atributo. **A migração desses registros
+para um estado explícito de não codificação ainda não foi executada no ledger
+canônico** — `data/processed/records.jsonl` continua armazenando `0` numérico
+puro nos dez indicadores desses 106 casos, sem sinalização estrutural distinta
+(apenas um campo `notes` em texto livre, presente de forma inconsistente, com
+teor como "Codificação pendente"). Até essa migração acontecer, qualquer script
+que trate o dado bruto sem replicar o filtro `coded_by`/zeros usado nas análises
+deste apêndice reintroduzirá o mesmo artefato. A correção conceitual não é
+ornamento de rigor: sem tratá-la à parte do dado bruto, o regime militar — cujos
+registros estão majoritariamente por examinar — aparece como o menos marcado do
+conjunto, quando o exame dos casos efetivamente lidos indica o contrário. Toda
+afirmação sobre o regime militar permanece suspensa até a conclusão da leitura
+**e até a migração do estado de não-codificação landar no schema**.
 
 ---
 

--- a/docs/metodologia/arquitetura-atributos-lpai-v3.md
+++ b/docs/metodologia/arquitetura-atributos-lpai-v3.md
@@ -8,6 +8,31 @@ Ana Vitória Vanzin Mendes · 29 de julho de 2026
 Base empírica: 328 registros de `data/processed/records.jsonl`
 Base bibliográfica: `pesquisa-arquitetura-atributos.md` (revisão de estado da arte)
 
+> **Nota de atualização (2026-08-05).** A revisão de #162 pelo Codex (Bugbot)
+> encontrou, após o merge: denominador desatualizado (o ledger já tinha 335
+> registros quando este texto ainda usava 328); `tools/audit/scripts/
+> analise_dimensional.py` sem leitura de `purificacao.record_metadata.medium`
+> (colapsava o suporte inteiro em "não classificado"); e o mesmo script sem
+> passagem filtrada pelos zeros de importação, o que o tornava incapaz de
+> reproduzir o achado de "3 fatores" citado abaixo. Os quatro scripts de
+> `tools/audit/scripts/` foram corrigidos (mesmo bug de filtro encontrado
+> também em `analise_indicadores.py`; denominadores hardcoded trocados por
+> cálculo dinâmico nos quatro) e re-executados sobre o ledger atual (335
+> registros, ainda 106 zeros de importação → 229 codificados). Os números
+> abaixo foram atualizados onde a re-execução divergiu; o achado central da
+> seção 2.3 (inversão do regime militar) **reproduziu-se exatamente**, com os
+> mesmos valores por indicador, apesar do corpus ter crescido — evidência de
+> robustez, não de fragilidade do achado original. Uma divergência maior e não
+> totalmente explicada apareceu na contagem de pares correlacionados *com* os
+> falsos zeros (§2.2): o texto original citava sete pares acima de r=0,70; a
+> re-execução encontra 18, com o mesmo par máximo (r=0,88). Fica registrado
+> como divergência a investigar, não corrigido por suposição. **Escopo desta
+> nota:** as seções 2.1–2.3 foram reverificadas e corrigidas explicitamente.
+> As seções seguintes (planejamento, painel ENDURECIMENTO, comparações
+> metodológicas) continuam citando 328/222 como estavam em 2026-07-29 — não
+> foram reprocessadas linha a linha e devem ser lidas como o corte histórico
+> que fundamentou o plano, não como número corrente do corpus.
+
 ---
 
 ## 1. Resposta direta
@@ -29,11 +54,11 @@ nenhum refinamento do esquema de atributos repara ([ISPOR](https://www.ispor.org
 
 A revisão de estado da arte concluiu que, no seu caso, três dessas decisões já
 estariam tomadas — unidade de análise (o registro iconográfico individual),
-população (os 328 casos) e nível de mensuração (corrigido pela aposentadoria do
+população (os 335 casos) e nível de mensuração (corrigido pela aposentadoria do
 índice) —, restando a arquitetura de atributos como único ponto de risco em
 aberto. **O diagnóstico empírico mostra que essa premissa é falsa.** A população
 não está fixada e o nível de mensuração não está resolvido, porque o corpus
-contém uma política de ausência implícita que nunca foi decidida: 106 dos 328
+contém uma política de ausência implícita que nunca foi decidida: 106 dos 335
 registros carregam zeros que não são medições. Enquanto isso valer, mexer na
 lista de atributos é otimizar a terceira casa decimal de um número cuja primeira
 casa está errada.
@@ -46,8 +71,8 @@ casa está errada.
 
 | Situação | Registros | % |
 |---|---|---|
-| Todos os 10 indicadores em zero | 106 | 32,3% |
-| Com ao menos um indicador marcado | 222 | 67,7% |
+| Todos os 10 indicadores em zero | 106 | 31,6% |
+| Com ao menos um indicador marcado | 229 | 68,4% |
 
 A origem desses 106 não deixa dúvida sobre a natureza do fenômeno: 86 vêm de
 `vault-import`, 19 de `migration`, 1 de `ana`. São zeros de importação, não
@@ -55,31 +80,33 @@ juízos de codificação. O único registro de autoria humana no bloco pode ser 
 codificação genuína de ausência total — e precisa ser inspecionado à parte,
 justamente porque é indistinguível dos outros 105 na estrutura atual.
 
-Isso reinterpreta um número que você já conhecia: dos 148 registros da fila de
+Isso reinterpreta um número que você já conhecia: dos 159 registros da fila de
 baixa confiança (origens `vault-import`, `hermes-auto`, `migration`,
-`batch-tentative`), **105 são zeros de importação, ou 71%**. A fila de baixa
+`batch-tentative`), **105 são zeros de importação, ou 66%**. A fila de baixa
 confiança não é majoritariamente um problema de qualidade de codificação. É um
 problema de cobertura vestido de codificação.
 
 ### 2.2 O falso zero fabricou unidimensionalidade
 
-Decomposi a matriz de correlação dos dez indicadores duas vezes: com os 328
-registros e apenas com os 222 efetivamente codificados.
+Decomposi a matriz de correlação dos dez indicadores duas vezes: com os 335
+registros e apenas com os 229 efetivamente codificados.
 
 | | Componente 1 | Autovalores > 1 | Leitura |
 |---|---|---|---|
-| Com os 106 falsos zeros (n=328) | 69,2% | **1** | esquema unidimensional |
-| Só codificados (n=222) | 46,5% | **3** | três dimensões (4,65 / 1,25 / 1,04) |
+| Com os 106 falsos zeros (n=335) | 69,5% | **1** | esquema unidimensional |
+| Só codificados (n=229) | 47,7% | **3** | três dimensões (4,77 / 1,24 / 1,03) |
 
-O alfa de Cronbach no subcorpus codificado é 0,846 — alto, mas longe do patamar
-que os 328 registros sugeriam. Em outras palavras: **a aparência de que os dez
+O alfa de Cronbach no subcorpus codificado é 0,855 — alto, mas longe do patamar
+que os 335 registros sugeriam. Em outras palavras: **a aparência de que os dez
 indicadores mediam uma coisa só era artefato dos zeros de importação.** Um bloco
 de 106 linhas idênticas em todas as variáveis correlaciona tudo com tudo.
 
-O efeito aparece nos pares. Com os falsos zeros, sete pares passavam de r=0,70,
-e `dessexualizacao × uniformizacao_facial` chegava a 0,88. No subcorpus
-codificado, sobra **um único par** acima de 0,70 (o mesmo, em 0,73). O esquema
-não é redundante como parecia.
+O efeito aparece nos pares. Com os falsos zeros, **18 pares** passavam de
+r=0,70 (revisado em 2026-08-05; o texto original, sobre n=328, citava sete —
+divergência ainda não explicada, ver nota de atualização no topo do
+documento), e `dessexualizacao × uniformizacao_facial` chegava a 0,88 nos dois
+casos. No subcorpus codificado, sobra **um único par** acima de 0,70 (o mesmo,
+em 0,74). O esquema não é redundante como parecia.
 
 Isso tem uma consequência desconfortável e produtiva: parte da justificativa
 estatística que se poderia dar à aposentadoria do índice — "os indicadores são
@@ -108,9 +135,9 @@ dos registros militares são zeros de importação.**
 | Regime | Não codificados | Total | % |
 |---|---|---|---|
 | militar | 32 | 54 | **59,3%** |
-| contra-alegoria | 6 | 14 | 42,9% |
-| normativo | 35 | 102 | 34,3% |
-| fundacional | 33 | 158 | 20,9% |
+| contra-alegoria | 6 | 15 | 40,0% |
+| normativo | 35 | 103 | 34,0% |
+| fundacional | 33 | 163 | 20,2% |
 
 A inflexão militar que os scripts de fios detectavam — e que eu, ontem, migrei
 diligentemente de "queda de escore" para "perda de atributos" — é, com alta

--- a/tools/audit/scripts/analise_dimensional.py
+++ b/tools/audit/scripts/analise_dimensional.py
@@ -10,18 +10,9 @@ recs = [json.loads(l) for l in open('data/processed/records.jsonl')]
 def ind(r):
     p = r.get('purificacao') or {}
     return {k: p.get(k, 0) for k in KEYS}
-X = [[ind(r)[k] for k in KEYS] for r in recs]
-n = len(X)
-
-# --- matriz de correlação e autovalores (dimensionalidade efetiva) ---
-def col(j): return [row[j] for row in X]
-means = [sum(col(j))/n for j in range(10)]
-sds = [math.sqrt(sum((v-means[j])**2 for v in col(j))/n) for j in range(10)]
-R = [[0.0]*10 for _ in range(10)]
-for a in range(10):
-    for b in range(10):
-        cov = sum((X[i][a]-means[a])*(X[i][b]-means[b]) for i in range(n))/n
-        R[a][b] = cov/(sds[a]*sds[b]) if sds[a] and sds[b] else 0.0
+def zero(r):
+    d = ind(r)
+    return all(d[k] == 0 for k in KEYS)
 
 def jacobi_eigen(M, iters=200):
     import copy
@@ -48,18 +39,40 @@ def jacobi_eigen(M, iters=200):
         A = A2
     return sorted((A[i][i] for i in range(m)), reverse=True)
 
-eig = jacobi_eigen(R)
-tot = sum(eig)
-print("=== DIMENSIONALIDADE EFETIVA (autovalores da matriz de correlação) ===")
-acc = 0
-for i, e in enumerate(eig, 1):
-    acc += e/tot
-    print(f"  componente {i}: autovalor {e:5.2f}  variância {e/tot*100:5.1f}%  acumulada {acc*100:5.1f}%")
-print(f"\n  componentes com autovalor > 1 (critério de Kaiser): {sum(1 for e in eig if e > 1)}")
-print(f"  → o esquema de 10 indicadores comporta-se como {sum(1 for e in eig if e > 1)} dimensão(ões)")
+def dimensionalidade(recs_subset, titulo):
+    """Autovalores da matriz de correlação sobre um subconjunto de registros.
+    Regenera o par de leituras que a Auditoria Hostil do PR #162 (achado
+    GRAVE, ver review comment do Codex) apontou como não-reproduzível pelo
+    script original: com os zeros de importação, e só sobre o codificado."""
+    Xs = [[ind(r)[k] for k in KEYS] for r in recs_subset]
+    ns = len(Xs)
+    def colj(j): return [row[j] for row in Xs]
+    ms = [sum(colj(j))/ns for j in range(10)]
+    sd = [math.sqrt(sum((v-ms[j])**2 for v in colj(j))/ns) for j in range(10)]
+    Rs = [[0.0]*10 for _ in range(10)]
+    for a in range(10):
+        for b in range(10):
+            cov = sum((Xs[i][a]-ms[a])*(Xs[i][b]-ms[b]) for i in range(ns))/ns
+            Rs[a][b] = cov/(sd[a]*sd[b]) if sd[a] and sd[b] else 0.0
+    eig = jacobi_eigen(Rs)
+    tot = sum(eig)
+    print(f"=== DIMENSIONALIDADE EFETIVA — {titulo} (n={ns}) ===")
+    acc = 0
+    for i, e in enumerate(eig, 1):
+        acc += e/tot
+        print(f"  componente {i}: autovalor {e:5.2f}  variância {e/tot*100:5.1f}%  acumulada {acc*100:5.1f}%")
+    kaiser = sum(1 for e in eig if e > 1)
+    print(f"\n  componentes com autovalor > 1 (critério de Kaiser): {kaiser}")
+    print(f"  → o esquema de 10 indicadores comporta-se como {kaiser} dimensão(ões)\n")
+    return eig
+
+dimensionalidade(recs, "com falsos zeros de importação")
+dimensionalidade([r for r in recs if not zero(r)], "só registros efetivamente codificados")
 
 # --- sensibilidade ao limiar ---
-print("\n=== SENSIBILIDADE AO LIMIAR DE 'ATRIBUTO PRESENTE' ===")
+X = [[ind(r)[k] for k in KEYS] for r in recs]
+n = len(X)
+print("\n=== SENSIBILIDADE AO LIMIAR DE 'ATRIBUTO PRESENTE' (n=todos) ===")
 for thr in (1, 2, 3):
     counts = [sum(1 for v in row if v >= thr) for row in X]
     zeros = sum(1 for c in counts if c == 0)
@@ -78,8 +91,12 @@ for nome, grupo in (("todos os 10 atributos", todos10), ("todos os indicadores e
         print(f"    {campo}: {dict(c.most_common(5))}")
 
 # --- suporte, pela via correta ---
-print("\n=== SUPORTE (via iconocode.pre_iconographic / metadata) ===")
+print("\n=== SUPORTE (via purificacao.record_metadata.medium, com fallbacks) ===")
 def medium(r):
+    p = r.get('purificacao') or {}
+    rm = p.get('record_metadata') or {}
+    if rm.get('medium'):
+        return rm['medium']
     ic = r.get('iconocode') or {}
     pre = ic.get('pre_iconographic')
     if isinstance(pre, dict) and pre.get('medium'):

--- a/tools/audit/scripts/analise_evidencia.py
+++ b/tools/audit/scripts/analise_evidencia.py
@@ -22,14 +22,18 @@ def classifica(url):
     if ext in ('.html', '.htm', ''): return 'página web (precisa navegar)'
     return f'outro ({ext})'
 
-print("=== EVIDÊNCIA VISUAL DISPONÍVEL (todos os 328) ===")
+n_total = len(recs)
+n_zero = sum(1 for r in recs if zero(r))
+n_coded = n_total - n_zero
+
+print(f"=== EVIDÊNCIA VISUAL DISPONÍVEL (todos os {n_total}) ===")
 c = collections.Counter(classifica((r.get('input') or {}).get('input_url')) for r in recs)
 for k, v in c.most_common():
     print(f"  {k:<34} {v:>4}  ({v/len(recs)*100:.0f}%)")
 
 print("\n=== POR ESTADO DE CODIFICAÇÃO ===")
-for nome, grupo in (("não codificados (106)", [r for r in recs if zero(r)]),
-                    ("codificados (222)", [r for r in recs if not zero(r)])):
+for nome, grupo in ((f"não codificados ({n_zero})", [r for r in recs if zero(r)]),
+                    (f"codificados ({n_coded})", [r for r in recs if not zero(r)])):
     c = collections.Counter(classifica((r.get('input') or {}).get('input_url')) for r in grupo)
     print(f"  {nome}: " + " | ".join(f"{k}={v}" for k, v in c.most_common()))
 
@@ -54,11 +58,11 @@ for r in recs:
     if (r.get('input') or {}).get('date_hint'): tem['data'] += 1
     if (r.get('input') or {}).get('title_hint'): tem['título'] += 1
 for k, v in tem.most_common():
-    print(f"  {k:<32} {v:>4}/328  ({v/len(recs)*100:.0f}%)")
+    print(f"  {k:<32} {v:>4}/{n_total}  ({v/len(recs)*100:.0f}%)")
 
 print("\n=== VOLUME DE TRABALHO POR CENÁRIO ===")
-for nome, n in (("recodificar tudo", 328), ("só os não codificados", 106),
-                ("codificados a revisar", 222)):
+for nome, n in (("recodificar tudo", n_total), ("só os não codificados", n_zero),
+                ("codificados a revisar", n_coded)):
     for min_item in (8, 15, 25):
         horas = n * min_item / 60
         print(f"  {nome:<26} a {min_item:>2} min/item = {horas:>5.1f} h "

--- a/tools/audit/scripts/analise_indicadores.py
+++ b/tools/audit/scripts/analise_indicadores.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Diagnóstico empírico dos 10 indicadores LPAI sobre os 328 registros."""
+"""Diagnóstico empírico dos 10 indicadores LPAI sobre o ledger canônico atual."""
 import json, itertools, collections, math
 
 KEYS = ["desincorporacao","rigidez_postural","dessexualizacao","uniformizacao_facial",
@@ -13,8 +13,20 @@ def ind(r):
     p = r.get('purificacao') or {}
     return {k: p[k] for k in KEYS if isinstance(p.get(k), (int, float))}
 
-coded = [r for r in recs if len(ind(r)) == 10]
-print(f"com os 10 indicadores completos: {len(coded)}")
+def import_zero(r):
+    """Bloco de 10 zeros herdado de importação (vault-import/migration), não
+    juízo de codificação — mesmo critério usado em analise_lacunas.py e
+    analise_dimensional.py. Um registro com formato completo mas neste estado
+    não é 'codificado': é placeholder. Ver achado do Codex em #162 (a versão
+    anterior deste script contava esses 10-zeros como codificação completa)."""
+    d = ind(r)
+    return len(d) == 10 and all(d[k] == 0 for k in KEYS)
+
+completos = [r for r in recs if len(ind(r)) == 10]
+coded = [r for r in completos if not import_zero(r)]
+print(f"com os 10 indicadores completos (formato): {len(completos)}")
+print(f"  dos quais, zeros de importação (não codificados): {sum(1 for r in completos if import_zero(r))}")
+print(f"  efetivamente codificados: {len(coded)}")
 print(f"com codificação parcial: {sum(1 for r in recs if 0 < len(ind(r)) < 10)}")
 print(f"sem nenhum indicador: {sum(1 for r in recs if not ind(r))}\n")
 
@@ -79,10 +91,12 @@ for sig, n in assin.most_common(8):
 print("\n=== ATRIBUTOS POR SUPORTE (contagem média de atributos >=2) ===")
 sup = collections.defaultdict(list)
 for r in coded:
-    medium = ((r.get('iconocode') or {}).get('pre_iconographic') or {})
-    m = medium.get('medium') if isinstance(medium, dict) else None
-    if isinstance(medium, list):
-        m = next((x.get('medium') for x in medium if isinstance(x, dict) and x.get('medium')), None)
+    m = (r.get('purificacao') or {}).get('record_metadata', {}).get('medium')
+    if not m:
+        medium = ((r.get('iconocode') or {}).get('pre_iconographic') or {})
+        m = medium.get('medium') if isinstance(medium, dict) else None
+        if isinstance(medium, list):
+            m = next((x.get('medium') for x in medium if isinstance(x, dict) and x.get('medium')), None)
     d = ind(r)
     sup[m or 'não classificado'].append(sum(1 for k in KEYS if d[k] >= 2))
 for m, v in sorted(sup.items(), key=lambda x: -len(x[1]))[:10]:

--- a/tools/audit/scripts/analise_lacunas.py
+++ b/tools/audit/scripts/analise_lacunas.py
@@ -40,7 +40,7 @@ def corr(a, b):
     if not sds[a] or not sds[b]: return 0.0
     return (sum((X[i][a]-means[a])*(X[i][b]-means[b]) for i in range(n))/n)/(sds[a]*sds[b])
 
-print("\n=== MATRIZ DE CORRELAÇÃO (subcorpus codificado, 222) ===")
+print(f"\n=== MATRIZ DE CORRELAÇÃO (subcorpus codificado, {len(codif)}) ===")
 print("      " + "".join(f"{k[:5]:>7}" for k in KEYS))
 for a in range(10):
     print(f"{KEYS[a][:5]:<6}" + "".join(f"{corr(a,b):>7.2f}" for b in range(10)))


### PR DESCRIPTION
## Summary

Codex reviewed #162 immediately after merge and left 4 review comments, all still unresolved. This PR addresses all four, plus one same-class bug found while fixing them, and regenerates the doc's headline figures against the current ledger.

## The four findings

1. **`analise_dimensional.py` never read `purificacao.record_metadata.medium`** — collapsed the entire support table to "não classificado" (335/335). Fixed the lookup order.
2. **Same script had no filtered (zero-row-excluded) pass** — computed dimensionality only over the full unfiltered set, so it couldn't reproduce the "3-factor" claim the LPAI v3 doc cites it for. Added a proper filtered pass; both now print side by side.
3. **`analise_indicadores.py` had the identical bug under a different name** — its `coded` filter checked only that all 10 indicator keys were numeric (which the 106 zero-import rows satisfy), not that they were actually coded. Fixed to match the correct filter already present in `analise_lacunas.py`. Also fixed its own, separate `medium` lookup for the same root cause as #1.
4. **The appendix claimed the zero→non-coded migration was done** — `records.jsonl` still stores raw numeric `0`, no structural marker. Corrected the text to state it's pending (Codex's recommended option); did **not** perform the actual schema migration — that's real corpus-data surgery needing a defined target schema, out of scope for a docs/audit-script fix.

## What else changed

- Every hardcoded `328`/`222`/`106` literal across the four audit scripts replaced with values computed from the live record count, so this doesn't rot again next time the corpus grows.
- `docs/metodologia/arquitetura-atributos-lpai-v3.md` §2.1–2.3 regenerated against the current ledger (335 total, still 106 zero-rows → 229 coded — corpus grew +7 since #162 merged):
  - **The flagship finding reproduced exactly**: military-regime inversion (serialidade 0.93→2.27, inscrição estatal 0.89→2.18, dessexualização 0.78→1.91, heraldização 0.76→1.86) — identical values despite +7 records. This is evidence the finding is robust, not an artifact of a stale snapshot.
  - 3-factor structure confirmed: 4.65/1.25/1.04 (old) → 4.77/1.24/1.03 (current), same shape.
  - Regime/country coverage tables updated with matching small drift.
  - **One new discrepancy surfaced, not silently resolved**: the "with false zeros" correlation-pair count recomputes to 18 pairs ≥0.70, not the original 7 (same max pair and value, r=0.88). Flagged explicitly in the doc's update note as unexplained, pending investigation — not asserted as fact either way.
- Sections beyond §2.3 (planning, ENDURECIMENTO panel rebuild) still cite 328/222 as originally written — explicitly scoped in the update note as the historical baseline (as of 2026-07-29), not silently left inconsistent with §2.

## Surface

- [x] Corpus/data — audit *scripts* only; `data/processed/records.jsonl` itself untouched
- [ ] Coding/analysis
- [x] Writing/docs
- [ ] Infra/publishing

## Checks

- [x] All four scripts in `tools/audit/scripts/` run clean against current `data/processed/records.jsonl` (verified locally, no exceptions)
- [ ] `python tools/scripts/validate_schemas.py` — n/a, no schema or canonical-data changes
- [ ] `code_purification.py --status` — n/a

## Notes

- The zero→`NÃO_CODIFICADO` migration itself (Codex finding #4's "or" option) is a separate, higher-risk follow-up: it touches the canonical `purificacao` block of 106 records and needs a schema decision (structured field vs. sentinel value) that doesn't exist yet in any merged doc.
- Marked draft pending your read of the 18-vs-7 correlation-pair discrepancy — didn't want to silently pick a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3FKLLbo5HpN2192K8Loau

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3FKLLbo5HpN2192K8Loau)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3FKLLbo5HpN2192K8Loau)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5dc4935a6c7f0822659cf8913c0fcd0d8a8d6bca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->