### PR TITLE
Set up Cursor Cloud Agent development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,14 @@ python tools/scripts/<script>.py           # always from repo root
 pytest tests/                              # full suite (~24 test files)
 ```
 
+> **Cloud Agent note:** the Cursor Cloud environment has **no conda**. It mirrors CI:
+> system Python 3.12 with dependencies installed via `pip install --user` (user site,
+> auto-imported by `python3`). There is no conda env to activate — run scripts directly
+> with `python tools/scripts/<script>.py` and tests with `python -m pytest tests/`.
+> Console scripts live in `~/.local/bin` (not on PATH), so invoke tools through
+> `python -m <tool>` (e.g. `python -m pytest`). `pandoc` is preinstalled for
+> `make -C vault/tese docx`; full-thesis **PDF** additionally needs a LaTeX/TeX Live install.
+
 ## Essential Commands
 
 ```bash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates a reproducible Cursor Cloud Agent development environment for the ICONOCRACIA thesis/corpus monorepo, mirroring the repository's CI (`.github/workflows/validate.yml`).

The Cloud VM has **no conda**, so the environment follows the CI path instead: **system Python 3.12** with dependencies installed via `pip install --user`. The only code change here is a short **Cloud Agent note in `AGENTS.md`** clarifying this (the file previously documented only the local `conda activate iconocracy` path). The environment `install` script itself is proposed through the Cursor environment panel (not committed), since this repo has no committed `.cursor/environment.json`.

## Environment contents

- System Python 3.12 + `python` → `python3` alias
- Core deps from `requirements.txt` (jsonschema, pydantic, numpy, pillow, python-docx, nltk, krippendorff, rich, requests, google-genai, openai, anthropic, pytest)
- ML stack (CPU-only torch to stay lean, no GPU): `torch`, `transformers`, `peft`, `trl`, `datasets`
- Notebook/analysis stack from `environment.yml`: matplotlib, scipy, statsmodels, seaborn, prince, scikit-posthocs, jupyter
- `pandoc` (apt) for `make -C vault/tese docx`

## Validation (all green on the VM)

| Check | Result |
| --- | --- |
| `validate_schemas.py` records / purification | 335/335 and 286/286 valid |
| `check_corpus_export_idempotent.py` | idempotent |
| `records_to_corpus.py --diff` | in sync (335/335 by URL) |
| `code_purification.py --status` / `vault_sync.py status` / `check_thesis_terms.py` | ok |
| `pytest tests/` | 279 passed |
| Thesis DOCX (`make -C vault/tese capitulo-1.docx`) | built |
| `pip check` | no broken requirements |

Note: `webiconocracy` and `indexing/gallica-mcp-server` (docker-compose `web`/`mcp` services) are retired/empty per `CLAUDE.md`; the real dev experience is the Python toolchain above, which requires no long-running services.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ba4b240-6bc6-4d10-91e6-8823071cb9a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ba4b240-6bc6-4d10-91e6-8823071cb9a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

