### PR TITLE
docs(huggingface): archive regime coverage analysis

### DIFF
--- a/docs/research/huggingface/regime-coverage-2026-08-13/README.md
+++ b/docs/research/huggingface/regime-coverage-2026-08-13/README.md
@@ -1,0 +1,87 @@
+# Cobertura de codificação por regime iconocrático
+
+Snapshot analítico do dataset público
+[`warholana/iconocracy-corpus`](https://huggingface.co/datasets/warholana/iconocracy-corpus),
+consultado em 13 de agosto de 2026.
+
+## Pergunta analítica
+
+Como os 49 itens ainda sem observação em `purification` se distribuem entre os
+quatro regimes iconocráticos do corpus público?
+
+## Resultado
+
+| Regime | Total | Codificados | Pendentes | Cobertura |
+| --- | ---: | ---: | ---: | ---: |
+| Fundacional | 163 | 149 | 14 | 91,4% |
+| Normativo | 103 | 99 | 4 | 96,1% |
+| Militar | 54 | 28 | 26 | 51,9% |
+| Contra-alegoria | 15 | 10 | 5 | 66,7% |
+| **Total** | **335** | **286** | **49** | **85,4%** |
+
+O regime militar concentra 26 dos 49 itens pendentes (53,1% da lacuna) e tem
+a menor cobertura de codificação (51,9%). Ele é, portanto, a prioridade
+quantitativa mais clara para a próxima campanha de codificação. Essa prioridade
+não substitui adjudicação qualitativa nem implica que todos os itens militares
+tenham o mesmo valor historiográfico.
+
+![Cobertura de codificação por regime iconocrático](coverage.svg)
+
+## Proveniência e limite de inferência
+
+A consulta usa os Parquets derivados pelo Dataset Viewer do Hugging Face:
+
+- `corpus/train/0000.parquet`: 335 itens, agregados por `regime`;
+- `purification/train/0000.parquet`: 286 observações, agregadas por
+  `regime_iconocratico`.
+
+Os namespaces de identidade não coincidem na superfície pública: `corpus.id`
+usa UUIDs, enquanto `purification.id` ainda contém identificadores como
+`AR-001`. Por isso, a análise compara contagens agregadas por regime e **não**
+faz join item a item. O campo `pending_items` é uma diferença entre estratos,
+não uma lista nominal de objetos pendentes.
+
+## Reprodução
+
+Requer Node.js e acesso à internet. A partir desta pasta:
+
+```bash
+CORPUS_PARQUET="hf://datasets/warholana/iconocracy-corpus"
+CORPUS_PARQUET="${CORPUS_PARQUET}@~parquet/corpus/train/0000.parquet"
+
+npx -y -p parquetlens -p @parquetlens/sql parquetlens \
+  "$CORPUS_PARQUET" \
+  --sql "$(tr '\n' ' ' < query.sql)"
+
+/Users/ana/.venvs/iconocracy/bin/python3.12 render_coverage.py
+```
+
+O primeiro comando produz `tmp_coverage.csv`; o segundo valida e promove esse
+arquivo atomicamente para `coverage.csv`, depois regenera `coverage.svg`.
+Para conferir a disponibilidade e os shards atuais antes da reprodução:
+
+```bash
+curl -fsSL \
+  "https://datasets-server.huggingface.co/is-valid?dataset=warholana%2Ficonocracy-corpus"
+
+curl -fsSL \
+  "https://datasets-server.huggingface.co/parquet?dataset=warholana%2Ficonocracy-corpus"
+```
+
+## Contrato da figura
+
+- Família: comparação e composição.
+- Variante: barras horizontais empilhadas.
+- Unidade: itens históricos por regime.
+- Denominador: total de itens de cada regime no `corpus`.
+- Cor: bordô para codificado; preenchimento neutro para pendente.
+- Distinção não cromática: rótulos diretos, contagens e percentuais.
+- Escala: começa em zero; comprimento total da barra equivale ao denominador.
+
+## Arquivos
+
+- `query.sql`: consulta DuckDB/ParquetLens executada sobre os Parquets públicos;
+- `coverage.csv`: resultado agregado e revisável em diff;
+- `render_coverage.py`: valida/promove o CSV e renderiza a figura, somente com
+  a biblioteca padrão;
+- `coverage.svg`: figura vetorial pronta para Markdown, impressão e slides.

--- a/docs/research/huggingface/regime-coverage-2026-08-13/coverage.csv
+++ b/docs/research/huggingface/regime-coverage-2026-08-13/coverage.csv
@@ -1,0 +1,5 @@
+regime,total_items,coded_items,pending_items,coverage_pct
+fundacional,163,149,14,91.4
+normativo,103,99,4,96.1
+militar,54,28,26,51.9
+contra-alegoria,15,10,5,66.7

--- a/docs/research/huggingface/regime-coverage-2026-08-13/coverage.svg
+++ b/docs/research/huggingface/regime-coverage-2026-08-13/coverage.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+<title id="title">Cobertura de codificação por regime iconocrático</title>
+<desc id="desc">Barras horizontais empilhadas mostram itens codificados e pendentes nos regimes fundacional, normativo, militar e contra-alegoria.</desc>
+<style>
+  .serif { font-family: Gentium, Georgia, serif; }
+  .sans { font-family: Inter, Helvetica, Arial, sans-serif; }
+  .mono { font-family: "DejaVu Sans Mono", Menlo, monospace; }
+</style>
+<rect width="1440" height="900" fill="#FAF6EC"/>
+<text id="chart-title" x="80" y="78" class="serif" font-size="38" font-weight="700" fill="#1C1C1C">Cobertura de codificação por regime</text>
+<text x="80" y="116" class="sans" font-size="19" fill="#6B6459">Corpus público: 335 itens · purification: 286 observações · 49 pendências</text>
+<line x1="80" y1="140" x2="670" y2="140" stroke="#B8892B" stroke-width="2"/>
+<text x="1360" y="76" text-anchor="end" class="serif" font-size="32" fill="#6B1E2E">❋</text>
+<text x="1360" y="108" text-anchor="end" class="mono" font-size="12" fill="#6B6459">ICONOCRACIA · 2026-08-13</text>
+<rect x="870" y="157" width="20" height="20" rx="2" fill="#6B1E2E"/><text x="900" y="173" class="sans" font-size="14" fill="#1C1C1C">Codificado</text>
+<rect x="1025" y="157" width="20" height="20" rx="2" fill="#E8D4D7" stroke="#6B6459" stroke-width="1"/><text x="1055" y="173" class="sans" font-size="14" fill="#1C1C1C">Pendente</text>
+<line x1="350.0" y1="205" x2="350.0" y2="690" stroke="#D8CCB9" stroke-width="1"/>
+<text x="350.0" y="716" text-anchor="middle" class="mono" font-size="12" fill="#6B6459">0</text>
+<line x1="570.9" y1="205" x2="570.9" y2="690" stroke="#D8CCB9" stroke-width="1"/>
+<text x="570.9" y="716" text-anchor="middle" class="mono" font-size="12" fill="#6B6459">40</text>
+<line x1="791.7" y1="205" x2="791.7" y2="690" stroke="#D8CCB9" stroke-width="1"/>
+<text x="791.7" y="716" text-anchor="middle" class="mono" font-size="12" fill="#6B6459">80</text>
+<line x1="1012.6" y1="205" x2="1012.6" y2="690" stroke="#D8CCB9" stroke-width="1"/>
+<text x="1012.6" y="716" text-anchor="middle" class="mono" font-size="12" fill="#6B6459">120</text>
+<line x1="1233.4" y1="205" x2="1233.4" y2="690" stroke="#D8CCB9" stroke-width="1"/>
+<text x="1233.4" y="716" text-anchor="middle" class="mono" font-size="12" fill="#6B6459">160</text>
+<text x="320" y="269" text-anchor="end" class="serif" font-size="22" fill="#1C1C1C">Fundacional</text>
+<rect x="350" y="235" width="900.0" height="54" rx="5" fill="#E8D4D7" stroke="#6B6459" stroke-width="1"/>
+<path d="M 355 235 H 1172.7 V 289 H 355 Q 350 289 350 284 V 240 Q 350 235 355 235 Z" fill="#6B1E2E"/>
+<text x="364" y="269" class="mono" font-size="14" fill="#FFFFFF">149 codificados</text>
+<text x="1268.0" y="260" class="mono" font-size="14" font-weight="700" fill="#1C1C1C">91,4%</text>
+<text x="1268.0" y="280" class="sans" font-size="12" fill="#6B6459">14 pendentes · n=163</text>
+<text x="320" y="381" text-anchor="end" class="serif" font-size="22" fill="#1C1C1C">Normativo</text>
+<rect x="350" y="347" width="568.7" height="54" rx="5" fill="#E8D4D7" stroke="#6B6459" stroke-width="1"/>
+<path d="M 355 347 H 896.6 V 401 H 355 Q 350 401 350 396 V 352 Q 350 347 355 347 Z" fill="#6B1E2E"/>
+<text x="364" y="381" class="mono" font-size="14" fill="#FFFFFF">99 codificados</text>
+<text x="936.7" y="372" class="mono" font-size="14" font-weight="700" fill="#1C1C1C">96,1%</text>
+<text x="936.7" y="392" class="sans" font-size="12" fill="#6B6459">4 pendentes · n=103</text>
+<text x="320" y="493" text-anchor="end" class="serif" font-size="22" fill="#1C1C1C">Militar</text>
+<rect x="350" y="459" width="298.2" height="54" rx="5" fill="#E8D4D7" stroke="#6B6459" stroke-width="1"/>
+<path d="M 355 459 H 504.6 V 513 H 355 Q 350 513 350 508 V 464 Q 350 459 355 459 Z" fill="#6B1E2E"/>
+<text x="364" y="493" class="mono" font-size="14" fill="#FFFFFF">28 codificados</text>
+<text x="666.2" y="484" class="mono" font-size="14" font-weight="700" fill="#1C1C1C">51,9%</text>
+<text x="666.2" y="504" class="sans" font-size="12" fill="#6B6459">26 pendentes · n=54</text>
+<text x="320" y="605" text-anchor="end" class="serif" font-size="22" fill="#1C1C1C">Contra-alegoria</text>
+<rect x="350" y="571" width="82.8" height="54" rx="5" fill="#E8D4D7" stroke="#6B6459" stroke-width="1"/>
+<path d="M 355 571 H 405.2 V 625 H 355 Q 350 625 350 620 V 576 Q 350 571 355 571 Z" fill="#6B1E2E"/>
+<text x="364" y="605" class="mono" font-size="14" fill="#FFFFFF">10</text>
+<text x="450.8" y="596" class="mono" font-size="14" font-weight="700" fill="#1C1C1C">66,7%</text>
+<text x="450.8" y="616" class="sans" font-size="12" fill="#6B6459">5 pendentes · n=15</text>
+<text x="800.0" y="750" text-anchor="middle" class="sans" font-size="14" fill="#6B6459">Itens históricos</text>
+<line x1="80" y1="790" x2="1360" y2="790" stroke="#B8892B" stroke-width="1"/>
+<text x="80" y="822" class="sans" font-size="13" fill="#1C1C1C"><tspan font-weight="700">Leitura:</tspan> o regime militar concentra 26 das 49 pendências e tem a menor cobertura (51,9%).</text>
+<text x="80" y="850" class="sans" font-size="12" fill="#6B6459">Fonte: Hugging Face Dataset Viewer · warholana/iconocracy-corpus · configs corpus e purification. Comparação agregada por regime; sem join item a item.</text>
+</svg>

--- a/docs/research/huggingface/regime-coverage-2026-08-13/query.sql
+++ b/docs/research/huggingface/regime-coverage-2026-08-13/query.sql
@@ -1,0 +1,27 @@
+COPY (
+  WITH totals AS (
+    SELECT
+      regime,
+      COUNT(*)::INTEGER AS total_items
+    FROM data
+    GROUP BY regime
+  ),
+  coded AS (
+    SELECT
+      regime_iconocratico AS regime,
+      COUNT(*)::INTEGER AS coded_items
+    FROM read_parquet(
+      'https://huggingface.co/datasets/warholana/iconocracy-corpus/resolve/refs%2Fconvert%2Fparquet/purification/train/0000.parquet'
+    )
+    GROUP BY regime_iconocratico
+  )
+  SELECT
+    totals.regime,
+    totals.total_items,
+    coded.coded_items,
+    totals.total_items - coded.coded_items AS pending_items,
+    ROUND(100.0 * coded.coded_items / totals.total_items, 1) AS coverage_pct
+  FROM totals
+  JOIN coded USING (regime)
+  ORDER BY totals.total_items DESC
+) TO 'tmp_coverage.csv' (FORMAT CSV, HEADER, DELIMITER ',');

--- a/docs/research/huggingface/regime-coverage-2026-08-13/render_coverage.py
+++ b/docs/research/huggingface/regime-coverage-2026-08-13/render_coverage.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Render the public Hugging Face regime-coverage snapshot as SVG."""
+
+from __future__ import annotations
+
+import csv
+from html import escape
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+INPUT = HERE / "coverage.csv"
+PENDING_INPUT = HERE / "tmp_coverage.csv"
+OUTPUT = HERE / "coverage.svg"
+
+WIDTH = 1440
+HEIGHT = 900
+BAR_X = 350
+BAR_WIDTH = 900
+BAR_HEIGHT = 54
+MAX_TOTAL = 163
+
+COLORS = {
+    "background": "#FAF6EC",
+    "ink": "#1C1C1C",
+    "muted": "#6B6459",
+    "coded": "#6B1E2E",
+    "pending": "#E8D4D7",
+    "gold": "#B8892B",
+    "grid": "#D8CCB9",
+}
+
+LABELS = {
+    "fundacional": "Fundacional",
+    "normativo": "Normativo",
+    "militar": "Militar",
+    "contra-alegoria": "Contra-alegoria",
+}
+
+
+def load_rows(path: Path = INPUT) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    required = {
+        "regime",
+        "total_items",
+        "coded_items",
+        "pending_items",
+        "coverage_pct",
+    }
+    if not rows or set(rows[0]) != required:
+        raise SystemExit(f"Unexpected columns in {path.name}: {rows[0].keys() if rows else 'empty'}")
+    if sum(int(row["total_items"]) for row in rows) != 335:
+        raise SystemExit(f"Unexpected corpus total in {path.name}")
+    if sum(int(row["coded_items"]) for row in rows) != 286:
+        raise SystemExit(f"Unexpected purification total in {path.name}")
+    if any(
+        int(row["coded_items"]) + int(row["pending_items"]) != int(row["total_items"])
+        for row in rows
+    ):
+        raise SystemExit(f"Inconsistent coverage arithmetic in {path.name}")
+    return rows
+
+
+def pct_pt(value: str) -> str:
+    return value.replace(".", ",") + "%"
+
+
+def render(rows: list[dict[str, str]]) -> str:
+    svg: list[str] = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        (
+            f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {WIDTH} {HEIGHT}" '
+            'role="img" aria-labelledby="title desc">'
+        ),
+        '<title id="title">Cobertura de codificação por regime iconocrático</title>',
+        (
+            '<desc id="desc">Barras horizontais empilhadas mostram itens codificados e '
+            'pendentes nos regimes fundacional, normativo, militar e contra-alegoria.</desc>'
+        ),
+        '<style>',
+        '  .serif { font-family: Gentium, Georgia, serif; }',
+        '  .sans { font-family: Inter, Helvetica, Arial, sans-serif; }',
+        '  .mono { font-family: "DejaVu Sans Mono", Menlo, monospace; }',
+        '</style>',
+        f'<rect width="{WIDTH}" height="{HEIGHT}" fill="{COLORS["background"]}"/>',
+        (
+            f'<text id="chart-title" x="80" y="78" class="serif" font-size="38" '
+            f'font-weight="700" fill="{COLORS["ink"]}">Cobertura de codificação por regime</text>'
+        ),
+        (
+            f'<text x="80" y="116" class="sans" font-size="19" fill="{COLORS["muted"]}">'
+            'Corpus público: 335 itens · purification: 286 observações · 49 pendências</text>'
+        ),
+        f'<line x1="80" y1="140" x2="670" y2="140" stroke="{COLORS["gold"]}" stroke-width="2"/>',
+        (
+            f'<text x="1360" y="76" text-anchor="end" class="serif" font-size="32" '
+            f'fill="{COLORS["coded"]}">❋</text>'
+        ),
+        (
+            f'<text x="1360" y="108" text-anchor="end" class="mono" font-size="12" '
+            f'fill="{COLORS["muted"]}">ICONOCRACIA · 2026-08-13</text>'
+        ),
+        (
+            f'<rect x="870" y="157" width="20" height="20" rx="2" fill="{COLORS["coded"]}"/>'
+            f'<text x="900" y="173" class="sans" font-size="14" fill="{COLORS["ink"]}">Codificado</text>'
+        ),
+        (
+            f'<rect x="1025" y="157" width="20" height="20" rx="2" fill="{COLORS["pending"]}" '
+            f'stroke="{COLORS["muted"]}" stroke-width="1"/>'
+            f'<text x="1055" y="173" class="sans" font-size="14" fill="{COLORS["ink"]}">Pendente</text>'
+        ),
+    ]
+
+    for tick in (0, 40, 80, 120, 160):
+        x = BAR_X + (tick / MAX_TOTAL) * BAR_WIDTH
+        svg.extend(
+            [
+                f'<line x1="{x:.1f}" y1="205" x2="{x:.1f}" y2="690" stroke="{COLORS["grid"]}" stroke-width="1"/>',
+                (
+                    f'<text x="{x:.1f}" y="716" text-anchor="middle" class="mono" '
+                    f'font-size="12" fill="{COLORS["muted"]}">{tick}</text>'
+                ),
+            ]
+        )
+
+    start_y = 235
+    gap = 112
+    for index, row in enumerate(rows):
+        y = start_y + index * gap
+        total = int(row["total_items"])
+        coded = int(row["coded_items"])
+        pending = int(row["pending_items"])
+        total_width = total / MAX_TOTAL * BAR_WIDTH
+        coded_width = coded / MAX_TOTAL * BAR_WIDTH
+        pending_width = pending / MAX_TOTAL * BAR_WIDTH
+        label = escape(LABELS.get(row["regime"], row["regime"]))
+        coverage = pct_pt(row["coverage_pct"])
+        coded_label = str(coded) if coded_width < 140 else f"{coded} codificados"
+
+        svg.extend(
+            [
+                (
+                    f'<text x="320" y="{y + 34}" text-anchor="end" class="serif" '
+                    f'font-size="22" fill="{COLORS["ink"]}">{label}</text>'
+                ),
+                (
+                    f'<rect x="{BAR_X}" y="{y}" width="{total_width:.1f}" height="{BAR_HEIGHT}" '
+                    f'rx="5" fill="{COLORS["pending"]}" stroke="{COLORS["muted"]}" stroke-width="1"/>'
+                ),
+                (
+                    f'<path d="M {BAR_X + 5} {y} H {BAR_X + coded_width:.1f} '
+                    f'V {y + BAR_HEIGHT} H {BAR_X + 5} Q {BAR_X} {y + BAR_HEIGHT} '
+                    f'{BAR_X} {y + BAR_HEIGHT - 5} V {y + 5} Q {BAR_X} {y} {BAR_X + 5} {y} Z" '
+                    f'fill="{COLORS["coded"]}"/>'
+                ),
+                (
+                    f'<text x="{BAR_X + 14}" y="{y + 34}" class="mono" font-size="14" '
+                    f'fill="#FFFFFF">{coded_label}</text>'
+                ),
+                (
+                    f'<text x="{BAR_X + total_width + 18:.1f}" y="{y + 25}" class="mono" '
+                    f'font-size="14" font-weight="700" fill="{COLORS["ink"]}">{coverage}</text>'
+                ),
+                (
+                    f'<text x="{BAR_X + total_width + 18:.1f}" y="{y + 45}" class="sans" '
+                    f'font-size="12" fill="{COLORS["muted"]}">{pending} pendentes · n={total}</text>'
+                ),
+            ]
+        )
+
+    svg.extend(
+        [
+            (
+                f'<text x="{BAR_X + BAR_WIDTH / 2}" y="750" text-anchor="middle" class="sans" '
+                f'font-size="14" fill="{COLORS["muted"]}">Itens históricos</text>'
+            ),
+            f'<line x1="80" y1="790" x2="1360" y2="790" stroke="{COLORS["gold"]}" stroke-width="1"/>',
+            (
+                f'<text x="80" y="822" class="sans" font-size="13" fill="{COLORS["ink"]}">'
+                '<tspan font-weight="700">Leitura:</tspan> o regime militar concentra 26 das 49 pendências '
+                'e tem a menor cobertura (51,9%).</text>'
+            ),
+            (
+                f'<text x="80" y="850" class="sans" font-size="12" fill="{COLORS["muted"]}">'
+                'Fonte: Hugging Face Dataset Viewer · warholana/iconocracy-corpus · configs corpus e purification. '
+                'Comparação agregada por regime; sem join item a item.</text>'
+            ),
+            '</svg>',
+        ]
+    )
+    return "\n".join(svg) + "\n"
+
+
+def main() -> None:
+    if PENDING_INPUT.exists():
+        load_rows(PENDING_INPUT)
+        PENDING_INPUT.replace(INPUT)
+        print(f"Promoted {PENDING_INPUT.name} to {INPUT.name}")
+    rows = load_rows()
+    OUTPUT.write_text(render(rows), encoding="utf-8")
+    print(f"Wrote {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resumo

- arquiva a consulta SQL reproduzível contra os Parquets públicos do Hugging Face
- registra o snapshot agregado de cobertura por regime em CSV
- adiciona renderizador determinístico e figura SVG inspecionada
- documenta a incompatibilidade atual entre UUIDs de corpus e IDs públicos de purification

## Resultado

- corpus: 335 itens
- purification: 286 observações
- pendentes: 49
- regime militar: 26 pendências e 51,9% de cobertura

## Validação

- consulta reproduzida com ParquetLens/DuckDB
- aritmética 335 = 286 + 49 verificada
- SVG válido e inspecionado visualmente
- render_coverage.py compilado com Python 3.12
- markdownlint e git diff --check sem erros