### PR TITLE
fix(huggingface): separate viewer dataset configs

### DIFF
--- a/docs/huggingface-release.md
+++ b/docs/huggingface-release.md
@@ -34,6 +34,16 @@ Snapshot contents:
 - `CHANGELOG.md`
 - `README.md`
 
+The generated dataset card exposes three independent Viewer configurations:
+
+- `corpus` (default): public-facing corpus export
+- `records`: canonical records ledger
+- `purification`: coding-observation ledger
+
+The configurations keep the three distinct schemas from being concatenated by
+the Hugging Face JSON builder. `release.json` remains metadata and is not
+declared as a tabular data file.
+
 ## Publish the dataset
 
 Prerequisite: authenticate the local CLI first.

--- a/tests/test_build_hf_release.py
+++ b/tests/test_build_hf_release.py
@@ -89,6 +89,26 @@ def test_render_readme_describes_drift_direction(delta: int, expected: str):
     assert "Master-record schema versions: `unknown`" in readme
 
 
+def test_render_readme_separates_incompatible_viewer_tables():
+    stats = {
+        "schema_versions": ["2.0.0"],
+        "mean_endurecimento": 0.964,
+        "corpus_records_delta": 0,
+        "generated_at": "2026-08-12T00:00:00Z",
+        "corpus_items": 335,
+        "records_items": 335,
+        "coded_items": 286,
+        "country_count": 19,
+    }
+
+    card = release.render_readme("owner/dataset", "v1", stats, "- note\n")
+
+    assert "- config_name: corpus\n  data_files: corpus-data.json\n  default: true" in card
+    assert "- config_name: records\n  data_files: records.jsonl" in card
+    assert "- config_name: purification\n  data_files: purification.jsonl" in card
+    assert "data_files: release.json" not in card
+
+
 def test_render_changelog_supplies_default_note():
     result = release.render_changelog([], {"corpus_items": 3, "records_items": 3, "coded_items": 2})
 

--- a/tools/scripts/build_hf_release.py
+++ b/tools/scripts/build_hf_release.py
@@ -152,6 +152,14 @@ tags:
 - feminist-iconography
 - abnt
 - metadata
+configs:
+- config_name: corpus
+  data_files: corpus-data.json
+  default: true
+- config_name: records
+  data_files: records.jsonl
+- config_name: purification
+  data_files: purification.jsonl
 ---
 
 # ICONOCRACY Corpus
@@ -192,9 +200,9 @@ Source-of-truth hierarchy:
 
 ## Files
 
-- `corpus-data.json`
-- `records.jsonl`
-- `purification.jsonl`
+- `corpus-data.json` — default `corpus` configuration for public exploration
+- `records.jsonl` — canonical `records` configuration
+- `purification.jsonl` — coding-observation `purification` configuration
 - `release.json`
 - `CHANGELOG.md`
 


### PR DESCRIPTION
## Resumo

- declara configurações independentes para corpus, records e purification
- impede que o Dataset Viewer concatene schemas incompatíveis
- mantém release.json fora da descoberta tabular
- documenta o contrato e adiciona teste de regressão

## Validação

- 335/335 registros válidos
- records.jsonl e corpus-data.json sincronizados
- 30 testes direcionados passando
- dataset card YAML validado localmente