### PR TITLE
refactor(corpus): harden canonical data projections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,17 @@
 
 > **This is the quick-reference card.** For full architecture, mode routing, hooks, skills, terminology tables, known data issues, and corpus parameters, see [`CLAUDE.md`](CLAUDE.md).
 
-## Data Hierarchy (audit 2026-07-31)
+## Canonical Field Ownership (audit 2026-08-12)
 
-| # | Layer | Count | Role |
-|---|-------|-------|------|
-| 1 | `data/processed/records.jsonl` | 335 | Canonical operational ledger |
-| 2 | `corpus/corpus-data.json` | 335 | Public-facing export |
-| 3 | `data/processed/purification.jsonl` | 279 | Endurecimento coding ledger |
-| 4 | `vault/candidatos/` | 410 | Auxiliary cataloguing mirror |
+| Field family | Authority | Current count |
+|---|---|---|
+| Identity, evidence, description, IconoCode claims | `data/processed/records.jsonl` | 335 items |
+| Endurecimento observations and coding provenance | `data/processed/purification.jsonl` | 286 rows |
+| Raw binary identity and storage | `data/raw/drive-manifest.json` + Drive | manifest |
+| Catalogue navigation | `vault/candidatos/` | auxiliary mirror |
+
+`corpus-data.json`, SQLite, CSV, dashboards, and release bundles are disposable
+projections. See `docs/adr/006-canonical-field-ownership-and-projections.md`.
 
 ## Environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,12 +68,17 @@ WebScout (archive discovery) → IconoCode (visual analysis) → master records
 - **IconoCode** performs 3-level Panofsky analysis + iconometria measurement (endurecimento = fixity axis, 10 indicators 0–3 scale)
 - Output: `data/processed/records.jsonl` (canonical) → `corpus/corpus-data.json` (public export)
 
-### Canonical Data Hierarchy (source-of-truth order)
+### Canonical Field Ownership
 
-1. `data/processed/records.jsonl` — operational canonical ledger
-2. `corpus/corpus-data.json` — public-facing export (browsers, dashboards, HF releases)
-3. `data/processed/purification.jsonl` — endurecimento coding ledger
-4. `vault/candidatos/` — auxiliary cataloguing mirror only
+- `data/processed/records.jsonl` — item identity, source evidence, descriptive
+  metadata, and IconoCode claims.
+- `data/processed/purification.jsonl` — endurecimento observations and coder,
+  round, instrument, and adjudication provenance.
+- `data/raw/drive-manifest.json` + Google Drive — raw-binary identity and storage.
+- `vault/candidatos/` — auxiliary cataloguing mirror only.
+
+`corpus-data.json`, SQLite, CSV, dashboards, and release bundles are disposable
+projections. See `docs/adr/006-canonical-field-ownership-and-projections.md`.
 
 ### Key Directories
 
@@ -206,7 +211,7 @@ These documented problems affect corpus operations:
 1. **Minor drift across exports** — current counts (audit: 2026-07-13, sync with main):
    - `data/processed/records.jsonl` → **335 records, all schema-valid** (`validate_schemas.py` → 335/335 ✓)
    - `corpus/corpus-data.json` → **335 items** (`records_to_corpus.py --diff` → synchronized by URL)
-   - `data/processed/purification.jsonl` → **279 records, all schema-valid** (`validate_schemas.py data/processed/purification.jsonl --schema purification-record` → 279/279 ✓; endurecimento coding now **279/335 = 83%**, 56 remaining, up from 236 on 2026-07-02, now 279 as of 2026-07-31)
+   - `data/processed/purification.jsonl` → **286 records** in the 2026-08-12 working snapshot (**286/335 = 85.4%**, 49 items without a separate coding-ledger row); validate live rather than copying this count into analytical claims.
    - `companion-data.json` → **277 declared corpus_total**, **9 country groups**, **21 `zwischenraum_panels`**; derived UI surface, not canonical authority.
 2. **Placeholder-`input_url` drift between ledger and export** — `records.jsonl` now carries **6** placeholder `input_url`s (all `https://iconocracy.corpus/placeholder/FR-0XX`), down from 8, but `corpus/corpus-data.json` still surfaces **8** placeholder-bearing items. Note this is *not* caught by `records_to_corpus.py --diff`: that check keys on `webscout.search_results[0].url` (normalized to corpus_id), **not** `input_url`, so the "synchronized by URL" green light does not cover the `input_url` field — which is exactly why this drift can persist unnoticed. Re-run `records_to_corpus.py` and verify the 6 remaining against `data/raw/drive-manifest.json`.
    - Minor dedup watch: **4 duplicate `input_url`s** in `records.jsonl` — 3× `https://iconocracy-corpus.local/piloto/` (pilot rows, distinct from the placeholder set above) + 3 real-source pairs — candidates for `corpus-dedup`, not confirmed duplicates.
@@ -215,7 +220,7 @@ These documented problems affect corpus operations:
    - Older artifacts that reference 145/165 (notebooks `01/05/06/07`; manuscript `Capitulo2_metodologia.md`, `Introducao_rev.md`, etc.; the frozen `Other/corpus-data.json`) are **historical analysis snapshots, not errors** — each records the sample a given run used. Update them lazily near the defense, not as blocking debt. `Other/` also holds a duplicate of `notebooks/01–08` (stale copy, not a second source of truth).
    - `endurecimento_score=0` is a valid score (low purification), not "uncoded". Background on the stratification dialectic: memory `corpus-n-20260605` + `docs/decisions/DIALETICA-N165-vs-265.md` — **informative, not a gate.**
 
-**Resolved issues:** the "11 records with out-of-range indicator values (>3)" and the records/export count drift are resolved in the current operational snapshot — `validate_schemas.py` reports 335/335 records valid, `purification.jsonl` reports 279/279 valid, and `records_to_corpus.py --diff` reports synchronization by URL.
+**Resolved issues:** the "11 records with out-of-range indicator values (>3)" and the records/export count drift were resolved in the audited snapshot. Re-run schema validation and projection gates for the current working state rather than relying on historical counts.
 
 ## Release Gate
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The public-facing browsable surfaces are all self-contained HTML — open them s
 
 - **335** coded records in the operational ledger (`data/processed/records.jsonl`)
 - **335** items in the public export (`corpus/corpus-data.json`)
-- **~279** items with full *endurecimento* coding (`data/processed/purification.jsonl`)
+- **286** coding observations in the current working snapshot (`data/processed/purification.jsonl`)
 - **410** catalog cards in the Obsidian vault (`vault/candidatos/`)
 
 **By country** (top of a non-exhaustive, transnational corpus):

--- a/docs/OPERATING_MODEL.md
+++ b/docs/OPERATING_MODEL.md
@@ -49,16 +49,18 @@ Hugging Face is the public release layer:
 
 ## Canonical data contract
 
-The source-of-truth hierarchy is:
+Authority is assigned by field family rather than by a linear ranking:
 
-1. `data/processed/records.jsonl`
-   Operational canonical ledger for traceable corpus records.
-2. `corpus/corpus-data.json`
-   Public-facing export for browsers, dashboards, and public releases.
-3. `data/processed/purification.jsonl`
-   Canonical ledger for endurecimento coding.
-4. `vault/candidatos/`
-   Auxiliary cataloguing mirror only.
+- `data/processed/records.jsonl` owns item identity, source evidence,
+  descriptive metadata, and IconoCode claims.
+- `data/processed/purification.jsonl` owns endurecimento observations and their
+  coder, round, instrument, and adjudication provenance.
+- `data/raw/drive-manifest.json` plus Google Drive own raw-binary identity and
+  external storage location.
+- `vault/candidatos/` is an auxiliary cataloguing and navigation mirror.
+
+`corpus-data.json`, SQLite, CSV, dashboards, and release bundles are disposable
+projections. See `docs/adr/006-canonical-field-ownership-and-projections.md`.
 
 Additional rules:
 
@@ -71,10 +73,16 @@ Additional rules:
 Before any public dataset or site release:
 
 1. Validate `records.jsonl`.
-2. Review `code_purification.py --status`.
-3. Review `vault_sync.py status` or `diff`.
-4. Review `records_to_corpus.py --diff` if release data depends on `corpus-data.json`.
-5. Generate a release snapshot for Hugging Face if the public dataset changes.
+2. Validate `purification.jsonl`.
+3. Check authoritative export-field idempotence.
+4. Generate and review the evidence traceability report; high-severity issues
+   block release, while historical coverage debt remains visible in the report.
+5. Review `code_purification.py --status`.
+6. Review `vault_sync.py status` or `diff`.
+7. Generate a release snapshot for Hugging Face if the public dataset changes.
+
+`build_hf_release.py` runs steps 1–4 itself and refuses count or semantic export
+drift. Steps 5–6 remain explicit scholarly review gates.
 
 ## Backup policy
 

--- a/docs/adr/006-canonical-field-ownership-and-projections.md
+++ b/docs/adr/006-canonical-field-ownership-and-projections.md
@@ -1,0 +1,64 @@
+# ADR-006: Canonical field ownership and disposable projections
+
+**Status:** Accepted
+**Date:** 2026-08-12
+
+## Context
+
+ADR-003 established `records.jsonl` as the canonical corpus ledger. Later
+workflows introduced a separate coding ledger, SQLite, dashboards, and release
+bundles. A linear source-of-truth ranking no longer explains which file owns
+each scientific field, and derived outputs can accidentally preserve facts not
+present in either ledger.
+
+Vault imports also used ten zero values to represent pending coding. Zero is an
+observed value on the 0–3 scale, so that representation collapses two different
+states: not coded and coded as absent.
+
+## Decision
+
+Canonical authority is assigned by field family:
+
+| Field family | Authority |
+|---|---|
+| Item identity, source evidence, descriptive metadata, IconoCode claims | `data/processed/records.jsonl` |
+| Endurecimento observations, coder, round, instrument version, adjudication | `data/processed/purification.jsonl` |
+| Raw binary identity and external storage location | `data/raw/drive-manifest.json` + Google Drive |
+| Catalogue notes and research navigation | `vault/candidatos/` as auxiliary mirror |
+
+`corpus-data.json`, SQLite, CSV, dashboards, notebooks inputs, and Hugging Face
+bundles are disposable projections. They must be rebuildable without treating
+their previous output as scientific evidence.
+
+A qualitative regime imported from a vault note remains a tentative claim. It
+does not create indicator values. A genuine all-zero coding remains valid only
+when it is an explicit observation carrying coder and date provenance.
+
+Evidence identifiers are scoped to their item. Relational projections therefore
+use `(item_id, evidence_id)`, not `evidence_id` alone.
+
+Coding observations are one-to-many per item. Projections preserve coder,
+timestamp, round, prompt version, and adjudication status rather than overwriting
+one row per item.
+
+## Consequences
+
+- Import and sync tools may propose records but cannot manufacture observations.
+- SQLite reads both canonical ledgers directly and remains read-only/disposable.
+- Release builds validate schemas and export idempotence, generate the evidence
+  report, and block high-severity traceability failures. Existing medium-severity
+  claim-linkage debt remains reported rather than silently waived.
+- Existing `vault-import` zero vectors require a separate, evidence-controlled
+  adjudication; this ADR does not delete them automatically.
+- Legacy merge fallback in `records_to_corpus.py` remains temporarily for public
+  fields not yet modeled canonically. It must not be expanded; later work should
+  replace it with an explicit, versioned public-overlay ledger.
+
+## Alternatives rejected
+
+- **SQLite as canonical store:** efficient for querying but weaker for Git review
+  and long-term human-readable provenance.
+- **One mutable coding row per item:** cannot represent instrument comparison,
+  recoding, or an apparatus of variants.
+- **Runtime agent writes directly to canonical data:** obscures authorship and
+  bypasses reviewable promotion from proposal to accepted observation.

--- a/docs/plans/2026-08-12-architecture-hardening.md
+++ b/docs/plans/2026-08-12-architecture-hardening.md
@@ -1,0 +1,78 @@
+# Architecture Hardening Plan — Canonical Data and Projections
+
+**Date:** 2026-08-12
+**Status:** implemented
+**Base:** `main` at `7e95a8e`
+**Branch:** `codex/architecture-hardening`
+
+## Objective
+
+Make scientific state explicit and make every database or public artifact a
+rebuildable projection. Preserve the accepted JSONL-first architecture while
+removing silent authority from imports and derived outputs.
+
+## Invariants
+
+1. `pending` is not encoded as ten observed zero values.
+2. Evidence identity is local to a corpus item unless explicitly global.
+3. Multiple coding observations for one item remain representable.
+4. SQLite, dashboards, and release bundles are disposable projections.
+5. Release validation checks semantic projection and evidence traceability,
+   not only record counts.
+6. Existing public file formats remain readable during this hardening phase.
+
+## Step 1 — Prevent placeholder coding during vault import
+
+Refactor `vault_sync.py` so a vault note with a qualitative regime but no ten
+observed indicators does not acquire a `purificacao` block. Preserve the regime
+as a tentative interpretation and add regression tests for pending and genuinely
+coded zero states.
+
+**Acceptance:** new vault imports contain no synthetic indicator vector;
+genuine zero-valued coding remains valid; focused tests pass.
+
+**Out of scope:** retrospective deletion or adjudication of the 86 existing
+`vault-import` zero vectors.
+
+## Step 2 — Rebuild SQLite from canonical ledgers
+
+Refactor `records_to_sqlite.py` to read `records.jsonl` and
+`purification.jsonl` directly. Use `(item_id, evidence_id)` for evidence and a
+stable coding-observation identity that permits multiple coders and rounds.
+Remove dependence on `corpus-data.json` for canonical research fields.
+
+**Acceptance:** all 339 current evidence relations survive projection; all
+coding rows survive projection; foreign-key checks pass; rebuild is deterministic.
+
+**Out of scope:** making SQLite a writable or canonical database.
+
+## Step 3 — Strengthen projection and release gates
+
+Remove the silent Brazil fallback from `records_to_corpus.py`. Make the Hugging
+Face builder run schema validation, export idempotence, and evidence traceability
+through one fail-closed contract before generating a snapshot.
+
+**Acceptance:** missing country remains unknown rather than fabricated; direct
+release builds reject semantic export drift; focused release tests pass.
+
+**Out of scope:** removing all legacy merge fallbacks before an explicit public
+overlay ledger exists.
+
+## Step 4 — Document authority boundaries and verify end to end
+
+Record the canonical-field ownership model and projection contract in an ADR,
+update operating documentation, run focused and full tests, run schema checks,
+and execute the repository drift detector before delivery.
+
+**Acceptance:** documentation names one authority per field family; validators
+and tests pass in the `iconocracy` environment; changed files are reviewable as
+one coherent diff.
+
+**Out of scope:** corpus-wide recoding, manuscript revision, dashboard redesign,
+deployment, merge, or publication.
+
+## Rollback
+
+Each implementation step is isolated by tests and can be reverted independently.
+No canonical corpus row is modified by this plan. Generated SQLite files and
+release snapshots remain untracked, disposable artifacts.

--- a/tests/test_build_hf_release.py
+++ b/tests/test_build_hf_release.py
@@ -106,9 +106,12 @@ def test_validate_local_contract_runs_both_validators(monkeypatch: pytest.Monkey
 
     release.validate_local_contract()
 
-    assert len(calls) == 2
+    assert len(calls) == 4
     assert calls[0][0][-3:] == ["--schema", "master-record", "--verbose"]
     assert calls[1][0][-3:] == ["--schema", "purification-record", "--verbose"]
+    assert Path(calls[2][0][1]).name == "check_corpus_export_idempotent.py"
+    assert Path(calls[3][0][1]).name == "trace_evidence.py"
+    assert calls[3][0][-1] == "--fail-on-high"
     assert all(kwargs == {"check": True} for _, kwargs in calls)
 
 

--- a/tests/test_records_to_corpus.py
+++ b/tests/test_records_to_corpus.py
@@ -42,3 +42,12 @@ def test_blank_or_non_string_medium_is_not_a_canonical_source() -> None:
         )
 
         assert "support" not in entry
+
+
+def test_missing_place_hint_does_not_fabricate_country() -> None:
+    record = _record()
+    record["input"].pop("place_hint")
+
+    entry = _corpus_entry_from_record(record, existing={"id": "TEST-001"})
+
+    assert "country" not in entry

--- a/tests/test_records_to_sqlite.py
+++ b/tests/test_records_to_sqlite.py
@@ -1,0 +1,136 @@
+import json
+import sqlite3
+
+from tools.scripts.records_to_sqlite import (
+    _deterministic_item_id,
+    _load_mapping,
+    build_database,
+)
+
+
+def _write_jsonl(path, rows):
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_sqlite_projection_preserves_local_evidence_ids_and_coding_rounds(tmp_path):
+    records_file = tmp_path / "records.jsonl"
+    purification_file = tmp_path / "purification.jsonl"
+    mapping_file = tmp_path / "id-mapping.json"
+    sqlite_db = tmp_path / "corpus.sqlite"
+
+    records = []
+    for item_id, corpus_id in (("item-1", "BR-001"), ("item-2", "FR-001")):
+        records.append(
+            {
+                "item_id": item_id,
+                "input": {
+                    "title_hint": corpus_id,
+                    "place_hint": "Brazil" if corpus_id.startswith("BR") else "France",
+                    "date_hint": "1901",
+                },
+                "webscout": {
+                    "search_results": [
+                        {
+                            "evidence_id": "e1",
+                            "source_type": "primary_image",
+                            "title": corpus_id,
+                            "url": f"https://example.org/{corpus_id}",
+                        }
+                    ]
+                },
+                "iconocode": {"codes": []},
+                "timestamps": {
+                    "created_at": "2026-08-12T00:00:00Z",
+                    "updated_at": "2026-08-12T00:00:00Z",
+                },
+            }
+        )
+
+    codings = []
+    for coder, round_number, prompt_version in (
+        ("ana", 1, "iconocode-v1"),
+        ("ana", 1, "iconocode-v2"),
+    ):
+        codings.append(
+            {
+                "id": "BR-001",
+                **{field: 0 for field in (
+                    "desincorporacao",
+                    "rigidez_postural",
+                    "dessexualizacao",
+                    "uniformizacao_facial",
+                    "heraldizacao",
+                    "enquadramento_arquitetonico",
+                    "apagamento_narrativo",
+                    "monocromatizacao",
+                    "serialidade",
+                    "inscricao_estatal",
+                )},
+                "regime_iconocratico": "normativo",
+                "coded_by": coder,
+                "coded_at": f"2026-08-{10 + round_number:02d}T00:00:00Z",
+                "coding_round": round_number,
+                "prompt_version": prompt_version,
+            }
+        )
+
+    _write_jsonl(records_file, records)
+    _write_jsonl(purification_file, codings)
+    mapping_file.write_text(
+        json.dumps(
+            {
+                "mapping": [
+                    {"corpus_id": "BR-001", "item_id": "item-1"},
+                    {"corpus_id": "FR-001", "item_id": "item-2"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    stats = build_database(
+        records_file=records_file,
+        purification_file=purification_file,
+        mapping_file=mapping_file,
+        sqlite_db=sqlite_db,
+        verify=False,
+    )
+
+    assert stats == {
+        "items": 2,
+        "purification": 2,
+        "evidence": 2,
+        "iconclass": 0,
+    }
+    with sqlite3.connect(sqlite_db) as db:
+        assert db.execute("SELECT COUNT(*) FROM evidence").fetchone()[0] == 2
+        assert db.execute("SELECT COUNT(*) FROM purification").fetchone()[0] == 2
+        assert db.execute("PRAGMA foreign_key_check").fetchall() == []
+        keys = db.execute(
+            "SELECT item_id, evidence_id FROM evidence ORDER BY item_id"
+        ).fetchall()
+        assert keys == [("item-1", "e1"), ("item-2", "e1")]
+
+
+def test_ambiguous_crosswalk_only_assigns_deterministic_public_identity(tmp_path):
+    mapping_file = tmp_path / "id-mapping.json"
+    deterministic = _deterministic_item_id("BR-001")
+    mapping_file.write_text(
+        json.dumps(
+            {
+                "mapping": [
+                    {"corpus_id": "BR-001", "item_id": "legacy-item"},
+                    {"corpus_id": "BR-001", "item_id": deterministic},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    corpus_to_item, item_to_corpus = _load_mapping(mapping_file)
+
+    assert corpus_to_item == {"BR-001": deterministic}
+    assert item_to_corpus == {deterministic: "BR-001"}

--- a/tests/test_vault_sync.py
+++ b/tests/test_vault_sync.py
@@ -1,0 +1,36 @@
+from tools.scripts.vault_sync import _vault_note_to_record
+
+
+def test_vault_import_with_regime_remains_pending_not_zero_coded():
+    record = _vault_note_to_record(
+        {
+            "id": "BR-999",
+            "titulo": "Alegoria de teste",
+            "url": "https://example.org/object/999",
+            "pais": "BR",
+            "regime": "normativo",
+            "_file": "BR-999 Alegoria de teste.md",
+        }
+    )
+
+    assert "purificacao" not in record
+    claim = record["iconocode"]["interpretation"][0]
+    assert claim["claim_text"] == "Regime iconocrático: NORMATIVO"
+    assert claim["status"] == "tentative"
+    assert "coding-pending" in record["exports"]["audit_flags"]
+
+
+def test_vault_import_without_regime_remains_pending():
+    record = _vault_note_to_record(
+        {
+            "id": "BR-998",
+            "titulo": "Alegoria sem regime",
+            "url": "https://example.org/object/998",
+            "pais": "BR",
+            "_file": "BR-998 Alegoria sem regime.md",
+        }
+    )
+
+    assert "purificacao" not in record
+    assert record["iconocode"]["interpretation"][0]["status"] == "tentative"
+    assert "coding-pending" in record["exports"]["audit_flags"]

--- a/tools/scripts/build_hf_release.py
+++ b/tools/scripts/build_hf_release.py
@@ -215,12 +215,24 @@ def ensure_hf_auth() -> None:
 def validate_local_contract() -> None:
     """Fail closed if local dataset artifacts are invalid or drifted."""
     validate_script = REPO / "tools" / "scripts" / "validate_schemas.py"
+    idempotence_script = REPO / "tools" / "scripts" / "check_corpus_export_idempotent.py"
+    traceability_script = REPO / "tools" / "scripts" / "trace_evidence.py"
     subprocess.run(
         [sys.executable, str(validate_script), str(RECORDS), "--schema", "master-record", "--verbose"],
         check=True,
     )
     subprocess.run(
         [sys.executable, str(validate_script), str(PURIFICATION), "--schema", "purification-record", "--verbose"],
+        check=True,
+    )
+    subprocess.run([sys.executable, str(idempotence_script)], check=True)
+    subprocess.run(
+        [
+            sys.executable,
+            str(traceability_script),
+            str(RECORDS),
+            "--fail-on-high",
+        ],
         check=True,
     )
 

--- a/tools/scripts/records_to_corpus.py
+++ b/tools/scripts/records_to_corpus.py
@@ -205,7 +205,9 @@ def _corpus_entry_from_record(record: dict, existing: dict | None, corpus_id: st
     if country:
         entry["country"] = country
     elif not entry.get("country"):
-        entry["country"] = "Brazil"
+        # Missing provenance must remain explicit.  A default country would
+        # fabricate a research fact and silently bias country-level analysis.
+        entry.pop("country", None)
 
     # Overwrite with authoritative fields from records.jsonl
     entry.update({

--- a/tools/scripts/records_to_sqlite.py
+++ b/tools/scripts/records_to_sqlite.py
@@ -1,376 +1,363 @@
 #!/usr/bin/env python3
-"""
-records_to_sqlite.py — Parses records.jsonl and purification.jsonl to build
-a normalized, high-performance SQLite database representation of the corpus.
+"""Build a disposable SQLite projection from the canonical JSONL ledgers.
 
-Usage:
-    python tools/scripts/records_to_sqlite.py
+The database is never authoritative.  Item and evidence metadata comes from
+``records.jsonl``; coding observations come from ``purification.jsonl``.
 """
+
+from __future__ import annotations
 
 import json
+import re
 import sqlite3
-import sys
+import tempfile
 import uuid
 from pathlib import Path
 
-# Paths (relative to repo root)
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 RECORDS_FILE = REPO_ROOT / "data" / "processed" / "records.jsonl"
+PURIFICATION_FILE = REPO_ROOT / "data" / "processed" / "purification.jsonl"
 MAPPING_FILE = REPO_ROOT / "data" / "processed" / "id-mapping.json"
-CORPUS_JSON = REPO_ROOT / "corpus" / "corpus-data.json"
 SQLITE_DB = REPO_ROOT / "data" / "processed" / "corpus.sqlite"
 
-SCHEMA = [
-    # 1. Main items table
-    """CREATE TABLE IF NOT EXISTS "items" (
-        "item_id" TEXT PRIMARY KEY,
-        "corpus_id" TEXT UNIQUE,
-        "title" TEXT NOT NULL,
-        "country" TEXT,
-        "year" INTEGER,
-        "period" TEXT,
-        "medium_norm" TEXT,
-        "created_at" TEXT,
-        "updated_at" TEXT
-    )""",
+_NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+INDICATOR_FIELDS = (
+    "desincorporacao",
+    "rigidez_postural",
+    "dessexualizacao",
+    "uniformizacao_facial",
+    "heraldizacao",
+    "enquadramento_arquitetonico",
+    "apagamento_narrativo",
+    "monocromatizacao",
+    "serialidade",
+    "inscricao_estatal",
+)
 
-    # 2. Purification indicators (1:1 with items)
-    """CREATE TABLE IF NOT EXISTS "purification" (
-        "item_id" TEXT PRIMARY KEY,
-        "desincorporacao" INTEGER CHECK (desincorporacao BETWEEN 0 AND 3),
-        "rigidez_postural" INTEGER CHECK (rigidez_postural BETWEEN 0 AND 3),
-        "dessexualizacao" INTEGER CHECK (dessexualizacao BETWEEN 0 AND 3),
-        "uniformizacao_facial" INTEGER CHECK (uniformizacao_facial BETWEEN 0 AND 3),
-        "heraldizacao" INTEGER CHECK (heraldizacao BETWEEN 0 AND 3),
-        "enquadramento_arquitetonico" INTEGER CHECK (enquadramento_arquitetonico BETWEEN 0 AND 3),
-        "apagamento_narrativo" INTEGER CHECK (apagamento_narrativo BETWEEN 0 AND 3),
-        "monocromatizacao" INTEGER CHECK (monocromatizacao BETWEEN 0 AND 3),
-        "serialidade" INTEGER CHECK (serialidade BETWEEN 0 AND 3),
-        "inscricao_estatal" INTEGER CHECK (inscricao_estatal BETWEEN 0 AND 3),
-        "purificacao_composto" REAL,
-        "regime_iconocratico" TEXT,
-        "coded_by" TEXT,
-        "coded_at" TEXT,
-        "notes" TEXT,
-        FOREIGN KEY("item_id") REFERENCES "items"("item_id") ON DELETE CASCADE
+SCHEMA = (
+    """CREATE TABLE items (
+        item_id TEXT PRIMARY KEY,
+        corpus_id TEXT UNIQUE,
+        title TEXT NOT NULL,
+        country TEXT,
+        year INTEGER,
+        period TEXT,
+        medium_norm TEXT,
+        created_at TEXT,
+        updated_at TEXT
     )""",
-
-    # 3. Webscout evidence (1:N with items)
-    """CREATE TABLE IF NOT EXISTS "evidence" (
-        "evidence_id" TEXT PRIMARY KEY,
-        "item_id" TEXT,
-        "source_type" TEXT,
-        "title" TEXT,
-        "url" TEXT,
-        "abnt_citation" TEXT,
-        "notes" TEXT,
-        FOREIGN KEY("item_id") REFERENCES "items"("item_id") ON DELETE CASCADE
+    """CREATE TABLE purification (
+        coding_id TEXT PRIMARY KEY,
+        item_id TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        desincorporacao INTEGER CHECK (desincorporacao BETWEEN 0 AND 3),
+        rigidez_postural INTEGER CHECK (rigidez_postural BETWEEN 0 AND 3),
+        dessexualizacao INTEGER CHECK (dessexualizacao BETWEEN 0 AND 3),
+        uniformizacao_facial INTEGER CHECK (uniformizacao_facial BETWEEN 0 AND 3),
+        heraldizacao INTEGER CHECK (heraldizacao BETWEEN 0 AND 3),
+        enquadramento_arquitetonico INTEGER CHECK (enquadramento_arquitetonico BETWEEN 0 AND 3),
+        apagamento_narrativo INTEGER CHECK (apagamento_narrativo BETWEEN 0 AND 3),
+        monocromatizacao INTEGER CHECK (monocromatizacao BETWEEN 0 AND 3),
+        serialidade INTEGER CHECK (serialidade BETWEEN 0 AND 3),
+        inscricao_estatal INTEGER CHECK (inscricao_estatal BETWEEN 0 AND 3),
+        purificacao_composto REAL,
+        regime_iconocratico TEXT,
+        coded_by TEXT NOT NULL,
+        coded_at TEXT NOT NULL,
+        coding_round INTEGER NOT NULL DEFAULT 1,
+        prompt_version TEXT,
+        adjudication_status TEXT,
+        notes TEXT,
+        FOREIGN KEY(item_id) REFERENCES items(item_id) ON DELETE CASCADE
     )""",
-
-    # 4. Iconclass codes associated with items (N:M mapping)
-    """CREATE TABLE IF NOT EXISTS "item_iconclass" (
-        "item_id" TEXT,
-        "notation" TEXT,
-        "confidence" REAL,
-        PRIMARY KEY ("item_id", "notation"),
-        FOREIGN KEY("item_id") REFERENCES "items"("item_id") ON DELETE CASCADE
+    """CREATE TABLE evidence (
+        item_id TEXT NOT NULL,
+        evidence_id TEXT NOT NULL,
+        source_type TEXT,
+        title TEXT,
+        url TEXT,
+        abnt_citation TEXT,
+        notes TEXT,
+        PRIMARY KEY(item_id, evidence_id),
+        FOREIGN KEY(item_id) REFERENCES items(item_id) ON DELETE CASCADE
     )""",
-
-    # 5. Full-Text Search Virtual Table (FTS5)
-    """CREATE VIRTUAL TABLE IF NOT EXISTS "items_fts" USING fts5(
-        title, country, period, medium_norm, content="items", content_rowid="rowid"
+    """CREATE TABLE item_iconclass (
+        item_id TEXT NOT NULL,
+        notation TEXT NOT NULL,
+        confidence REAL,
+        PRIMARY KEY(item_id, notation),
+        FOREIGN KEY(item_id) REFERENCES items(item_id) ON DELETE CASCADE
     )""",
-
-    # 6. Triggers to keep FTS table in sync
-    """CREATE TRIGGER IF NOT EXISTS "items_ai" AFTER INSERT ON "items" BEGIN
-        INSERT INTO "items_fts"(rowid, title, country, period, medium_norm)
+    """CREATE VIRTUAL TABLE items_fts USING fts5(
+        title, country, period, medium_norm, content='items', content_rowid='rowid'
+    )""",
+    """CREATE TRIGGER items_ai AFTER INSERT ON items BEGIN
+        INSERT INTO items_fts(rowid, title, country, period, medium_norm)
         VALUES (new.rowid, new.title, new.country, new.period, new.medium_norm);
     END""",
-    """CREATE TRIGGER IF NOT EXISTS "items_ad" AFTER DELETE ON "items" BEGIN
-        INSERT INTO "items_fts"("items_fts", rowid, title, country, period, medium_norm)
+    """CREATE TRIGGER items_ad AFTER DELETE ON items BEGIN
+        INSERT INTO items_fts(items_fts, rowid, title, country, period, medium_norm)
         VALUES ('delete', old.rowid, old.title, old.country, old.period, old.medium_norm);
     END""",
-    """CREATE TRIGGER IF NOT EXISTS "items_au" AFTER UPDATE ON "items" BEGIN
-        INSERT INTO "items_fts"("items_fts", rowid, title, country, period, medium_norm)
+    """CREATE TRIGGER items_au AFTER UPDATE ON items BEGIN
+        INSERT INTO items_fts(items_fts, rowid, title, country, period, medium_norm)
         VALUES ('delete', old.rowid, old.title, old.country, old.period, old.medium_norm);
-        INSERT INTO "items_fts"(rowid, title, country, period, medium_norm)
+        INSERT INTO items_fts(rowid, title, country, period, medium_norm)
         VALUES (new.rowid, new.title, new.country, new.period, new.medium_norm);
-    END"""
-]
+    END""",
+)
 
-INDEXES = [
-    "CREATE INDEX IF NOT EXISTS \"idx_items_corpus_id\" ON \"items\" (\"corpus_id\")",
-    "CREATE INDEX IF NOT EXISTS \"idx_purification_regime\" ON \"purification\" (\"regime_iconocratico\")",
-    "CREATE INDEX IF NOT EXISTS \"idx_purification_composite\" ON \"purification\" (\"purificacao_composto\")",
-    "CREATE INDEX IF NOT EXISTS \"idx_evidence_item\" ON \"evidence\" (\"item_id\")",
-    "CREATE INDEX IF NOT EXISTS \"idx_iconclass_item\" ON \"item_iconclass\" (\"item_id\")",
-]
+INDEXES = (
+    "CREATE INDEX idx_items_corpus_id ON items(corpus_id)",
+    "CREATE INDEX idx_purification_item ON purification(item_id)",
+    "CREATE INDEX idx_purification_regime ON purification(regime_iconocratico)",
+    "CREATE INDEX idx_purification_coder ON purification(coded_by)",
+    "CREATE INDEX idx_evidence_item ON evidence(item_id)",
+    "CREATE INDEX idx_iconclass_item ON item_iconclass(item_id)",
+)
 
-def load_mapping():
-    """Load UUID mapping to corpus ID."""
-    mapping = {}
-    if MAPPING_FILE.exists():
-        with open(MAPPING_FILE, encoding="utf-8") as f:
-            try:
-                data = json.load(f)
-                corpus_to_items = {}
-                for entry in data.get("mapping", []):
-                    c_id = entry.get("corpus_id")
-                    item_id = entry.get("item_id")
-                    if c_id and item_id:
-                        corpus_to_items.setdefault(c_id, []).append(item_id)
-                
-                for entry in data.get("mapping", []):
-                    c_id = entry.get("corpus_id")
-                    item_id = entry.get("item_id")
-                    if c_id and item_id:
-                        items_mapped = corpus_to_items[c_id]
-                        if len(items_mapped) > 1:
-                            ns = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-                            expected_uuid = str(uuid.uuid5(ns, f"iconocracy-corpus-{c_id}"))
-                            if item_id == expected_uuid:
-                                mapping[item_id] = c_id
-                        else:
-                            mapping[item_id] = c_id
-            except Exception as e:
-                print(f"Warning: Failed to load id-mapping.json: {e}")
-    return mapping
 
-def load_corpus_metadata():
-    """Load metadata details from corpus-data.json for richer item fields."""
-    metadata = {}
-    if CORPUS_JSON.exists():
-        with open(CORPUS_JSON, encoding="utf-8") as f:
-            try:
-                corpus = json.load(f)
-                for item in corpus:
-                    c_id = item.get("id")
-                    if c_id:
-                        metadata[c_id] = item
-            except Exception as e:
-                print(f"Warning: Failed to load corpus-data.json: {e}")
-    return metadata
-
-def build_database():
-    print(f"Connecting to SQLite database: {SQLITE_DB}")
-    # Remove existing db to ensure clean import
-    if SQLITE_DB.exists():
-        SQLITE_DB.unlink()
-        
-    db = sqlite3.connect(str(SQLITE_DB))
-    cursor = db.cursor()
-    
-    # Enable performance and security PRAGMAs
-    cursor.execute("PRAGMA foreign_keys = ON;")
-    cursor.execute("PRAGMA journal_mode = WAL;")
-    cursor.execute("PRAGMA synchronous = NORMAL;")
-    cursor.execute("PRAGMA temp_store = MEMORY;")
-    cursor.execute("PRAGMA mmap_size = 30000000000;")
-    cursor.execute("PRAGMA page_size = 4096;")
-    
-    # Create tables
-    for ddl in SCHEMA:
-        cursor.execute(ddl)
-        
-    # Load auxiliary data
-    uuid_to_corpus = load_mapping()
-    corpus_metadata = load_corpus_metadata()
-    
-    # Process records
-    items_count = 0
-    purification_count = 0
-    evidence_count = 0
-    iconclass_count = 0
-    
-    # Batch arrays
-    items_batch = []
-    purification_batch = []
-    evidence_batch = []
-    iconclass_batch = []
-    
-    seen_evidence = set()
-    seen_iconclass = set()
-    
-    if not RECORDS_FILE.exists():
-        print(f"Error: {RECORDS_FILE} not found. Cannot load data.")
-        sys.exit(1)
-        
-    with open(RECORDS_FILE, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
+def _load_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
                 continue
-                
             try:
-                rec = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-                
-            item_id = rec.get("item_id")
-            if not item_id:
-                continue
-                
-            corpus_id = uuid_to_corpus.get(item_id)
-            if not corpus_id or corpus_id.strip() == "":
-                corpus_id = None
-            meta = corpus_metadata.get(corpus_id, {}) if corpus_id else {}
-            
-            # 1. Gather for items
-            title = meta.get("title") or rec.get("input", {}).get("title_hint") or "Unknown Title"
-            country = meta.get("country") or rec.get("input", {}).get("place_hint")
-            year = meta.get("year")
-            if year is None:
-                try:
-                    # Fallback parsing for year hint
-                    year_hint = rec.get("input", {}).get("date_hint", "")
-                    # Extract first 4-digit number
-                    year_match = re.search(r'\b\d{4}\b', str(year_hint))
-                    year = int(year_match.group(0)) if year_match else None
-                except Exception:
-                    year = None
-                    
-            period = meta.get("period") or rec.get("purificacao", {}).get("period")
-            medium_norm = (
-                meta.get("support")
-                or rec.get("purificacao", {}).get("medium_norm")
-                or rec.get("purificacao", {}).get("record_metadata", {}).get("medium")
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as error:
+                raise ValueError(f"Invalid JSON in {path}:{line_number}: {error}") from error
+    return rows
+
+
+def _load_mapping(path: Path) -> tuple[dict[str, str], dict[str, str]]:
+    if not path.exists():
+        return {}, {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    grouped: dict[str, list[str]] = {}
+    for entry in payload.get("mapping", []):
+        corpus_id = entry.get("corpus_id")
+        item_id = entry.get("item_id")
+        if corpus_id and item_id:
+            grouped.setdefault(corpus_id, []).append(item_id)
+
+    corpus_to_item: dict[str, str] = {}
+    item_to_corpus: dict[str, str] = {}
+    for corpus_id, item_ids in grouped.items():
+        deterministic = _deterministic_item_id(corpus_id)
+        if deterministic in item_ids:
+            chosen = deterministic
+        elif len(item_ids) == 1:
+            chosen = item_ids[0]
+        else:
+            # An ambiguous historical crosswalk must not assign the same
+            # public identity to multiple canonical records.
+            continue
+        corpus_to_item[corpus_id] = chosen
+        item_to_corpus[chosen] = corpus_id
+    return corpus_to_item, item_to_corpus
+
+
+def _deterministic_item_id(corpus_id: str) -> str:
+    return str(uuid.uuid5(_NS, f"iconocracy-corpus-{corpus_id}"))
+
+
+def _resolve_item_id(source_id: str, corpus_to_item: dict[str, str], known: set[str]) -> str:
+    candidate = corpus_to_item.get(source_id, source_id)
+    if candidate in known:
+        return candidate
+    deterministic = _deterministic_item_id(source_id)
+    if deterministic in known:
+        return deterministic
+    raise ValueError(f"Coding row {source_id!r} has no matching canonical record")
+
+
+def _year(value: object) -> int | None:
+    match = re.search(r"\b(1[0-9]{3}|20[0-9]{2})\b", str(value or ""))
+    return int(match.group(1)) if match else None
+
+
+def _place(value: object) -> str | None:
+    if isinstance(value, list):
+        return str(value[0]) if value else None
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _coding_id(row: dict, item_id: str) -> str:
+    identity = "|".join(
+        str(row.get(field, ""))
+        for field in ("id", "coded_by", "coded_at", "coding_round", "prompt_version")
+    )
+    return str(uuid.uuid5(_NS, f"iconocracy-coding-{item_id}-{identity}"))
+
+
+def build_database(
+    *,
+    records_file: Path = RECORDS_FILE,
+    purification_file: Path = PURIFICATION_FILE,
+    mapping_file: Path = MAPPING_FILE,
+    sqlite_db: Path = SQLITE_DB,
+    verify: bool = True,
+) -> dict[str, int]:
+    """Rebuild *sqlite_db* atomically and return projected row counts."""
+    records = _load_jsonl(records_file)
+    codings = _load_jsonl(purification_file)
+    corpus_to_item, item_to_corpus = _load_mapping(mapping_file)
+    known_item_ids = {row["item_id"] for row in records}
+
+    sqlite_db.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=sqlite_db.parent, prefix=f".{sqlite_db.name}.", suffix=".tmp", delete=False
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+
+    stats = {"items": 0, "purification": 0, "evidence": 0, "iconclass": 0}
+    try:
+        with sqlite3.connect(temporary_path) as db:
+            db.execute("PRAGMA foreign_keys = ON")
+            # This is a one-shot atomic rebuild in a temporary file. DELETE
+            # mode avoids WAL sidecars; FULL sync protects the committed file
+            # before its final atomic replacement.
+            db.execute("PRAGMA journal_mode = DELETE")
+            db.execute("PRAGMA synchronous = FULL")
+            db.execute("PRAGMA temp_store = MEMORY")
+            for statement in SCHEMA:
+                db.execute(statement)
+
+            items: list[tuple] = []
+            evidence: list[tuple] = []
+            iconclass: list[tuple] = []
+            seen_evidence: set[tuple[str, str]] = set()
+            seen_iconclass: set[tuple[str, str]] = set()
+
+            for record in records:
+                item_id = record["item_id"]
+                input_data = record.get("input") or {}
+                embedded = record.get("purificacao") or {}
+                metadata = embedded.get("record_metadata") or {}
+                items.append(
+                    (
+                        item_id,
+                        item_to_corpus.get(item_id),
+                        input_data.get("title_hint") or "Unknown Title",
+                        _place(input_data.get("place_hint")),
+                        _year(input_data.get("date_hint")),
+                        embedded.get("period"),
+                        embedded.get("medium_norm") or metadata.get("medium"),
+                        (record.get("timestamps") or {}).get("created_at"),
+                        (record.get("timestamps") or {}).get("updated_at"),
+                    )
+                )
+
+                for result in (record.get("webscout") or {}).get("search_results", []):
+                    evidence_id = result.get("evidence_id")
+                    key = (item_id, evidence_id)
+                    if not evidence_id or key in seen_evidence:
+                        continue
+                    seen_evidence.add(key)
+                    evidence.append(
+                        (
+                            item_id,
+                            evidence_id,
+                            result.get("source_type"),
+                            result.get("title"),
+                            result.get("url"),
+                            result.get("abnt_citation"),
+                            result.get("notes"),
+                        )
+                    )
+
+                for code in (record.get("iconocode") or {}).get("codes", []):
+                    notation = code.get("notation")
+                    key = (item_id, notation)
+                    if not notation or key in seen_iconclass:
+                        continue
+                    seen_iconclass.add(key)
+                    iconclass.append((item_id, notation, code.get("confidence")))
+
+            db.executemany(
+                "INSERT INTO items VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", items
             )
-            created_at = rec.get("timestamps", {}).get("created_at")
-            updated_at = rec.get("timestamps", {}).get("updated_at")
-            
-            items_batch.append((item_id, corpus_id, title, country, year, period, medium_norm, created_at, updated_at))
-            items_count += 1
-            
-            # 2. Gather for purification
-            purif = rec.get("purificacao")
-            if purif:
-                purification_batch.append((
-                    item_id,
-                    purif.get("desincorporacao"),
-                    purif.get("rigidez_postural"),
-                    purif.get("dessexualizacao"),
-                    purif.get("uniformizacao_facial"),
-                    purif.get("heraldizacao"),
-                    purif.get("enquadramento_arquitetonico"),
-                    purif.get("apagamento_narrativo"),
-                    purif.get("monocromatizacao"),
-                    purif.get("serialidade"),
-                    purif.get("inscricao_estatal"),
-                    purif.get("purificacao_composto"),
-                    purif.get("regime_iconocratico"),
-                    purif.get("coded_by"),
-                    purif.get("coded_at"),
-                    purif.get("notes")
-                ))
-                purification_count += 1
-                
-            # 3. Gather evidence
-            webscout = rec.get("webscout", {})
-            for result in webscout.get("search_results", []):
-                evidence_id = result.get("evidence_id")
-                if not evidence_id or evidence_id in seen_evidence:
-                    continue
-                seen_evidence.add(evidence_id)
-                evidence_batch.append((
-                    evidence_id,
-                    item_id,
-                    result.get("source_type"),
-                    result.get("title"),
-                    result.get("url"),
-                    result.get("abnt_citation"),
-                    result.get("notes")
-                ))
-                evidence_count += 1
-                
-            # 4. Gather item_iconclass codes
-            iconocode = rec.get("iconocode", {})
-            for code_entry in iconocode.get("codes", []):
-                notation = code_entry.get("notation")
-                if not notation or (item_id, notation) in seen_iconclass:
-                    continue
-                seen_iconclass.add((item_id, notation))
-                iconclass_batch.append((
-                    item_id,
-                    notation,
-                    code_entry.get("confidence")
-                ))
-                iconclass_count += 1
+            db.executemany(
+                "INSERT INTO evidence VALUES (?, ?, ?, ?, ?, ?, ?)", evidence
+            )
+            db.executemany(
+                "INSERT INTO item_iconclass VALUES (?, ?, ?)", iconclass
+            )
 
-    # Execute batched inserts
-    cursor.executemany(
-        """INSERT INTO items (item_id, corpus_id, title, country, year, period, medium_norm, created_at, updated_at) 
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        items_batch
-    )
-    
-    cursor.executemany(
-        """INSERT INTO purification (
-            item_id, desincorporacao, rigidez_postural, dessexualizacao, uniformizacao_facial,
-            heraldizacao, enquadramento_arquitetonico, apagamento_narrativo, monocromatizacao,
-            serialidade, inscricao_estatal, purificacao_composto, regime_iconocratico,
-            coded_by, coded_at, notes
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        purification_batch
-    )
+            coding_rows: list[tuple] = []
+            for coding in codings:
+                source_id = coding["id"]
+                item_id = _resolve_item_id(source_id, corpus_to_item, known_item_ids)
+                coding_rows.append(
+                    (
+                        _coding_id(coding, item_id),
+                        item_id,
+                        source_id,
+                        *(coding.get(field) for field in INDICATOR_FIELDS),
+                        coding.get("purificacao_composto"),
+                        coding.get("regime_iconocratico"),
+                        coding.get("coded_by") or "unknown",
+                        coding.get("coded_at") or "unknown",
+                        coding.get("coding_round") or 1,
+                        coding.get("prompt_version"),
+                        coding.get("adjudication_status"),
+                        coding.get("notes"),
+                    )
+                )
 
-    cursor.executemany(
-        """INSERT INTO evidence (evidence_id, item_id, source_type, title, url, abnt_citation, notes)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
-        evidence_batch
-    )
+            placeholders = ", ".join("?" for _ in range(21))
+            db.executemany(
+                f"INSERT INTO purification VALUES ({placeholders})", coding_rows
+            )
+            for statement in INDEXES:
+                db.execute(statement)
 
-    cursor.executemany(
-        """INSERT OR IGNORE INTO item_iconclass (item_id, notation, confidence)
-           VALUES (?, ?, ?)""",
-        iconclass_batch
-    )
-                
-    # Create indexes
-    for idx_ddl in INDEXES:
-        cursor.execute(idx_ddl)
-        
-    # Database Maintenance
-    cursor.execute("PRAGMA optimize;")
-    db.commit()
-    cursor.execute("ANALYZE;")
-    cursor.execute("VACUUM;")
-    
-    db.close()
-    
-    print("\nImport Complete:")
-    print(f"  Items loaded:        {items_count}")
-    print(f"  Purification records:{purification_count}")
-    print(f"  Evidence sources:    {evidence_count}")
-    print(f"  Iconclass mappings:  {iconclass_count}")
-    print(f"Database successfully saved to {SQLITE_DB}\n")
-    
-    # Quick verification query
-    verify_database()
+            foreign_key_errors = db.execute("PRAGMA foreign_key_check").fetchall()
+            if foreign_key_errors:
+                raise ValueError(f"SQLite foreign-key violations: {foreign_key_errors[:5]}")
+            db.execute("INSERT INTO items_fts(items_fts) VALUES ('rebuild')")
+            db.execute("ANALYZE")
 
-def verify_database():
-    db = sqlite3.connect(str(SQLITE_DB))
-    cursor = db.cursor()
-    
-    print("Verifying database with test query:")
-    cursor.execute("""
-        SELECT 
-            i.country,
-            p.regime_iconocratico,
-            COUNT(i.item_id) as total_items,
-            ROUND(AVG(p.purificacao_composto), 2) as avg_composite
-        FROM items i
-        JOIN purification p ON i.item_id = p.item_id
-        GROUP BY i.country, p.regime_iconocratico
-        ORDER BY avg_composite DESC
-        LIMIT 5;
-    """)
-    rows = cursor.fetchall()
-    print("  Country    | Regime      | Count | Avg Composite")
-    print("  -----------+-------------+-------+--------------")
-    for r in rows:
-        print(f"  {r[0]:<10} | {str(r[1]).upper():<11} | {r[2]:<5} | {r[3]:.2f}")
-    db.close()
+            stats = {
+                "items": len(items),
+                "purification": len(coding_rows),
+                "evidence": len(evidence),
+                "iconclass": len(iconclass),
+            }
+
+        temporary_path.replace(sqlite_db)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    if verify:
+        verify_database(sqlite_db)
+    return stats
+
+
+def verify_database(sqlite_db: Path = SQLITE_DB) -> None:
+    with sqlite3.connect(sqlite_db) as db:
+        violations = db.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise ValueError(f"SQLite foreign-key violations: {violations[:5]}")
+        counts = {
+            table: db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in ("items", "purification", "evidence", "item_iconclass")
+        }
+    print("SQLite projection verified:")
+    for table, count in counts.items():
+        print(f"  {table}: {count}")
+
+
+def main() -> None:
+    stats = build_database()
+    print(f"SQLite projection written to: {SQLITE_DB}")
+    print("Counts: " + ", ".join(f"{key}={value}" for key, value in stats.items()))
+
 
 if __name__ == "__main__":
-    import re  # needed for year regex fallback
-    build_database()
+    main()

--- a/tools/scripts/trace_evidence.py
+++ b/tools/scripts/trace_evidence.py
@@ -302,6 +302,11 @@ def main() -> None:
         action="store_true",
         help="Show detailed issue list"
     )
+    parser.add_argument(
+        "--fail-on-high",
+        action="store_true",
+        help="Exit non-zero when the report contains high-severity issues",
+    )
 
     args = parser.parse_args()
 
@@ -331,6 +336,9 @@ def main() -> None:
             encoding="utf-8"
         )
         print(f"Detailed report saved to: {args.output}")
+
+    if args.fail_on_high and report["issues"]["by_severity"]["high"]:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tools/scripts/vault_sync.py
+++ b/tools/scripts/vault_sync.py
@@ -238,7 +238,9 @@ def _vault_note_to_record(fm: dict) -> dict:
 
     # Tags
     tags = fm.get("tags") or []
-    audit_flags = ["vault-import", "#verificar"] if "#verificar" in str(tags) else ["vault-import"]
+    audit_flags = ["vault-import", "coding-pending"]
+    if "#verificar" in str(tags):
+        audit_flags.append("#verificar")
 
     now = _now_iso()
 
@@ -275,7 +277,10 @@ def _vault_note_to_record(fm: dict) -> dict:
                 {
                     "claim_text": f"Regime iconocrático: {regime.upper()}" if regime else "Regime pendente",
                     "claim_type": "iconographic",
-                    "status": "tentative" if not regime else "supported",
+                    # A qualitative vault label is a lead, not an observed
+                    # ten-indicator coding.  Keep it tentative until a coder
+                    # inspects the image under a versioned codebook.
+                    "status": "tentative",
                     "confidence": confidence,
                 }
             ],
@@ -291,19 +296,6 @@ def _vault_note_to_record(fm: dict) -> dict:
             "updated_at": now,
         },
     }
-
-    if regime:
-        record["purificacao"] = {
-            "desincorporacao": 0, "rigidez_postural": 0, "dessexualizacao": 0,
-            "uniformizacao_facial": 0, "heraldizacao": 0, "enquadramento_arquitetonico": 0,
-            "apagamento_narrativo": 0, "monocromatizacao": 0, "serialidade": 0,
-            "inscricao_estatal": 0,
-            "purificacao_composto": 0.0,
-            "regime_iconocratico": regime,
-            "coded_by": "vault-import",
-            "coded_at": now,
-            "notes": "Codificação pendente — importado do vault",
-        }
 
     return record
 


### PR DESCRIPTION
## Summary

Describe the intent of this change in 2-4 lines.

## Surface

- [ ] Corpus/data
- [ ] Coding/analysis
- [ ] Writing/docs
- [ ] Infra/publishing

## Checks

- [ ] `python tools/scripts/validate_schemas.py data/processed/records.jsonl --schema master-record --verbose`
- [ ] `python tools/scripts/code_purification.py --status` if coding-related
- [ ] `python tools/scripts/vault_sync.py status` or `diff` if vault-facing
- [ ] Release/docs updated if GitHub Pages or Hugging Face is affected

## Notes

List any known drift, skipped checks, or external follow-up.
