### PR TITLE
fix(tests): remove marcadores de conflito commitados no merge 0f80b6b

### DIFF
--- a/docs/decisions/ELICIT-CODEBOOK-PATCH-v2.3.0-2026-06-25.md
+++ b/docs/decisions/ELICIT-CODEBOOK-PATCH-v2.3.0-2026-06-25.md
@@ -214,4 +214,3 @@ nao tapalas. Justificativa epistemologica em ADR §4.
    (Chillon/19&20, orioqueorionaove, Titius) antes de promover v2.3.0 a
    `master_record`. As 5 refs normalizadas cobrem a bibliografia central;
    estas 3 sao fontes secundarias para casos brasileiros.
-||||||| 967f1d9

--- a/schema/codebook-v2.3.0.md
+++ b/schema/codebook-v2.3.0.md
@@ -448,4 +448,3 @@ Refs:
   - commit 49caba3 (validator升级 com 3 regras condicionais)
   - commit cc0bb31 (patch v2.3.0 original; "Bloqueios para freeze real")
   - docs/decisions/2026-06-25-lacunas-v2.3.0.md (ADR formal deste registro)
-||||||| 967f1d9

--- a/tese/artigos/justica-liberdade-vestes-femininas-rev.md
+++ b/tese/artigos/justica-liberdade-vestes-femininas-rev.md
@@ -214,8 +214,3 @@ SCOTT, Joan Wallach. **The politics of the veil**. Princeton: Princeton Universi
 SEBESTA, Judith Lynn; BONFANTE, Larissa (org.). **The world of Roman costume**. Madison: University of Wisconsin Press, 1994.
 
 WARNER, Marina. **Monuments and maidens: the allegory of the female form**. London: Weidenfeld & Nicolson, 1985.
-<<<<<<< HEAD
-
-||||||| 2b5f656
-=======
->>>>>>> origin/fix/support-idempotency-gate

--- a/tests/argos/test_manifest_builder.py
+++ b/tests/argos/test_manifest_builder.py
@@ -11,17 +11,6 @@ from unittest import mock
 
 from tools.argos.manifest import build_manifest
 
-<<<<<<< HEAD
-# Exercise CLI entry points with the same interpreter running the test suite.
-ICONOCRACY_PYTHON = sys.executable
-
-||||||| 2b5f656
-# Use the iconocracy conda environment Python for subprocess calls
-ICONOCRACY_PYTHON = "/opt/homebrew/Caskroom/miniforge/base/envs/iconocracy/bin/python"
-
-=======
->>>>>>> origin/fix/support-idempotency-gate
-
 def load_argos_build_manifest_module():
     repo_root = Path(__file__).resolve().parents[2]
     script_path = repo_root / "tools" / "scripts" / "argos_build_manifest.py"

--- a/tests/argos/test_manifest_schema.py
+++ b/tests/argos/test_manifest_schema.py
@@ -8,17 +8,6 @@ from pathlib import Path
 
 from tools.scripts.validate_schemas import load_schema, validate_record
 
-<<<<<<< HEAD
-# Exercise CLI entry points with the same interpreter running the test suite.
-ICONOCRACY_PYTHON = sys.executable
-
-||||||| 2b5f656
-# Use the iconocracy conda environment Python for subprocess calls
-ICONOCRACY_PYTHON = "/opt/homebrew/Caskroom/miniforge/base/envs/iconocracy/bin/python"
-
-=======
->>>>>>> origin/fix/support-idempotency-gate
-
 class ManifestSchemaTests(unittest.TestCase):
     def make_manifest(self, *, status="pending"):
         return {

--- a/tests/argos/test_manifest_update.py
+++ b/tests/argos/test_manifest_update.py
@@ -8,17 +8,6 @@ from pathlib import Path
 
 from tools.argos.manifest import locked_update_manifest
 
-<<<<<<< HEAD
-# Exercise CLI entry points with the same interpreter running the test suite.
-ICONOCRACY_PYTHON = sys.executable
-
-||||||| 2b5f656
-# Use the iconocracy conda environment Python for subprocess calls
-ICONOCRACY_PYTHON = "/opt/homebrew/Caskroom/miniforge/base/envs/iconocracy/bin/python"
-
-=======
->>>>>>> origin/fix/support-idempotency-gate
-
 class ManifestUpdateTests(unittest.TestCase):
     def setUp(self):
         self.repo_root = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Por quê

A `main` está vermelha no **Validate Schemas** desde 2026-08-12: o merge `0f80b6b` ("Expand corpus research materials") subiu com **marcadores de conflito diff3 commitados** em 6 arquivos. Nos 3 testes argos, o bloco `||||||| 2b5f656` é um SyntaxError que interrompe a coleta do pytest:

```
tests/argos/test_manifest_builder.py:18
    ||||||| 2b5f656
SyntaxError: invalid decimal literal
!!!! Interrupted: 3 errors during collection !!!!
```

É a mesma classe de bug que o PR #178 já corrigiu no `DASHBOARD_CORPUS.html`.

## Resolução

**Testes argos (3 arquivos):** lado entrante (`b961663`), que remove a constante `ICONOCRACY_PYTHON` e usa `sys.executable` inline nos call sites. As alternativas eram piores: o lado HEAD manteria uma constante morta, e a versão base (`2b5f656`) hardcodava `/opt/homebrew/.../iconocracy/bin/python` — path local que não existe no runner do CI.

**Detritos sem conteúdo (zero mudança de texto):**
- `tese/artigos/justica-liberdade-vestes-femininas-rev.md` — bloco de conflito **vazio** no fim das referências ABNT
- `schema/codebook-v2.3.0.md` — marcador `||||||| 967f1d9` órfão na última linha
- `docs/decisions/ELICIT-CODEBOOK-PATCH-v2.3.0-2026-06-25.md` — idem

**Não tocado:** `wiki/conflict-files-obsidian-git.md` — é o log auto-gerado pelo plugin Obsidian Git (lista de conflitos a resolver), não um conflito real.

## Verificação

```
$ pytest tests/  →  275 passed          # antes: coleta interrompida, 3 SyntaxError
$ python tools/scripts/check_corpus_export_idempotent.py
corpus export idempotent: authoritative fields match   # segue verde pós-#160
```

Diff total: 6 arquivos, 40 deleções, 0 inserções — só remoção de marcadores.