### PR TITLE
Harden LPAI proxy coder staging contract

### DIFF
--- a/tests/test_lpai_proxy_coder_k3.py
+++ b/tests/test_lpai_proxy_coder_k3.py
@@ -7,21 +7,35 @@ codificação humana.
 
 from __future__ import annotations
 
+import fcntl
 import json
+import os
+import socket
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+import tools.scripts.lpai_proxy_coder_k3 as proxy
 from tools.scripts.lpai_proxy_coder_k3 import (
     AGENT_ID,
+    CODEBOOK_PATH,
     INDICATOR_KEYS,
+    PROXY_SCHEMA_VERSION,
     REPO,
+    SCRIPT_VERSION,
     GuardrailError,
+    append_row,
     assert_write_target,
     build_output_schema,
     build_row,
     build_user_content,
+    cached_download,
     load_done,
+    load_master_prompt,
     select_items,
+    validate_proxy_row,
 )
 
 
@@ -29,7 +43,7 @@ from tools.scripts.lpai_proxy_coder_k3 import (
 def staging(tmp_path, monkeypatch):
     root = tmp_path / "staging"
     root.mkdir()
-    monkeypatch.setenv("LPAI_PROXY_STAGING_ROOT", str(root))
+    monkeypatch.setattr(proxy, "DEFAULT_STAGING_ROOT", root)
     return root
 
 
@@ -39,8 +53,8 @@ def staging(tmp_path, monkeypatch):
 
 
 def test_aceita_destino_em_staging(staging):
-    target = assert_write_target(staging / "lpai-proxy-k3-runs.jsonl")
-    assert target == (staging / "lpai-proxy-k3-runs.jsonl").resolve()
+    target = assert_write_target(staging / proxy.DEFAULT_OUTPUT_NAME)
+    assert target == (staging / proxy.DEFAULT_OUTPUT_NAME).resolve()
 
 
 def test_recusa_records_jsonl_canonico(staging):
@@ -89,6 +103,149 @@ def test_recusa_escapar_de_staging_por_caminho_relativo(staging):
         assert_write_target(staging / ".." / "proxy-runs.jsonl")
 
 
+def test_recusa_evasao_por_symlink_de_diretorio(staging, tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = staging / "escape"
+    link.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(GuardrailError):
+        assert_write_target(link / "proxy-runs.jsonl")
+
+
+def test_recusa_evasao_por_symlink_de_arquivo(staging, tmp_path):
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text("não tocar\n", encoding="utf-8")
+    link = staging / "proxy-runs.jsonl"
+    link.symlink_to(outside)
+
+    with pytest.raises(GuardrailError):
+        assert_write_target(link)
+    assert outside.read_text(encoding="utf-8") == "não tocar\n"
+
+
+@pytest.mark.parametrize(
+    "directory",
+    [
+        REPO / "data" / "processed",
+        REPO / "corpus",
+        REPO / "examples",
+        REPO / "schema",
+        REPO / "tools" / "schemas",
+    ],
+)
+def test_recusa_todos_os_diretorios_proibidos(staging, directory):
+    with pytest.raises(GuardrailError):
+        assert_write_target(directory / "proxy-runs.jsonl")
+
+
+def test_saida_invalida_retorna_tres_sem_truncar_antes_de_rede(
+    staging, monkeypatch
+):
+    forbidden = staging / "records.jsonl"
+    forbidden.write_text("conteúdo original\n", encoding="utf-8")
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        proxy, "make_client", lambda *_: calls.append("client")
+    )
+    monkeypatch.setattr(
+        proxy, "cached_download", lambda *_: calls.append("network")
+    )
+
+    assert proxy.main(["--all", "--output", str(forbidden)]) == 3
+    assert calls == []
+    assert forbidden.read_text(encoding="utf-8") == "conteúdo original\n"
+
+
+def test_append_recusa_troca_toctou_de_ancestral(staging, tmp_path, monkeypatch):
+    safe_parent = staging / "batch"
+    safe_parent.mkdir()
+    output = safe_parent / "runs.jsonl"
+    approved = assert_write_target(output)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    original_assert = proxy.assert_write_target
+    swapped = False
+
+    def approve_then_swap(candidate):
+        nonlocal swapped
+        result = original_assert(candidate)
+        if not swapped:
+            safe_parent.rmdir()
+            safe_parent.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return result
+
+    monkeypatch.setattr(proxy, "assert_write_target", approve_then_swap)
+    with pytest.raises(GuardrailError):
+        append_row(
+            approved,
+            build_row(
+                _record(),
+                _coded(),
+                model="kimi-k3",
+                codebook_version="2.2.1",
+                image_source=None,
+            ),
+        )
+    assert not (outside / "runs.jsonl").exists()
+
+
+def test_append_recusa_troca_toctou_do_arquivo(staging, tmp_path, monkeypatch):
+    output = staging / "runs.jsonl"
+    approved = assert_write_target(output)
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text("não tocar\n", encoding="utf-8")
+    original_assert = proxy.assert_write_target
+    swapped = False
+
+    def approve_then_swap(candidate):
+        nonlocal swapped
+        result = original_assert(candidate)
+        if not swapped:
+            output.symlink_to(outside)
+            swapped = True
+        return result
+
+    monkeypatch.setattr(proxy, "assert_write_target", approve_then_swap)
+    with pytest.raises(GuardrailError):
+        append_row(
+            approved,
+            build_row(
+                _record(),
+                _coded(),
+                model="kimi-k3",
+                codebook_version="2.2.1",
+                image_source=None,
+            ),
+        )
+    assert outside.read_text(encoding="utf-8") == "não tocar\n"
+
+
+def test_append_recusa_hardlink_para_arquivo_externo(staging, tmp_path):
+    outside = tmp_path / "outside.jsonl"
+    original = b"nao tocar\n"
+    outside.write_bytes(original)
+    output = staging / "runs.jsonl"
+    os.link(outside, output)
+
+    with pytest.raises(GuardrailError, match="hardlinks"):
+        append_row(output, _row())
+    assert outside.read_bytes() == original
+
+
+def test_append_recusa_hardlink_especificamente_para_records(staging):
+    records = REPO / "data" / "processed" / "records.jsonl"
+    before = records.read_bytes()
+    output = staging / "proxy-hardlink.jsonl"
+    os.link(records, output)
+
+    with pytest.raises(GuardrailError, match="hardlinks|canônico"):
+        append_row(output, _row())
+    assert records.read_bytes() == before
+
+
 # --------------------------------------------------------------------------
 # Envelope de proxy
 # --------------------------------------------------------------------------
@@ -104,8 +261,23 @@ def _record():
             "date_hint": "1889",
             "place_hint": "Brazil",
         },
-        "webscout": {"summary_evidence": "gravura", "gaps": []},
-        "purificacao": {"coded_by": "ana", "regime_iconocratico": "fundacional"},
+        "webscout": {
+            "summary_evidence": "gravura",
+            "gaps": [],
+            "search_results": [
+                {
+                    "title": "Registro institucional",
+                    "url": "https://example.org/catalogo",
+                    "notes": "descrição catalográfica",
+                }
+            ],
+        },
+        "purificacao": {
+            "coded_by": "ana",
+            "regime_iconocratico": "fundacional",
+            "record_metadata": {"medium": "moeda/metal"},
+            "notes": "nota humana anterior",
+        },
     }
 
 
@@ -115,10 +287,28 @@ def _coded():
         "codificavel": True,
         "indicadores": {key: 1 for key in INDICATOR_KEYS},
         "inventario_verbal": ["balança", "olhos vendados"],
+        "vetor_colonial": "republicano_brasileiro",
+        "atributos_iconograficos": ["balança", "venda"],
+        "hipotese_racial": "leitura situada, requer adjudicação",
+        "programa_id": "programa-1",
+        "ordem_no_programa": 2,
+        "finalidade_atribuida": "legitimacao_juridica",
+        "power_at_stake": "legitima a autoridade estatal",
         "regime_iconocratico": "normativo",
         "confianca": "media",
         "justificativa": "atributos visíveis",
+        "notes": "incerteza preservada",
     }
+
+
+def _row():
+    return build_row(
+        _record(),
+        _coded(),
+        model="kimi-k3",
+        codebook_version="2.2.1",
+        image_source=None,
+    )
 
 
 def test_row_marca_autoridade_de_proxy():
@@ -136,6 +326,8 @@ def test_row_marca_autoridade_de_proxy():
     assert row["coded_by"] == AGENT_ID
     assert row["target_field"] == "purificacao_proposta"
     assert row["codebook_version"] == "2.2.0"
+    assert row["script_version"] == SCRIPT_VERSION
+    assert row["proxy_schema_version"] == PROXY_SCHEMA_VERSION
     assert row["capta_declaration"].startswith("LPAI v2-capta")
 
 
@@ -152,6 +344,26 @@ def test_row_e_serializavel():
         _record(), _coded(), model="kimi-k3", codebook_version="2.2.0", image_source=None
     )
     assert json.loads(json.dumps(row, ensure_ascii=False))["item_id"] == "abc-123"
+
+
+def test_row_preserva_todos_os_campos_do_paragrafo_16():
+    coded = _coded()
+    row = build_row(
+        _record(), coded, model="kimi-k3", codebook_version="2.2.1", image_source=None
+    )
+    expected = {
+        "vetor_colonial",
+        "atributos_iconograficos",
+        "hipotese_racial",
+        "programa_id",
+        "ordem_no_programa",
+        "finalidade_atribuida",
+        "power_at_stake",
+        "notes",
+    }
+    assert expected <= row["proposta"].keys()
+    assert all(row["proposta"][field] == coded[field] for field in expected)
+    validate_proxy_row(row)
 
 
 # --------------------------------------------------------------------------
@@ -184,6 +396,297 @@ def test_schema_exige_justificativa_e_confianca():
     required = build_output_schema()["required"]
     assert "justificativa" in required
     assert "confianca" in required
+    assert "notes" in required
+
+
+def test_linha_completa_valida_contra_schema_persistido():
+    row = build_row(
+        _record(), _coded(), model="kimi-k3", codebook_version="2.2.1", image_source=None
+    )
+    validate_proxy_row(row)
+
+
+def test_schema_exige_versao_explicita_do_envelope():
+    row = _row()
+    del row["proxy_schema_version"]
+    with pytest.raises(ValueError, match="proxy_schema_version"):
+        validate_proxy_row(row)
+
+
+def test_substituicao_do_conteudo_do_schema_invalida_validator(tmp_path):
+    schema_path = tmp_path / "proxy.schema.json"
+    original = proxy.PROXY_SCHEMA_PATH.read_bytes()
+    schema_path.write_bytes(original)
+    warmed = proxy.get_proxy_validator(schema_path)
+    validate_proxy_row(_row(), validator=warmed)
+
+    changed = json.loads(original)
+    changed["properties"]["proxy_schema_version"]["const"] = "9.9.9"
+    schema_path.write_text(json.dumps(changed), encoding="utf-8")
+    current = proxy.get_proxy_validator(schema_path)
+
+    assert current is not warmed
+    with pytest.raises(ValueError, match="proxy_schema_version"):
+        validate_proxy_row(_row(), validator=current)
+
+
+def test_remocao_do_schema_apos_aquecimento_falha(tmp_path):
+    schema_path = tmp_path / "proxy.schema.json"
+    schema_path.write_bytes(proxy.PROXY_SCHEMA_PATH.read_bytes())
+    proxy.get_proxy_validator(schema_path)
+    schema_path.unlink()
+
+    with pytest.raises(FileNotFoundError, match="schema do proxy não encontrado"):
+        proxy.get_proxy_validator(schema_path)
+
+
+def test_mutacao_do_dict_publico_nao_altera_validator(tmp_path):
+    schema_path = tmp_path / "proxy.schema.json"
+    schema_path.write_bytes(proxy.PROXY_SCHEMA_PATH.read_bytes())
+    validator = proxy.get_proxy_validator(schema_path)
+    public_schema = proxy.load_proxy_schema(schema_path)
+    public_schema["properties"]["proxy_schema_version"]["const"] = "9.9.9"
+
+    fresh_public_schema = proxy.load_proxy_schema(schema_path)
+    assert fresh_public_schema["properties"]["proxy_schema_version"]["const"] == "1.0.0"
+    assert fresh_public_schema is not public_schema
+    validate_proxy_row(_row(), validator=validator)
+
+
+def test_validator_reutiliza_somente_bytes_identicos(tmp_path):
+    schema_path = tmp_path / "proxy.schema.json"
+    original = proxy.PROXY_SCHEMA_PATH.read_bytes()
+    schema_path.write_bytes(original)
+    first = proxy.get_proxy_validator(schema_path)
+    second = proxy.get_proxy_validator(schema_path)
+    assert second is first
+
+    schema_path.write_bytes(original + b"\n")
+    changed = proxy.get_proxy_validator(schema_path)
+    assert changed is not first
+
+    schema_path.write_bytes(original)
+    restored = proxy.get_proxy_validator(schema_path)
+    assert restored is first
+
+
+def test_append_rele_schema_antes_de_gravar(staging, monkeypatch):
+    output = staging / "runs.jsonl"
+    output.write_bytes(b"")
+    original = output.read_bytes()
+    warmed = proxy.get_proxy_validator()
+    calls = 0
+
+    def validator_then_missing():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return warmed
+        raise FileNotFoundError("schema removido durante a operação")
+
+    monkeypatch.setattr(proxy, "get_proxy_validator", validator_then_missing)
+    with pytest.raises(FileNotFoundError, match="schema removido"):
+        append_row(output, _row())
+
+    assert calls == 2
+    assert output.read_bytes() == original
+
+
+def test_schema_rejeita_composto_e_campo_extra():
+    coded = _coded()
+    coded["purificacao_composto"] = 1.5
+    row = build_row(
+        _record(), coded, model="kimi-k3", codebook_version="2.2.1", image_source=None
+    )
+    with pytest.raises(ValueError, match="purificacao_composto"):
+        validate_proxy_row(row)
+
+    row = build_row(
+        _record(), _coded(), model="kimi-k3", codebook_version="2.2.1", image_source=None
+    )
+    row["campo_extra"] = True
+    with pytest.raises(ValueError, match="campo_extra"):
+        validate_proxy_row(row)
+
+
+def test_linha_invalida_nao_cria_arquivo(staging):
+    output = staging / "runs.jsonl"
+    row = build_row(
+        _record(), _coded(), model="kimi-k3", codebook_version="2.2.1", image_source=None
+    )
+    row["proposta"]["purificacao_composto"] = 1.5
+
+    with pytest.raises(ValueError, match="purificacao_composto"):
+        append_row(output, row)
+    assert not output.exists()
+
+
+def test_append_deduplica_concorrencia_sob_lock(staging):
+    output = staging / "runs.jsonl"
+    barrier = threading.Barrier(2)
+
+    def worker():
+        barrier.wait()
+        return append_row(output, _row())
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: worker(), range(2)))
+
+    assert sorted(results) == [False, True]
+    lines = output.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["item_id"] == "abc-123"
+
+
+def test_append_respeita_lock_posix_exclusivo(staging):
+    output = staging / "runs.jsonl"
+    output.touch()
+    held_fd = os.open(output, os.O_RDWR)
+    started = threading.Event()
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    def worker():
+        started.set()
+        return append_row(output, _row())
+
+    try:
+        fcntl.flock(held_fd, fcntl.LOCK_EX)
+        future = pool.submit(worker)
+        assert started.wait(timeout=1)
+        time.sleep(0.05)
+        assert not future.done()
+        fcntl.flock(held_fd, fcntl.LOCK_UN)
+        assert future.result(timeout=1) is True
+    finally:
+        fcntl.flock(held_fd, fcntl.LOCK_UN)
+        pool.shutdown(wait=True)
+        os.close(held_fd)
+
+
+def test_append_rejeita_partial_write_e_reverte_arquivo(staging, monkeypatch):
+    output = staging / "runs.jsonl"
+    real_write = proxy.os.write
+
+    def partial_write(fd, payload):
+        return real_write(fd, payload[:-1])
+
+    monkeypatch.setattr(proxy.os, "write", partial_write)
+    with pytest.raises(OSError, match="parcial"):
+        append_row(output, _row())
+    assert output.read_bytes() == b""
+
+
+# --------------------------------------------------------------------------
+# Instrumento e CLI
+# --------------------------------------------------------------------------
+
+
+def test_caminho_real_do_codebook_e_secao_16():
+    assert CODEBOOK_PATH == (
+        REPO / "docs" / "methodology" / "codebooks" / "codebook-MASTER.md"
+    )
+    assert CODEBOOK_PATH.is_file()
+    prompt, codebook_version = load_master_prompt()
+    assert prompt
+    assert codebook_version == "2.2.1"
+    assert "Você é um codificador LPAI v2.2.1" in prompt
+
+
+def test_version_e_do_script_nao_do_codebook(capsys):
+    with pytest.raises(SystemExit) as exc:
+        proxy.parse_args(["--version"])
+    assert exc.value.code == 0
+    output = capsys.readouterr().out.strip()
+    assert output.endswith(SCRIPT_VERSION)
+    assert "2.2.1" not in output
+
+
+def test_dry_run_smoke_caminho_real_sem_escrita(tmp_path, monkeypatch):
+    staging_root = tmp_path / "staging"
+    images_dir = tmp_path / "images"
+    images_dir.mkdir()
+    (images_dir / "abc-123.jpg").write_bytes(b"placeholder")
+    monkeypatch.setattr(proxy, "DEFAULT_STAGING_ROOT", staging_root)
+    monkeypatch.setattr(proxy, "load_records", lambda: [_record()])
+    monkeypatch.setattr(
+        proxy,
+        "make_client",
+        lambda *_: pytest.fail("dry-run não pode criar cliente"),
+    )
+    monkeypatch.setattr(
+        proxy,
+        "cached_download",
+        lambda *_: pytest.fail("dry-run não pode tocar a rede"),
+    )
+
+    assert (
+        proxy.main(
+            ["--all", "--dry-run", "--limit", "1", "--images-dir", str(images_dir)]
+        )
+        == 0
+    )
+    assert not staging_root.exists()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--items", ""],
+        ["--items", ", ,"],
+        ["--all", "--limit", "0"],
+        ["--all", "--limit", "-1"],
+        ["--all", "--retries", "-1"],
+    ],
+)
+def test_cli_recusa_seletores_e_numeros_invalidos_antes_de_rede(argv, monkeypatch):
+    monkeypatch.setattr(
+        proxy, "make_client", lambda *_: pytest.fail("argumento inválido não cria cliente")
+    )
+    with pytest.raises(SystemExit) as exc:
+        proxy.parse_args(argv)
+    assert exc.value.code == 2
+
+
+def test_todos_pulados_sem_evidencia_retorna_dois(staging, monkeypatch):
+    monkeypatch.setattr(proxy, "load_records", lambda: [_record()])
+    monkeypatch.setattr(
+        proxy, "make_client", lambda *_: pytest.fail("dry-run não cria cliente")
+    )
+    assert proxy.main(["--all", "--dry-run", "--limit", "1"]) == 2
+    assert not (staging / proxy.DEFAULT_OUTPUT_NAME).exists()
+
+
+def test_default_versionado_nao_le_nem_toca_staging_legado(staging, monkeypatch):
+    legacy = staging / "lpai-proxy-k3-runs.jsonl"
+    legacy_bytes = b'{"legado":"historico-e-incompativel"}'
+    legacy.write_bytes(legacy_bytes)
+    monkeypatch.setattr(proxy, "load_records", lambda: [])
+    monkeypatch.setattr(
+        proxy, "make_client", lambda *_: pytest.fail("sem itens não cria cliente")
+    )
+
+    assert proxy.main(["--all", "--dry-run"]) == 0
+    assert legacy.read_bytes() == legacy_bytes
+    assert not (staging / proxy.DEFAULT_OUTPUT_NAME).exists()
+
+
+def test_default_versionado_retoma_linhas_do_schema_corrente(staging, monkeypatch):
+    current = staging / proxy.DEFAULT_OUTPUT_NAME
+    assert append_row(current, _row()) is True
+    original = current.read_bytes()
+    monkeypatch.setattr(proxy, "load_records", lambda: [_record()])
+    monkeypatch.setattr(
+        proxy, "make_client", lambda *_: pytest.fail("item retomado não cria cliente")
+    )
+    monkeypatch.setattr(
+        proxy,
+        "cached_download",
+        lambda *_: pytest.fail("item retomado não toca a rede"),
+    )
+
+    assert proxy.main(["--all"]) == 0
+    assert current.read_bytes() == original
+    assert load_done(current) == {"abc-123"}
 
 
 # --------------------------------------------------------------------------
@@ -223,21 +726,337 @@ def test_select_items_filtra_por_regime_e_origem():
     ] == ["abc-123"]
 
 
-def test_load_done_ignora_linha_corrompida(tmp_path):
-    path = tmp_path / "runs.jsonl"
-    path.write_text(
-        json.dumps({"item_id": "a"}) + "\n{quebrado\n" + json.dumps({"item_id": "b"}) + "\n",
-        encoding="utf-8",
-    )
-    assert load_done(path) == {"a", "b"}
+def test_load_done_recusa_linha_corrompida(staging):
+    path = staging / "runs.jsonl"
+    path.write_text("{quebrado\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON inválido"):
+        load_done(path)
+
+
+def test_load_done_recusa_ultima_linha_sem_newline(staging):
+    path = staging / "runs.jsonl"
+    path.write_text(json.dumps({"item_id": "a"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="truncado"):
+        load_done(path)
+
+
+@pytest.mark.parametrize("extra_args", [[], ["--force"]])
+def test_jsonl_corrompido_falha_antes_de_cliente_ou_rede(
+    staging, monkeypatch, extra_args
+):
+    output = staging / "runs.jsonl"
+    output.write_text('{"item_id":"a"}\n{"item_id":', encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(proxy, "load_records", lambda: [_record()])
+    monkeypatch.setattr(proxy, "make_client", lambda *_: calls.append("client"))
+    monkeypatch.setattr(proxy, "cached_download", lambda *_: calls.append("network"))
+    assert proxy.main(["--all", "--output", str(output), *extra_args]) == 1
+    assert calls == []
+    assert output.read_text(encoding="utf-8") == '{"item_id":"a"}\n{"item_id":'
+
+
+def test_jsonl_sintaticamente_valido_fora_do_schema_falha_antes_da_rede(
+    staging, monkeypatch
+):
+    output = staging / "runs.jsonl"
+    invalid = {"item_id": "abc-123", "campo_extra": True}
+    original = json.dumps(invalid) + "\n"
+    output.write_text(original, encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(proxy, "load_records", lambda: [_record()])
+    monkeypatch.setattr(proxy, "make_client", lambda *_: calls.append("client"))
+    monkeypatch.setattr(proxy, "cached_download", lambda *_: calls.append("network"))
+
+    assert proxy.main(["--all", "--output", str(output)]) == 1
+    assert calls == []
+    assert output.read_text(encoding="utf-8") == original
 
 
 def test_user_content_sem_imagem_instrui_nc():
     content = build_user_content(_record(), None, None)
     assert len(content) == 1
     assert "nc_causa=sem_imagem" in content[0]["text"]
+    assert "FONTE ledger.input" in content[0]["text"]
+    assert "FONTE purificacao preexistente" in content[0]["text"]
+    assert '"suporte_medium": "moeda/metal"' in content[0]["text"]
+    assert '"notas_anteriores": "nota humana anterior"' in content[0]["text"]
+    assert "FONTE webscout" in content[0]["text"]
+    assert "Registro institucional" in content[0]["text"]
+    assert "não prova de recepção histórica" in content[0]["text"]
+    assert "sentido produzido" in content[0]["text"]
 
 
 def test_user_content_com_imagem_anexa_base64():
     content = build_user_content(_record(), "QUJD", "image/jpeg")
     assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+def test_user_content_limita_notas_e_resultados_auxiliares():
+    record = _record()
+    record["purificacao"]["notes"] = "n" * 20_000
+    record["webscout"]["search_results"] = [
+        {"title": f"resultado-{index}", "notes": "x" * 5_000}
+        for index in range(100)
+    ]
+    text = build_user_content(record, None, None)[0]["text"]
+    assert "truncado" in text or "omitidos" in text
+    assert len(text) < 3 * proxy.SOURCE_BLOCK_MAX_CHARS + 3_000
+    assert "resultado-0" in text
+    assert "resultado-99" not in text
+
+
+# --------------------------------------------------------------------------
+# Download e cache de evidência (todos mockados, sem rede)
+# --------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        body: bytes,
+        *,
+        content_type: str = "image/jpeg",
+        status: int = 200,
+        url: str = "https://example.org/image.jpg",
+        location: str | None = None,
+        content_length: int | None = None,
+    ):
+        self.body = body
+        self.status_code = status
+        self.url = url
+        self.closed = False
+        self.headers = {"Content-Type": content_type}
+        if location is not None:
+            self.headers["Location"] = location
+        if content_length is not None:
+            self.headers["Content-Length"] = str(content_length)
+
+    def iter_content(self, chunk_size):
+        for offset in range(0, len(self.body), max(1, min(chunk_size, 3))):
+            yield self.body[offset : offset + max(1, min(chunk_size, 3))]
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.urls = []
+
+    def get(self, url, **kwargs):
+        self.urls.append(url)
+        if not self.responses:
+            pytest.fail("requisição mockada inesperada")
+        return self.responses.pop(0)
+
+
+@pytest.fixture()
+def public_dns(monkeypatch):
+    def resolve(host, port, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port))]
+
+    monkeypatch.setattr(proxy.socket, "getaddrinfo", resolve)
+
+
+def _install_fake_session(monkeypatch, responses):
+    session = _FakeSession(responses)
+    import requests
+
+    monkeypatch.setattr(requests, "Session", lambda: session)
+    return session
+
+
+@pytest.mark.parametrize(
+    ("url", "address"),
+    [
+        ("http://localhost/a.jpg", "127.0.0.1"),
+        ("http://private.example/a.jpg", "10.0.0.1"),
+        ("http://linklocal.example/a.jpg", "169.254.1.1"),
+        ("http://reserved.example/a.jpg", "240.0.0.1"),
+    ],
+)
+def test_url_recusa_host_nao_publico(url, address, monkeypatch):
+    def resolve(host, port, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port))]
+
+    monkeypatch.setattr(proxy.socket, "getaddrinfo", resolve)
+    with pytest.raises(ValueError):
+        proxy._validate_public_http_url(url)
+
+
+@pytest.mark.parametrize("url", ["file:///tmp/a.jpg", "ftp://example.org/a.jpg", "data:image/png,x"])
+def test_url_recusa_esquema_nao_http(url):
+    with pytest.raises(ValueError):
+        proxy._validate_public_http_url(url)
+
+
+def test_guarda_dns_recusa_rebinding_no_instante_da_conexao(monkeypatch):
+    def rebound(host, port, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", port))]
+
+    monkeypatch.setattr(proxy.socket, "getaddrinfo", rebound)
+    with pytest.raises(ValueError, match="não público"):
+        with proxy._public_dns_only():
+            proxy.socket.getaddrinfo("example.org", 443, type=socket.SOCK_STREAM)
+
+
+def test_download_valido_e_streaming_atomico(tmp_path, monkeypatch, public_dns):
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+    body = b"\xff\xd8\xff\xe0" + b"imagem"
+    response = _FakeResponse(body, content_length=len(body))
+    session = _install_fake_session(monkeypatch, [response])
+
+    result = cached_download("https://example.org/sem-extensao", "abc-123")
+
+    assert result == cache / "abc-123.jpg"
+    assert result.read_bytes() == body
+    assert session.urls == ["https://example.org/sem-extensao"]
+    assert response.closed
+    assert list(cache.glob("*.tmp")) == []
+
+
+def test_download_recusa_html_disfarcado_de_jpg(tmp_path, monkeypatch, public_dns):
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+    response = _FakeResponse(b"<html>segredo</html>", content_type="image/jpeg")
+    _install_fake_session(monkeypatch, [response])
+
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert not (cache / "abc-123.jpg").exists()
+    assert list(cache.glob("*.tmp")) == []
+
+
+def test_download_recusa_content_type_nao_imagem(tmp_path, monkeypatch, public_dns):
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+    response = _FakeResponse(b"\xff\xd8\xff\xe0x", content_type="text/html")
+    _install_fake_session(monkeypatch, [response])
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert not any(cache.iterdir())
+
+
+def test_download_recusa_tamanho_declarado_excessivo(tmp_path, monkeypatch, public_dns):
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+    response = _FakeResponse(
+        b"\xff\xd8\xff\xe0x",
+        content_length=proxy.IMAGE_MAX_BYTES + 1,
+    )
+    _install_fake_session(monkeypatch, [response])
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert not any(cache.iterdir())
+
+
+def test_download_recusa_tamanho_real_excessivo(tmp_path, monkeypatch, public_dns):
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+    monkeypatch.setattr(proxy, "IMAGE_MAX_BYTES", 8)
+    response = _FakeResponse(b"\xff\xd8\xff\xe0" + b"12345")
+    _install_fake_session(monkeypatch, [response])
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert not any(cache.iterdir())
+
+
+def test_download_valida_url_final_reportada(tmp_path, monkeypatch):
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+
+    def resolve(host, port, **kwargs):
+        address = "127.0.0.1" if host == "127.0.0.1" else "93.184.216.34"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port))]
+
+    monkeypatch.setattr(proxy.socket, "getaddrinfo", resolve)
+    response = _FakeResponse(
+        b"\xff\xd8\xff\xe0x",
+        url="http://127.0.0.1/final.jpg",
+    )
+    _install_fake_session(monkeypatch, [response])
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert not any(cache.iterdir())
+
+
+def test_redirect_para_ip_privado_e_bloqueado_antes_da_segunda_requisicao(
+    tmp_path, monkeypatch
+):
+    cache = tmp_path / "cache"
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+
+    def resolve(host, port, **kwargs):
+        address = "127.0.0.1" if host == "127.0.0.1" else "93.184.216.34"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port))]
+
+    monkeypatch.setattr(proxy.socket, "getaddrinfo", resolve)
+    redirect = _FakeResponse(
+        b"",
+        status=302,
+        location="http://127.0.0.1/secret.jpg",
+        url="https://example.org/a.jpg",
+    )
+    session = _install_fake_session(monkeypatch, [redirect])
+
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert session.urls == ["https://example.org/a.jpg"]
+    assert not any(cache.iterdir())
+
+
+def test_cache_recusa_symlink_de_arquivo_sem_tocar_alvo(
+    tmp_path, monkeypatch, public_dns
+):
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    outside = tmp_path / "outside.jpg"
+    outside.write_bytes("não tocar".encode())
+    (cache / "abc-123.jpg").symlink_to(outside)
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+    monkeypatch.setattr(
+        proxy,
+        "_download_response",
+        lambda *_: pytest.fail("symlink deve bloquear antes do download"),
+    )
+
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert outside.read_bytes() == "não tocar".encode()
+
+
+def test_cache_recusa_hardlink_sem_tocar_alvo(
+    tmp_path, monkeypatch, public_dns
+):
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    outside = tmp_path / "outside.jpg"
+    original = b"\xff\xd8\xff\xe0nao-tocar"
+    outside.write_bytes(original)
+    os.link(outside, cache / "abc-123.jpg")
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache)
+    monkeypatch.setattr(
+        proxy,
+        "_download_response",
+        lambda *_: pytest.fail("hardlink deve bloquear antes do download"),
+    )
+
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert outside.read_bytes() == original
+
+
+def test_cache_recusa_ancestral_symlink_sem_escrever_fora(
+    tmp_path, monkeypatch, public_dns
+):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    cache_link = tmp_path / "cache"
+    cache_link.symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(proxy, "IMAGE_CACHE", cache_link)
+    monkeypatch.setattr(
+        proxy,
+        "_download_response",
+        lambda *_: pytest.fail("ancestral symlink deve bloquear antes do download"),
+    )
+
+    assert cached_download("https://example.org/a.jpg", "abc-123") is None
+    assert list(outside.iterdir()) == []

--- a/tools/schemas/lpai-proxy-record.schema.json
+++ b/tools/schemas/lpai-proxy-record.schema.json
@@ -1,0 +1,339 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://iconocracia.com/schemas/lpai-proxy-record.schema.json",
+  "title": "LPAI proxy staging record",
+  "description": "Uma linha proxy-only do staging LPAI. Não autoriza merge sem adjudicação humana.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "item_id",
+    "item_hash",
+    "proxy_only",
+    "authority",
+    "target_field",
+    "merge_policy",
+    "human_class",
+    "human_coded_by_at_read_time",
+    "capta_declaration",
+    "coded_by",
+    "coded_at",
+    "model",
+    "script_version",
+    "proxy_schema_version",
+    "prompt_version",
+    "codebook_version",
+    "image_source",
+    "usage",
+    "proposta"
+  ],
+  "properties": {
+    "item_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "item_hash": {
+      "type": "string",
+      "minLength": 1
+    },
+    "proxy_only": {
+      "const": true
+    },
+    "authority": {
+      "const": "proxy"
+    },
+    "target_field": {
+      "const": "purificacao_proposta"
+    },
+    "merge_policy": {
+      "const": "requires_human_adjudication"
+    },
+    "human_class": {
+      "type": "null"
+    },
+    "human_coded_by_at_read_time": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "capta_declaration": {
+      "type": "string",
+      "minLength": 1
+    },
+    "coded_by": {
+      "const": "lpai-proxy-k3"
+    },
+    "coded_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1
+    },
+    "script_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "proxy_schema_version": {
+      "const": "1.0.0"
+    },
+    "prompt_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "codebook_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "image_source": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "usage": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "proposta": {
+      "$ref": "#/$defs/proposal"
+    }
+  },
+  "$defs": {
+    "proposal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "item_id",
+        "codificavel",
+        "indicadores",
+        "inventario_verbal",
+        "confianca",
+        "justificativa",
+        "notes"
+      ],
+      "properties": {
+        "item_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "codificavel": {
+          "type": "boolean",
+          "description": "A evidência permite codificação visual suficiente."
+        },
+        "indicadores": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "desincorporacao",
+            "rigidez_postural",
+            "dessexualizacao",
+            "uniformizacao_facial",
+            "heraldizacao",
+            "enquadramento_arquitetonico",
+            "apagamento_narrativo",
+            "monocromatizacao",
+            "serialidade",
+            "inscricao_estatal"
+          ],
+          "properties": {
+            "desincorporacao": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "rigidez_postural": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "dessexualizacao": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "uniformizacao_facial": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "heraldizacao": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "enquadramento_arquitetonico": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "apagamento_narrativo": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "monocromatizacao": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "serialidade": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            },
+            "inscricao_estatal": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
+            }
+          }
+        },
+        "inventario_verbal": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Atributos observados, sem índice ou escore agregado."
+        },
+        "familia_alegorica": {
+          "type": "string"
+        },
+        "subtipo": {
+          "type": "string"
+        },
+        "regime_iconocratico": {
+          "type": "string",
+          "enum": [
+            "fundacional",
+            "normativo",
+            "militar",
+            "contra-alegoria",
+            "NC"
+          ]
+        },
+        "recusa": {
+          "type": "string",
+          "enum": [
+            "substituicao_remasculinizante",
+            "negacao_pura",
+            "feminino_esvaziado",
+            "substituicao_neutro_abstrata",
+            "nenhuma"
+          ]
+        },
+        "genero_atribuido": {
+          "type": "string"
+        },
+        "funcao_juridica": {
+          "type": "string"
+        },
+        "vetor_colonial": {
+          "type": "string",
+          "enum": [
+            "europeu_direto",
+            "luso_brasileiro",
+            "republicano_brasileiro",
+            "nao_aplicavel"
+          ]
+        },
+        "atributos_iconograficos": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hipotese_racial": {
+          "type": "string",
+          "maxLength": 500
+        },
+        "dado_negativo": {
+          "type": "boolean"
+        },
+        "subaltern_caution": {
+          "type": "boolean"
+        },
+        "programa_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ordem_no_programa": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "finalidade_atribuida": {
+          "type": "string",
+          "enum": [
+            "legitimacao_juridica",
+            "pedagogia_civica",
+            "dissuasao",
+            "comemoracao",
+            "branding_estatal",
+            "outro"
+          ]
+        },
+        "power_at_stake": {
+          "type": "string",
+          "maxLength": 500
+        },
+        "confianca": {
+          "type": "string",
+          "enum": [
+            "alta",
+            "media",
+            "baixa"
+          ]
+        },
+        "nc_causa": {
+          "type": "string",
+          "enum": [
+            "evidencia_insuficiente",
+            "ambiguidade",
+            "fora_de_escopo",
+            "sem_imagem"
+          ]
+        },
+        "justificativa": {
+          "type": "string",
+          "minLength": 1
+        },
+        "notes": {
+          "type": "string"
+        },
+        "duvidas": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "codificavel": {
+                "const": false
+              }
+            },
+            "required": [
+              "codificavel"
+            ]
+          },
+          "then": {
+            "required": [
+              "nc_causa"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tools/scripts/README-lpai-proxy.md
+++ b/tools/scripts/README-lpai-proxy.md
@@ -1,0 +1,289 @@
+# Codificador-proxy LPAI
+
+Guia operacional de `tools/scripts/lpai_proxy_coder_k3.py`.
+
+## Escopo
+
+O script aplica o instrumento LPAI a registros do corpus como
+**codificador-proxy**. Sua saída é uma proposta situada (*capta*), sem
+autoridade humana. Ela não substitui codificação ou adjudicação humana e não
+promove dados ao corpus.
+
+O prompt operacional tem uma única fonte:
+`docs/methodology/codebooks/codebook-MASTER.md`, seção 16. O Python lê essa
+seção em tempo de execução; não mantém uma cópia do prompt.
+
+O script não calcula nem emite `purificacao_composto`, média ou outro escore
+agregado. Os dez indicadores ordinais e o inventário verbal permanecem
+indícios para leitura qualitativa.
+
+## Instalação
+
+A partir da raiz do repositório:
+
+```bash
+conda env create -f environment.yml
+conda activate iconocracy
+```
+
+Em ambiente sem Conda, instale ao menos as dependências declaradas em
+`requirements.txt`:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+## Versões
+
+Consulte a versão do programa:
+
+```bash
+python tools/scripts/lpai_proxy_coder_k3.py --version
+```
+
+Essa é a versão do **script**, registrada em `script_version`. Ela é distinta
+de:
+
+- `proxy_schema_version`, versão do contrato do envelope JSONL;
+- `codebook_version`, lida do front matter do codebook;
+- `prompt_version`, versão do envelope/instruções de proxy;
+- `model`, identificador do modelo chamado.
+
+## Variáveis de ambiente
+
+Uma execução real requer:
+
+```bash
+export MOONSHOT_API_KEY="..."
+```
+
+Não registre a chave em arquivos do repositório. `--dry-run` não requer chave,
+não cria cliente e não toca a rede.
+
+## Dry-run
+
+Valide caminho, instrumento, seleção e disponibilidade local de evidência:
+
+```bash
+python tools/scripts/lpai_proxy_coder_k3.py --all --dry-run --limit 3
+```
+
+Para IDs específicos:
+
+```bash
+python tools/scripts/lpai_proxy_coder_k3.py \
+  --items UUID-1,UUID-2 \
+  --dry-run
+```
+
+O `item_id` esperado é o UUID de `data/processed/records.jsonl`, não o ID
+público de `corpus/corpus-data.json`.
+
+## Execução
+
+Exemplo limitado:
+
+```bash
+python tools/scripts/lpai_proxy_coder_k3.py --all --limit 40
+```
+
+Com imagens locais nomeadas por `<item_id>.<ext>`:
+
+```bash
+python tools/scripts/lpai_proxy_coder_k3.py \
+  --all \
+  --limit 40 \
+  --images-dir /caminho/para/imagens
+```
+
+Sem `--images-dir`, o script tenta obter apenas URLs públicas HTTP(S). Cada
+download é feito em streaming, com limite fixo de 10 MiB, redirects validados,
+`Content-Type` de imagem e assinatura binária compatível. Localhost, endereços
+privados, link-local e reservados são recusados. PDF, HTML — ainda que renomeado
+como `.jpg` — e formatos sem assinatura suportada não são enviados ao modelo.
+O cliente ignora proxies herdados do ambiente e revalida a resolução DNS no
+instante da conexão, fechando mudança de endereço entre checagem e requisição.
+Use `--allow-textual` somente quando a codificação sem imagem for
+metodologicamente deliberada; itens insuficientes devem sair como não
+codificáveis.
+
+## Contexto entregue ao codificador
+
+O conteúdo por item separa explicitamente três proveniências:
+
+1. `ledger.input`: título, data, local e URL de entrada;
+2. `purificacao` preexistente: `record_metadata.medium` e `notes`;
+3. `webscout`: `summary_evidence`, `gaps` e, quando presentes,
+   `search_results`.
+
+Listas, dicionários, profundidade e textos têm limites fixos; cada bloco de
+fonte ocupa no máximo 4.000 caracteres. As anotações anteriores são pistas
+documentais, não autoridade nem prova de sentido recebido. O prompt lembra
+expressamente que recepção histórica exige fonte específica e que o proxy
+codifica somente o sentido produzido pelo dispositivo.
+
+## Saída e formato
+
+O destino padrão é:
+
+```text
+data/staging/lpai-proxy-k3-schema-v1-runs.jsonl
+```
+
+O nome inclui a versão principal do schema para impedir migração ou reescrita
+silenciosa de linhas incompatíveis. O antigo
+`data/staging/lpai-proxy-k3-runs.jsonl` é **somente histórico**: o default novo
+não o lê, valida, altera ou incorpora. Não renomeie o arquivo legado para o
+default atual.
+
+Para retomar ou criar outro arquivo compatível com o schema corrente, escolha-o
+explicitamente sob `data/staging/`:
+
+```bash
+python tools/scripts/lpai_proxy_coder_k3.py \
+  --all \
+  --output data/staging/lpai-proxy-k3-schema-v1-campanha-a.jsonl
+```
+
+O arquivo indicado por `--output` precisa conter exclusivamente envelopes com
+`proxy_schema_version: "1.0.0"` válidos contra o schema corrente. Um arquivo
+legado sem esse campo falha fechado antes de cliente ou rede; o script não o
+migra automaticamente.
+
+Cada linha JSONL é validada contra
+`tools/schemas/lpai-proxy-record.schema.json` antes da abertura do arquivo. O
+envelope registra, entre outros:
+
+- `proxy_only: true`;
+- `authority: "proxy"`;
+- `merge_policy: "requires_human_adjudication"`;
+- `script_version`, `proxy_schema_version`, `prompt_version` e
+  `codebook_version`;
+- modelo, data, fonte da imagem e uso reportado pela API;
+- `proposta`, com os dez indicadores, inventário verbal e os campos situados do
+  §16, incluindo `vetor_colonial`, `atributos_iconograficos`,
+  `hipotese_racial`, `programa_id`, `ordem_no_programa`,
+  `finalidade_atribuida`, `power_at_stake` e `notes`.
+
+`--force` permite nova linha para item já presente. Isso não transforma a linha
+mais recente em autoridade nem resolve divergências automaticamente.
+
+Antes de retomar, o arquivo existente é lido integralmente e **cada linha** é
+validada contra `tools/schemas/lpai-proxy-record.schema.json`. Linha fora do
+schema, JSON inválido, UTF-8 inválido ou última linha sem newline encerram a
+execução antes da criação do cliente e de qualquer download; o script nunca
+concatena uma linha nova a JSONL truncado.
+
+Os bytes atuais do schema são relidos no início de cada operação de validação e
+novamente imediatamente antes do append. A construção do validator é reutilizada
+somente quando esses bytes são idênticos; substituir ou remover o schema faz a
+operação falhar, sem conservar resultado associado apenas ao caminho.
+
+## Segurança de escrita
+
+As barreiras são avaliadas antes de criar cliente ou realizar chamada de rede.
+O destino:
+
+1. deve terminar em `.jsonl`;
+2. deve resolver fisicamente sob `data/staging/`;
+3. não pode escapar com `..` ou por link simbólico;
+4. não pode usar nomes de artefatos canônicos, como `records.jsonl`,
+   `purification.jsonl` ou `corpus-data.json`;
+5. não pode estar em `data/processed/`, `corpus/`, `examples/`, `schema/` ou
+   `tools/schemas/`.
+
+Na gravação, staging e cada ancestral são abertos por descritor com
+`O_DIRECTORY`/`O_NOFOLLOW`; o arquivo final também usa `O_NOFOLLOW`, precisa ser
+regular, precisa ter exatamente um link e não pode compartilhar dispositivo e
+inode com nenhum artefato canônico conhecido. Isso bloqueia hardlinks e mantém
+a barreira mesmo se um caminho for trocado depois da validação inicial.
+Violação retorna código 3 e não cria nem trunca saída. Não há variável de
+ambiente para mudar a raiz permitida de staging.
+
+O cache de imagens segue a mesma política no-follow. Downloads entram em arquivo
+temporário exclusivo e só são renomeados atomicamente após validação de tamanho,
+MIME, assinatura, contagem de links e identidade do inode.
+
+A decisão “item já gravado?” e o append ocorrem sob `flock` POSIX exclusivo no
+descritor da saída. A linha inteira usa uma única chamada `os.write`; escrita
+parcial é rejeitada e revertida ao tamanho anterior. Assim, duas execuções sem
+`--force` não intercalam linhas nem gravam o mesmo `item_id` duas vezes. Com
+`--force`, duplicidade é deliberadamente permitida.
+
+Essas garantias dependem de `openat`/`dir_fd`, `O_NOFOLLOW` e `flock`; portanto,
+o codificador operacional é suportado em sistemas POSIX. Não execute esta
+versão em Windows nativo.
+
+## Adjudicação humana
+
+A saída não deve ser copiada ou mesclada automaticamente em:
+
+- `data/processed/records.jsonl`;
+- `data/processed/purification.jsonl`;
+- `corpus/corpus-data.json`;
+- qualquer export público.
+
+Revise evidência, dúvidas, confiança, dados negativos e justificativa por item.
+Registre a decisão humana em fluxo separado e mantenha a autoria do proxy apenas
+como proveniência. Este script não implementa promoção.
+
+## Códigos de saída
+
+| Código | Significado |
+| --- | --- |
+| 0 | sucesso; sem baixa confiança detectada |
+| 1 | erro de I/O, instrumento, schema, cliente ou API |
+| 2 | execução concluída com baixa confiança/NC ou um ou mais itens pulados por falta de evidência |
+| 3 | barreira de escrita rejeitou o destino antes da rede |
+
+## Troubleshooting
+
+### `codebook não encontrado`
+
+Confirme:
+
+```bash
+test -f docs/methodology/codebooks/codebook-MASTER.md
+```
+
+### `master prompt (§16) não encontrado`
+
+Não copie o prompt para o Python. Corrija a seção 16 na fonte editorial e
+registre a mudança de `codebook_version` no próprio codebook.
+
+### `saída deve ficar sob .../data/staging`
+
+Remova `--output` ou use um caminho `.jsonl` dentro de `data/staging/`. Links
+simbólicos para fora são recusados.
+
+### `defina MOONSHOT_API_KEY no ambiente`
+
+Exporte a chave somente para execução real. Para validar sem credencial, use
+`--dry-run`.
+
+### item sem imagem
+
+Forneça `--images-dir` com arquivo nomeado pelo UUID, ou confirme que a URL do
+registro aponta para uma imagem pública direta. A extensão da URL não é
+suficiente: MIME e assinatura precisam corresponder. Sem `--allow-textual`, cada
+item sem evidência é pulado e a execução retorna 2 — inclusive quando todos são
+pulados. Não trate descrição textual como recepção histórica ou observação
+visual sem declarar a limitação.
+
+### `JSONL truncado`, `JSON inválido` ou `linha fora do schema`
+
+Não edite por concatenação. Preserve o arquivo para auditoria, corrija-o
+explicitamente ou escolha um novo nome `.jsonl` sob `data/staging/`. A falha
+acontece antes de cliente e rede.
+
+### argumento inválido
+
+`--items` exige ao menos um ID; `--limit` deve ser maior que zero; `--retries`
+aceita zero, mas não valor negativo. O `argparse` encerra com código 2 antes de
+ler o corpus ou tocar a rede.
+
+## Testes
+
+```bash
+python -m pytest tests/test_lpai_proxy_coder_k3.py -q --tb=short
+```

--- a/tools/scripts/lpai_proxy_coder_k3.py
+++ b/tools/scripts/lpai_proxy_coder_k3.py
@@ -2,16 +2,17 @@
 """
 lpai_proxy_coder_k3.py — Codificador-proxy LPAI v2 sobre Kimi K3 (Moonshot AI).
 
-Aplica o master prompt operacional do codebook (`schema/codebook-MASTER.md`,
-§16) a itens do corpus ICONOCRACY e grava capta iconográfico *de proxy* em um
-arquivo de staging separado. O objetivo é medir concordância (kappa) contra a
-codificação humana cega, não substituí-la.
+Aplica o master prompt operacional do codebook
+(`docs/methodology/codebooks/codebook-MASTER.md`, §16) a itens do corpus
+ICONOCRACY e grava capta iconográfico *de proxy* em um arquivo de staging
+separado. O objetivo é apoiar diagnóstico interno contra codificação humana,
+não substituí-la.
 
 Instrumento e autoridade
 ------------------------
   * Instrumento: §16 do codebook MASTER, lido em tempo de execução. O script
     NÃO reescreve nem parafraseia o prompt — a fidelidade do instrumento é o
-    que torna o kappa defensável. `codebook_version` é registrado em cada linha.
+    que preserva a rastreabilidade. `codebook_version` é registrado em cada linha.
   * Autoridade: nenhuma. Toda linha nasce com `proxy_only: true` e
     `merge_policy: requires_human_adjudication`. A classe humana permanece
     vazia por construção.
@@ -37,7 +38,8 @@ campo de composto — não há flag que o reintroduza.
 Uso
 ---
     export MOONSHOT_API_KEY=sk-...
-    python tools/scripts/lpai_proxy_coder_k3.py --dry-run --limit 3
+    python tools/scripts/lpai_proxy_coder_k3.py --version
+    python tools/scripts/lpai_proxy_coder_k3.py --all --dry-run --limit 3
     python tools/scripts/lpai_proxy_coder_k3.py --items <item_id>,<item_id>
     python tools/scripts/lpai_proxy_coder_k3.py --all --limit 40
 
@@ -45,7 +47,7 @@ Códigos de saída
 ----------------
     0 — sucesso; todos os itens codificados com confiança media|alta
     1 — erro fatal (I/O, API, instrumento ausente)
-    2 — concluído, porém com itens de confiança baixa ou NC (sinal, não bloqueio)
+    2 — concluído com baixa confiança/NC ou item pulado sem evidência
     3 — violação de barreira de escrita (nada foi gravado, nada foi gasto)
 """
 
@@ -53,14 +55,23 @@ from __future__ import annotations
 
 import argparse
 import base64
+import copy
+import fcntl
+import ipaddress
 import json
 import os
 import re
+import secrets
+import socket
+import stat
 import sys
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable
+from urllib.parse import urljoin, urlsplit
 
 REPO = Path(__file__).resolve().parent.parent.parent
 
@@ -68,16 +79,26 @@ REPO = Path(__file__).resolve().parent.parent.parent
 # Instrumento, entrada e saída
 # ---------------------------------------------------------------------------
 
-CODEBOOK_PATH = REPO / "schema" / "codebook-MASTER.md"
+SCRIPT_VERSION = "1.3.0"
+PROXY_SCHEMA_VERSION = "1.0.0"
+CODEBOOK_PATH = REPO / "docs" / "methodology" / "codebooks" / "codebook-MASTER.md"
+PROXY_SCHEMA_PATH = REPO / "tools" / "schemas" / "lpai-proxy-record.schema.json"
 CANONICAL_RECORDS = REPO / "data" / "processed" / "records.jsonl"
 DEFAULT_STAGING_ROOT = REPO / "data" / "staging"
-DEFAULT_OUTPUT_NAME = "lpai-proxy-k3-runs.jsonl"
+DEFAULT_OUTPUT_NAME = "lpai-proxy-k3-schema-v1-runs.jsonl"
 IMAGE_CACHE = REPO / ".cache" / "lpai-proxy-images"
 
 AGENT_ID = "lpai-proxy-k3"
 PROMPT_VERSION = "lpai-proxy-k3-v2"  # v2: composto aposentado (DEC-2026-07-28)
 MODEL_DEFAULT = "kimi-k3"
 BASE_URL_DEFAULT = "https://api.moonshot.ai/v1"
+IMAGE_MAX_BYTES = 10 * 1024 * 1024
+IMAGE_CHUNK_BYTES = 64 * 1024
+MAX_REDIRECTS = 5
+SOURCE_BLOCK_MAX_CHARS = 4_000
+SOURCE_STRING_MAX_CHARS = 1_000
+SOURCE_LIST_MAX_ITEMS = 5
+SOURCE_DICT_MAX_ITEMS = 12
 
 INDICATOR_KEYS: tuple[str, ...] = (
     "desincorporacao",
@@ -94,20 +115,13 @@ INDICATOR_KEYS: tuple[str, ...] = (
 
 REGIMES = ("fundacional", "normativo", "militar", "contra-alegoria")
 
-RECUSA_TIPOS = (
-    "substituicao_remasculinizante",
-    "negacao_pura",
-    "feminino_esvaziado",
-    "substituicao_neutro_abstrata",
-    "nenhuma",
-)
-
 # ---------------------------------------------------------------------------
 # Barreiras de escrita
 # ---------------------------------------------------------------------------
 
 CANONICAL_WRITE_FORBIDDEN: tuple[Path, ...] = (
     REPO / "data" / "processed" / "records.jsonl",
+    REPO / "data" / "processed" / "purification.jsonl",
     REPO / "corpus" / "corpus-data.json",
     REPO / "corpus" / "corpus-data.v2.json",
     REPO / "corpus" / "corpus-data-enriched.json",
@@ -125,6 +139,7 @@ FORBIDDEN_DIRS: tuple[Path, ...] = (
 FORBIDDEN_BASENAMES: frozenset[str] = frozenset(
     {
         "records.jsonl",
+        "purification.jsonl",
         "corpus-data.json",
         "corpus-data.v2.json",
         "corpus-data-enriched.json",
@@ -137,10 +152,43 @@ class GuardrailError(RuntimeError):
     """Tentativa de escrever fora da área de staging do proxy."""
 
 
+def _canonical_artifact_paths() -> tuple[Path, ...]:
+    """Artefatos conhecidos mais qualquer corpus-data*.json existente."""
+    candidates = list(CANONICAL_WRITE_FORBIDDEN)
+    candidates.extend(sorted((REPO / "corpus").glob("corpus-data*.json")))
+    return tuple(dict.fromkeys(candidates))
+
+
+def _assert_safe_file_identity(
+    fd: int, path: Path | str, *, purpose: str
+) -> os.stat_result:
+    """Exige inode regular, sem hardlinks e distinto dos artefatos canônicos."""
+    info = os.fstat(fd)
+    if not stat.S_ISREG(info.st_mode):
+        raise GuardrailError(f"{purpose} não é arquivo regular: {path}")
+    for canonical in _canonical_artifact_paths():
+        try:
+            canonical_info = canonical.stat()
+        except (FileNotFoundError, OSError):
+            continue
+        if (info.st_dev, info.st_ino) == (
+            canonical_info.st_dev,
+            canonical_info.st_ino,
+        ):
+            raise GuardrailError(
+                f"{purpose} compartilha inode com artefato canônico: {canonical}"
+            )
+    if info.st_nlink != 1:
+        raise GuardrailError(
+            f"{purpose} recusado: número de hardlinks precisa ser 1 "
+            f"(recebido: {info.st_nlink}): {path}"
+        )
+    return info
+
+
 def staging_root() -> Path:
-    """Raiz permitida para saída. Sobrescritível apenas para teste."""
-    override = os.environ.get("LPAI_PROXY_STAGING_ROOT")
-    return Path(override).resolve() if override else DEFAULT_STAGING_ROOT.resolve()
+    """Raiz lexical fixa; a abertura por descritor recusa symlinks em cada componente."""
+    return Path(os.path.abspath(DEFAULT_STAGING_ROOT))
 
 
 def _is_within(path: Path, parent: Path) -> bool:
@@ -159,7 +207,13 @@ def assert_write_target(candidate: str | Path) -> Path:
     ou diretório canônico; caminho contido na raiz de staging.
     """
     path = Path(candidate).expanduser()
-    resolved = (path if path.is_absolute() else (Path.cwd() / path)).resolve()
+    if ".." in path.parts:
+        raise GuardrailError("componentes '..' são proibidos no destino")
+    lexical = Path(os.path.abspath(path if path.is_absolute() else Path.cwd() / path))
+    try:
+        resolved = lexical.resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        raise GuardrailError(f"não foi possível resolver o destino: {path}") from exc
 
     if resolved.suffix != ".jsonl":
         raise GuardrailError(
@@ -184,12 +238,100 @@ def assert_write_target(candidate: str | Path) -> Path:
             )
 
     root = staging_root()
-    if not _is_within(resolved, root):
+    root_resolved = root.resolve(strict=False)
+    if not _is_within(resolved, root_resolved):
         raise GuardrailError(
-            f"saída deve ficar sob {root} (recebido: {resolved})"
+            f"saída deve ficar sob {root_resolved} (recebido: {resolved})"
         )
 
-    return resolved
+    return lexical
+
+
+def _open_directory_nofollow(path: Path, *, create: bool) -> int:
+    """Abre um diretório absoluto componente a componente, sem seguir symlinks."""
+    absolute = Path(os.path.abspath(path))
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    current_fd = os.open("/", flags)
+    try:
+        for component in absolute.parts[1:]:
+            try:
+                next_fd = os.open(component, flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                if not create:
+                    raise
+                os.mkdir(component, mode=0o700, dir_fd=current_fd)
+                next_fd = os.open(component, flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except Exception:
+        os.close(current_fd)
+        raise
+
+
+def _open_staging_parent(output_path: Path, *, create: bool) -> tuple[int, str]:
+    """Revalida e abre o pai sob staging por descritor (openat/no-follow)."""
+    safe_path = assert_write_target(output_path)
+    try:
+        relative = safe_path.relative_to(staging_root())
+    except ValueError as exc:  # defesa em profundidade
+        raise GuardrailError("destino não é lexicalmente relativo a staging") from exc
+    if not relative.parts or relative.name in {"", ".", ".."}:
+        raise GuardrailError("nome de saída inválido")
+    try:
+        parent_fd = _open_directory_nofollow(
+            staging_root().joinpath(*relative.parts[:-1]), create=create
+        )
+    except FileNotFoundError:
+        raise
+    except (OSError, RuntimeError) as exc:
+        raise GuardrailError(
+            "staging ou ancestral do destino não é diretório real sem symlink"
+        ) from exc
+    return parent_fd, relative.name
+
+
+def _validate_jsonl_fd(
+    fd: int, path: Path, *, validator: Any | None = None
+) -> set[str]:
+    """Valida integralmente JSONL já existente usando o mesmo descritor aberto."""
+    if validator is None:
+        validator = get_proxy_validator()
+    info = _assert_safe_file_identity(fd, path, purpose="saída existente")
+    if info.st_size == 0:
+        return set()
+
+    os.lseek(fd, 0, os.SEEK_SET)
+    raw = bytearray()
+    while chunk := os.read(fd, 64 * 1024):
+        raw.extend(chunk)
+    if not raw.endswith(b"\n"):
+        raise ValueError(f"{path}: JSONL truncado: última linha não termina em newline")
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{path}: JSONL não é UTF-8 válido") from exc
+
+    done: set[str] = set()
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path}:{line_number} JSON inválido: {exc}") from exc
+        if not isinstance(value, dict):
+            raise ValueError(f"{path}:{line_number}: cada linha deve ser objeto JSON")
+        try:
+            validate_proxy_row(value, validator=validator)
+        except ValueError as exc:
+            raise ValueError(
+                f"{path}:{line_number}: linha fora de "
+                f"lpai-proxy-record.schema.json: {exc}"
+            ) from exc
+        item_id = value["item_id"]
+        done.add(item_id)
+    return done
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +358,8 @@ def load_master_prompt(codebook_path: Path = CODEBOOK_PATH) -> tuple[str, str]:
     )
     if not section:
         raise ValueError(
-            "master prompt (§16) não encontrado em schema/codebook-MASTER.md"
+            "master prompt (§16) não encontrado em "
+            "docs/methodology/codebooks/codebook-MASTER.md"
         )
 
     return section.group(1).strip(), version
@@ -246,76 +389,70 @@ def build_system_prompt(master_prompt: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def load_proxy_schema(schema_path: Path | None = None) -> dict[str, Any]:
+    """Lê o schema atual e devolve um objeto novo, não retido pelo validator."""
+    schema_path = schema_path or PROXY_SCHEMA_PATH
+    try:
+        schema_bytes = schema_path.read_bytes()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"schema do proxy não encontrado: {schema_path}") from exc
+    try:
+        return json.loads(schema_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"schema do proxy inválido: {schema_path}: {exc}") from exc
+
+
+@lru_cache(maxsize=8)
+def _validator_from_schema_bytes(schema_bytes: bytes) -> Any:
+    """Cacheia validator somente pela cópia imutável exata do schema."""
+    try:
+        from jsonschema import Draft202012Validator, FormatChecker
+        from jsonschema.exceptions import SchemaError
+    except ImportError as exc:  # pragma: no cover - requirements.txt inclui jsonschema
+        raise RuntimeError("pip install jsonschema") from exc
+
+    schema = json.loads(schema_bytes)
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as exc:
+        raise ValueError(f"contrato JSON Schema inválido: {exc.message}") from exc
+    return Draft202012Validator(schema, format_checker=FormatChecker())
+
+
+def get_proxy_validator(schema_path: Path | None = None) -> Any:
+    """Relê bytes atuais; só reutiliza construção quando o conteúdo é idêntico."""
+    schema_path = schema_path or PROXY_SCHEMA_PATH
+    try:
+        schema_bytes = schema_path.read_bytes()
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"schema do proxy não encontrado: {schema_path}") from exc
+    try:
+        return _validator_from_schema_bytes(schema_bytes)
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ValueError(f"schema do proxy inválido: {schema_path}: {exc}") from exc
+
+
 def build_output_schema() -> dict[str, Any]:
-    """Esquema de saída do proxy.
+    """Retorna o subesquema entregue ao modelo para a proposta LPAI.
 
     Não existe campo de índice composto: `purificacao_composto` está aposentado
-    desde o codebook v2.2.1 e a proibição vive na estrutura, não numa flag.
+    desde o codebook v2.2.1 e a proibição vive no schema persistido.
     """
-    indicadores = {
-        key: {"type": "integer", "minimum": 0, "maximum": 3}
-        for key in INDICATOR_KEYS
-    }
+    schema = load_proxy_schema()
+    return copy.deepcopy(schema["$defs"]["proposal"])
 
-    return {
-        "type": "object",
-        "required": [
-            "item_id",
-            "codificavel",
-            "indicadores",
-            "inventario_verbal",
-            "confianca",
-            "justificativa",
-        ],
-        "properties": {
-            "item_id": {"type": "string"},
-            "codificavel": {
-                "type": "boolean",
-                "description": "a evidência permite codificação visual suficiente",
-            },
-            "indicadores": {
-                "type": "object",
-                "required": list(INDICATOR_KEYS),
-                "properties": indicadores,
-                "additionalProperties": False,
-            },
-            "inventario_verbal": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "atributos observados em vocabulário iconográfico, sem escore",
-            },
-            "familia_alegorica": {
-                "type": "string",
-                "description": "Justitia, Libertas, Respublica, Marianne, Germania, "
-                "Britannia, Columbia, outra, ou NC",
-            },
-            "subtipo": {"type": "string"},
-            "regime_iconocratico": {
-                "type": "string",
-                "enum": [*REGIMES, "NC"],
-            },
-            "recusa": {"type": "string", "enum": list(RECUSA_TIPOS)},
-            "genero_atribuido": {"type": "string"},
-            "funcao_juridica": {"type": "string"},
-            "dado_negativo": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "ausências analiticamente relevantes",
-            },
-            "subaltern_caution": {"type": "boolean"},
-            "confianca": {"type": "string", "enum": ["alta", "media", "baixa"]},
-            "nc_causa": {
-                "type": "string",
-                "description": "obrigatório quando codificavel=false: "
-                "evidencia_insuficiente | ambiguidade | fora_de_escopo | sem_imagem",
-            },
-            "justificativa": {
-                "type": "string",
-                "description": "o que na evidência sustenta a codificação",
-            },
-            "duvidas": {"type": "array", "items": {"type": "string"}},
-        },
-    }
+
+def validate_proxy_row(row: dict[str, Any], *, validator: Any | None = None) -> None:
+    """Valida uma linha completa antes de criar ou abrir a saída."""
+    if validator is None:
+        validator = get_proxy_validator()
+    errors = sorted(validator.iter_errors(row), key=lambda error: list(error.path))
+    if errors:
+        details = "; ".join(
+            f"{'.'.join(str(part) for part in error.path) or '<root>'}: {error.message}"
+            for error in errors
+        )
+        raise ValueError(f"linha de staging inválida: {details}")
 
 
 # ---------------------------------------------------------------------------
@@ -370,21 +507,28 @@ def select_items(
 
 
 def load_done(output_path: Path) -> set[str]:
-    """Retomada: itens já presentes na saída de staging."""
-    if not output_path.exists():
+    """Retomada fail-closed: toda linha existente precisa ser JSONL íntegro."""
+    try:
+        parent_fd, name = _open_staging_parent(output_path, create=False)
+    except FileNotFoundError:
         return set()
-    done: set[str] = set()
-    with output_path.open("r", encoding="utf-8") as handle:
-        for line in handle:
-            line = line.strip()
-            if not line:
-                continue
+    try:
+        try:
+            fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=parent_fd)
+        except FileNotFoundError:
+            return set()
+        except OSError as exc:
+            raise GuardrailError("saída existente é symlink ou não pode ser aberta") from exc
+        try:
+            fcntl.flock(fd, fcntl.LOCK_SH)
             try:
-                done.add(json.loads(line).get("item_id", ""))
-            except json.JSONDecodeError:
-                continue
-    done.discard("")
-    return done
+                return _validate_jsonl_fd(fd, output_path)
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+    finally:
+        os.close(parent_fd)
 
 
 # ---------------------------------------------------------------------------
@@ -401,10 +545,19 @@ MIME_BY_SUFFIX = {
     ".tif": "image/tiff",
     ".tiff": "image/tiff",
 }
+SUFFIX_BY_MIME = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+    "image/tiff": ".tiff",
+}
 
 
 def local_image_for(item_id: str, images_dir: Path | None) -> Path | None:
     if images_dir is None:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", item_id):
         return None
     for suffix in IMAGE_SUFFIXES:
         candidate = images_dir / f"{item_id}{suffix}"
@@ -413,57 +566,341 @@ def local_image_for(item_id: str, images_dir: Path | None) -> Path | None:
     return None
 
 
-def cached_download(url: str, item_id: str) -> Path | None:
-    """Baixa a imagem para cache local. PDFs e HTML são recusados de propósito:
-    o proxy só codifica o que consegue ver."""
-    suffix = Path(url.split("?")[0]).suffix.lower()
-    if suffix not in IMAGE_SUFFIXES:
-        return None
+def _validate_public_http_url(url: str) -> str:
+    """Recusa esquemas não HTTP e qualquer resolução não global."""
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("URL de imagem precisa usar http ou https")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("credenciais embutidas em URL são proibidas")
+    hostname = parsed.hostname.rstrip(".").lower()
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        raise ValueError("localhost é proibido")
 
-    IMAGE_CACHE.mkdir(parents=True, exist_ok=True)
-    target = IMAGE_CACHE / f"{item_id}{suffix}"
-    if target.exists() and target.stat().st_size > 0:
-        return target
+    port = parsed.port or (443 if parsed.scheme.lower() == "https" else 80)
+    try:
+        addresses = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError(f"host de imagem não pôde ser resolvido: {hostname}") from exc
+    if not addresses:
+        raise ValueError(f"host de imagem sem endereço resolvido: {hostname}")
+    _require_global_addresses(addresses)
+    return url
 
+
+def _require_global_addresses(addresses: list[tuple[Any, ...]]) -> None:
+    for address in addresses:
+        ip = ipaddress.ip_address(address[4][0])
+        if not ip.is_global:
+            raise ValueError(f"endereço de imagem não público é proibido: {ip}")
+
+
+@contextmanager
+def _public_dns_only():
+    """Revalida também a resolução feita pelo cliente no instante da conexão."""
+    original_getaddrinfo = socket.getaddrinfo
+
+    def guarded_getaddrinfo(*args, **kwargs):
+        addresses = original_getaddrinfo(*args, **kwargs)
+        if not addresses:
+            raise OSError("resolução sem endereços")
+        _require_global_addresses(addresses)
+        return addresses
+
+    socket.getaddrinfo = guarded_getaddrinfo
+    try:
+        yield
+    finally:
+        socket.getaddrinfo = original_getaddrinfo
+
+
+def _image_mime_from_signature(prefix: bytes) -> str | None:
+    if prefix.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if prefix.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if prefix.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if len(prefix) >= 12 and prefix[:4] == b"RIFF" and prefix[8:12] == b"WEBP":
+        return "image/webp"
+    if prefix.startswith((b"II*\x00", b"MM\x00*")):
+        return "image/tiff"
+    return None
+
+
+def _existing_regular_cache_file(parent_fd: int, name: str) -> bool:
+    try:
+        info = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    if stat.S_ISLNK(info.st_mode):
+        raise GuardrailError(f"cache recusado: {name} é symlink")
+    if not stat.S_ISREG(info.st_mode):
+        raise GuardrailError(f"cache recusado: {name} não é arquivo regular")
+    fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=parent_fd)
+    try:
+        info = _assert_safe_file_identity(fd, name, purpose="arquivo de cache")
+        if info.st_size == 0:
+            return False
+        prefix = os.read(fd, 16)
+    finally:
+        os.close(fd)
+    expected_mime = MIME_BY_SUFFIX.get(Path(name).suffix.lower())
+    if _image_mime_from_signature(prefix) != expected_mime:
+        raise ValueError(f"cache existente tem assinatura inválida: {name}")
+    return True
+
+
+def _download_response(url: str):
+    """Segue redirects manualmente, validando cada destino antes da requisição."""
     try:
         import requests  # dependência opcional, só no caminho de download
-    except ImportError:  # pragma: no cover
-        print("[aviso] requests ausente; use --images-dir", file=sys.stderr)
-        return None
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("requests ausente; use --images-dir") from exc
 
-    try:
-        response = requests.get(url, timeout=60)
+    session = requests.Session()
+    session.trust_env = False
+    current = url
+    for redirect_count in range(MAX_REDIRECTS + 1):
+        _validate_public_http_url(current)
+        with _public_dns_only():
+            response = session.get(
+                current,
+                allow_redirects=False,
+                stream=True,
+                timeout=(5, 30),
+            )
+        if 300 <= response.status_code < 400:
+            location = response.headers.get("Location")
+            response.close()
+            if not location:
+                raise ValueError("redirect sem Location")
+            if redirect_count >= MAX_REDIRECTS:
+                raise ValueError("limite de redirects excedido")
+            current = urljoin(current, location)
+            _validate_public_http_url(current)
+            continue
         response.raise_for_status()
+        _validate_public_http_url(response.url)
+        return response
+    raise ValueError("limite de redirects excedido")  # pragma: no cover
+
+
+def cached_download(url: str, item_id: str) -> Path | None:
+    """Baixa imagem pública, limitada e autenticada por MIME + assinatura."""
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", item_id):
+        print(f"[aviso] item_id inseguro para cache: {item_id!r}", file=sys.stderr)
+        return None
+    response = None
+    try:
+        _validate_public_http_url(url)
+        cache_fd = _open_directory_nofollow(IMAGE_CACHE, create=True)
+        try:
+            for suffix in sorted(set(SUFFIX_BY_MIME.values())):
+                name = f"{item_id}{suffix}"
+                if _existing_regular_cache_file(cache_fd, name):
+                    return IMAGE_CACHE / name
+
+            response = _download_response(url)
+            content_type = response.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+            suffix = SUFFIX_BY_MIME.get(content_type)
+            if suffix is None:
+                raise ValueError(f"Content-Type não suportado: {content_type or '<ausente>'}")
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None and int(content_length) > IMAGE_MAX_BYTES:
+                raise ValueError(f"imagem excede limite de {IMAGE_MAX_BYTES} bytes")
+
+            target_name = f"{item_id}{suffix}"
+            if _existing_regular_cache_file(cache_fd, target_name):
+                return IMAGE_CACHE / target_name
+            temp_name = f".{item_id}.{secrets.token_hex(8)}.tmp"
+            temp_fd = os.open(
+                temp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=cache_fd,
+            )
+            total = 0
+            prefix = bytearray()
+            try:
+                _assert_safe_file_identity(
+                    temp_fd, temp_name, purpose="arquivo temporário de cache"
+                )
+                for chunk in response.iter_content(chunk_size=IMAGE_CHUNK_BYTES):
+                    if not chunk:
+                        continue
+                    total += len(chunk)
+                    if total > IMAGE_MAX_BYTES:
+                        raise ValueError(f"imagem excede limite de {IMAGE_MAX_BYTES} bytes")
+                    if len(prefix) < 16:
+                        prefix.extend(chunk[: 16 - len(prefix)])
+                    view = memoryview(chunk)
+                    while view:
+                        written = os.write(temp_fd, view)
+                        if written <= 0:  # pragma: no cover - falha de filesystem
+                            raise OSError("escrita de cache incompleta")
+                        view = view[written:]
+                if total == 0:
+                    raise ValueError("imagem vazia")
+                signature_mime = _image_mime_from_signature(bytes(prefix))
+                if signature_mime != content_type:
+                    raise ValueError(
+                        "assinatura do conteúdo não corresponde ao Content-Type de imagem"
+                    )
+                _assert_safe_file_identity(
+                    temp_fd, temp_name, purpose="arquivo temporário de cache"
+                )
+                os.fsync(temp_fd)
+            except Exception:
+                os.close(temp_fd)
+                os.unlink(temp_name, dir_fd=cache_fd)
+                raise
+            else:
+                os.close(temp_fd)
+
+            try:
+                target_exists = _existing_regular_cache_file(cache_fd, target_name)
+            except Exception:
+                os.unlink(temp_name, dir_fd=cache_fd)
+                raise
+            if target_exists:
+                os.unlink(temp_name, dir_fd=cache_fd)
+                return IMAGE_CACHE / target_name
+            try:
+                os.replace(
+                    temp_name,
+                    target_name,
+                    src_dir_fd=cache_fd,
+                    dst_dir_fd=cache_fd,
+                )
+            except Exception:
+                try:
+                    os.unlink(temp_name, dir_fd=cache_fd)
+                except FileNotFoundError:
+                    pass
+                raise
+            return IMAGE_CACHE / target_name
+        finally:
+            os.close(cache_fd)
     except Exception as exc:  # noqa: BLE001 - rede é ruidosa por natureza
         print(f"[aviso] download falhou ({item_id}): {exc}", file=sys.stderr)
         return None
-
-    target.write_bytes(response.content)
-    return target
+    finally:
+        if response is not None:
+            response.close()
 
 
 def encode_image(path: Path) -> tuple[str, str]:
     mime = MIME_BY_SUFFIX.get(path.suffix.lower(), "image/jpeg")
-    return base64.b64encode(path.read_bytes()).decode("ascii"), mime
+    parent_fd = _open_directory_nofollow(path.parent, create=False)
+    try:
+        fd = os.open(path.name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=parent_fd)
+        try:
+            info = _assert_safe_file_identity(
+                fd, path, purpose="arquivo de evidência/cache"
+            )
+            if info.st_size > IMAGE_MAX_BYTES:
+                raise ValueError(f"imagem excede limite de {IMAGE_MAX_BYTES} bytes")
+            chunks = bytearray()
+            while chunk := os.read(fd, IMAGE_CHUNK_BYTES):
+                chunks.extend(chunk)
+                if len(chunks) > IMAGE_MAX_BYTES:
+                    raise ValueError(f"imagem excede limite de {IMAGE_MAX_BYTES} bytes")
+        finally:
+            os.close(fd)
+    finally:
+        os.close(parent_fd)
+    signature_mime = _image_mime_from_signature(bytes(chunks[:16]))
+    if signature_mime != mime:
+        raise ValueError("extensão da imagem não corresponde à assinatura suportada")
+    return base64.b64encode(chunks).decode("ascii"), mime
+
+
+def _bounded_source_value(value: Any, *, depth: int = 0) -> Any:
+    """Reduz metadados auxiliares sem transformar seu conteúdo substantivo."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        if len(value) <= SOURCE_STRING_MAX_CHARS:
+            return value
+        return value[:SOURCE_STRING_MAX_CHARS] + "… [truncado]"
+    if depth >= 3:
+        return "… [profundidade truncada]"
+    if isinstance(value, dict):
+        limited: dict[str, Any] = {}
+        for index, (key, nested) in enumerate(value.items()):
+            if index >= SOURCE_DICT_MAX_ITEMS:
+                limited["_truncado"] = "campos adicionais omitidos"
+                break
+            limited[str(key)] = _bounded_source_value(nested, depth=depth + 1)
+        return limited
+    if isinstance(value, (list, tuple)):
+        limited = [
+            _bounded_source_value(nested, depth=depth + 1)
+            for nested in value[:SOURCE_LIST_MAX_ITEMS]
+        ]
+        if len(value) > SOURCE_LIST_MAX_ITEMS:
+            limited.append("… [itens adicionais omitidos]")
+        return limited
+    return _bounded_source_value(str(value), depth=depth + 1)
+
+
+def _render_source_block(label: str, value: Any) -> str:
+    rendered = json.dumps(
+        _bounded_source_value(value), ensure_ascii=False, indent=2
+    )
+    if len(rendered) > SOURCE_BLOCK_MAX_CHARS:
+        rendered = rendered[:SOURCE_BLOCK_MAX_CHARS] + "\n… [bloco truncado]"
+    return f"FONTE {label}:\n{rendered}"
 
 
 def build_user_content(
     record: dict[str, Any], image_b64: str | None, mime: str | None
 ) -> list[dict[str, Any]]:
     entrada = record.get("input") or {}
-    metadados = {
+    purificacao = record.get("purificacao") or {}
+    webscout = record.get("webscout") or {}
+    ledger_input = {
         "item_id": record.get("item_id"),
         "titulo": entrada.get("title_hint"),
         "data": entrada.get("date_hint"),
         "local": entrada.get("place_hint"),
-        "fonte": entrada.get("input_url"),
-        "evidencia_webscout": (record.get("webscout") or {}).get("summary_evidence"),
-        "lacunas_declaradas": (record.get("webscout") or {}).get("gaps"),
+        "url_de_entrada": entrada.get("input_url"),
     }
+    previous_purification = {
+        "suporte_medium": (purificacao.get("record_metadata") or {}).get(
+            "medium"
+        ),
+        "notas_anteriores": purificacao.get("notes"),
+    }
+    webscout_evidence = {
+        "evidencia_resumida": webscout.get("summary_evidence"),
+        "lacunas_declaradas": webscout.get("gaps"),
+    }
+    if webscout.get("search_results"):
+        webscout_evidence["resultados_de_busca"] = webscout["search_results"]
+    source_blocks = "\n\n".join(
+        (
+            _render_source_block("ledger.input", ledger_input),
+            _render_source_block(
+                "purificacao preexistente (record_metadata.medium e notes)",
+                previous_purification,
+            ),
+            _render_source_block(
+                "webscout (summary_evidence, gaps e search_results)",
+                webscout_evidence,
+            ),
+        )
+    )
     texto = (
         "Codifique o item abaixo conforme o instrumento LPAI.\n\n"
-        f"METADADOS CONHECIDOS (não os contradiga, não os complete por inferência):\n"
-        f"{json.dumps(metadados, ensure_ascii=False, indent=2)}\n\n"
+        "EVIDÊNCIAS E ANOTAÇÕES POR PROVENIÊNCIA "
+        "(não as contradiga nem complete por inferência):\n"
+        f"{source_blocks}\n\n"
+        "Notas anteriores e resultados de busca são pistas documentais, não "
+        "prova de recepção histórica. Não infira sentido recebido pelo "
+        "espectador sem fonte específica; codifique apenas o sentido produzido "
+        "pelo dispositivo e preserve a incerteza.\n\n"
     )
     if image_b64:
         texto += "A imagem do item segue anexada."
@@ -586,6 +1023,8 @@ def build_row(
         "coded_by": AGENT_ID,
         "coded_at": now,
         "model": model,
+        "script_version": SCRIPT_VERSION,
+        "proxy_schema_version": PROXY_SCHEMA_VERSION,
         "prompt_version": PROMPT_VERSION,
         "codebook_version": codebook_version,
         "image_source": image_source,
@@ -594,10 +1033,63 @@ def build_row(
     }
 
 
-def append_row(output_path: Path, row: dict[str, Any]) -> None:
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+def append_row(
+    output_path: Path, row: dict[str, Any], *, force: bool = False
+) -> bool:
+    """Decide duplicidade e anexa uma linha sob lock POSIX exclusivo."""
+    initial_validator = get_proxy_validator()
+    validate_proxy_row(row, validator=initial_validator)
+    parent_fd, name = _open_staging_parent(output_path, create=True)
+    try:
+        try:
+            fd = os.open(
+                name,
+                os.O_RDWR | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+        except OSError as exc:
+            raise GuardrailError("saída é symlink ou não pôde ser aberta com segurança") from exc
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            try:
+                current_validator = get_proxy_validator()
+                done = _validate_jsonl_fd(
+                    fd, output_path, validator=current_validator
+                )
+                validate_proxy_row(row, validator=current_validator)
+                if row["item_id"] in done and not force:
+                    return False
+                original_size = os.fstat(fd).st_size
+                _assert_safe_file_identity(fd, output_path, purpose="saída")
+                payload = (json.dumps(row, ensure_ascii=False) + "\n").encode("utf-8")
+                os.lseek(fd, 0, os.SEEK_END)
+                try:
+                    written = os.write(fd, payload)
+                except OSError:
+                    os.ftruncate(fd, original_size)
+                    os.fsync(fd)
+                    raise
+                if written != len(payload):
+                    os.ftruncate(fd, original_size)
+                    os.fsync(fd)
+                    raise OSError(
+                        f"escrita JSONL parcial recusada: {written}/{len(payload)} bytes"
+                    )
+                try:
+                    _assert_safe_file_identity(fd, output_path, purpose="saída")
+                except GuardrailError:
+                    os.ftruncate(fd, original_size)
+                    os.fsync(fd)
+                    raise
+                os.fsync(fd)
+                return True
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+    finally:
+        os.close(parent_fd)
 
 
 # ---------------------------------------------------------------------------
@@ -605,17 +1097,43 @@ def append_row(output_path: Path, row: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _nonempty_items(value: str) -> str:
+    if not any(part.strip() for part in value.split(",")):
+        raise argparse.ArgumentTypeError("--items exige ao menos um item_id não vazio")
+    return value
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("valor precisa ser maior que zero")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("valor não pode ser negativo")
+    return parsed
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Codificador-proxy LPAI v2 sobre Kimi K3 (saída em staging)."
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {SCRIPT_VERSION}",
+        help="mostra a versão do script (não a versão do codebook)",
+    )
     alvo = parser.add_mutually_exclusive_group(required=True)
-    alvo.add_argument("--items", help="item_id[,item_id,...]")
+    alvo.add_argument("--items", type=_nonempty_items, help="item_id[,item_id,...]")
     alvo.add_argument("--all", action="store_true", help="todos os registros")
 
     parser.add_argument("--regime", choices=REGIMES, help="filtra por regime")
     parser.add_argument("--coded-by", help="filtra pela origem de codificação")
-    parser.add_argument("--limit", type=int, help="teto de itens no lote")
+    parser.add_argument("--limit", type=_positive_int, help="teto positivo de itens no lote")
     parser.add_argument("--output", help="caminho de staging (.jsonl)")
     parser.add_argument("--images-dir", help="diretório de imagens locais <item_id>.<ext>")
     parser.add_argument(
@@ -625,7 +1143,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--model", default=MODEL_DEFAULT)
     parser.add_argument("--base-url", default=BASE_URL_DEFAULT)
-    parser.add_argument("--retries", type=int, default=1)
+    parser.add_argument("--retries", type=_nonnegative_int, default=1)
     parser.add_argument("--force", action="store_true", help="recodificar já feitos")
     parser.add_argument(
         "--dry-run",
@@ -648,6 +1166,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         master_prompt, codebook_version = load_master_prompt()
         records = load_records()
+        existing_done = load_done(output_path)
+    except GuardrailError as exc:
+        print(f"[barreira] {exc}", file=sys.stderr)
+        return 3
     except (FileNotFoundError, ValueError) as exc:
         print(f"[fatal] {exc}", file=sys.stderr)
         return 1
@@ -655,7 +1177,7 @@ def main(argv: list[str] | None = None) -> int:
     item_ids = (
         [i.strip() for i in args.items.split(",") if i.strip()] if args.items else None
     )
-    done = set() if args.force else load_done(output_path)
+    done = set() if args.force else existing_done
     selected = select_items(
         records,
         item_ids,
@@ -690,6 +1212,7 @@ def main(argv: list[str] | None = None) -> int:
 
     baixa_confianca = 0
     sem_imagem = 0
+    pulados_sem_evidencia = 0
     falhas = 0
 
     for index, record in enumerate(selected, start=1):
@@ -704,6 +1227,7 @@ def main(argv: list[str] | None = None) -> int:
         if image_path is None:
             sem_imagem += 1
             if not args.allow_textual:
+                pulados_sem_evidencia += 1
                 print(
                     f"[{index}/{len(selected)}] {item_id}: sem imagem — pulado "
                     "(use --allow-textual para codificar só com texto)",
@@ -713,7 +1237,12 @@ def main(argv: list[str] | None = None) -> int:
 
         image_b64 = mime = None
         if image_path is not None and not args.dry_run:
-            image_b64, mime = encode_image(image_path)
+            try:
+                image_b64, mime = encode_image(image_path)
+            except (OSError, ValueError) as exc:
+                falhas += 1
+                print(f"[erro] {item_id}: evidência visual insegura/inválida: {exc}", file=sys.stderr)
+                continue
 
         user_content = build_user_content(record, image_b64, mime)
 
@@ -746,7 +1275,22 @@ def main(argv: list[str] | None = None) -> int:
             codebook_version=codebook_version,
             image_source=str(image_path) if image_path else None,
         )
-        append_row(output_path, row)
+        try:
+            appended = append_row(output_path, row, force=args.force)
+        except GuardrailError as exc:
+            print(f"[barreira] {item_id}: {exc}", file=sys.stderr)
+            return 3
+        except (RuntimeError, ValueError) as exc:
+            falhas += 1
+            print(f"[erro] {item_id}: {exc}", file=sys.stderr)
+            continue
+        if not appended:
+            print(
+                f"[{index}/{len(selected)}] {item_id}: já gravado por execução "
+                "concorrente — duplicata recusada",
+                file=sys.stderr,
+            )
+            continue
 
         confianca = coded.get("confianca", "baixa")
         if confianca == "baixa" or not coded.get("codificavel", True):
@@ -759,7 +1303,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         f"\nfim | baixa confiança/NC: {baixa_confianca} | sem imagem: {sem_imagem} "
-        f"| falhas: {falhas}",
+        f"| pulados sem evidência: {pulados_sem_evidencia} | falhas: {falhas}",
         file=sys.stderr,
     )
     print(
@@ -769,7 +1313,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if falhas:
         return 1
-    return 2 if baixa_confianca else 0
+    return 2 if baixa_confianca or pulados_sem_evidencia else 0
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Escopo

Versiona e endurece o codificador-proxy LPAI v2 como CLI isolado em `tools/scripts/`, mantendo o §16 de `docs/methodology/codebooks/codebook-MASTER.md` como fonte única do prompt.

## Mudanças

- corrige o caminho real do codebook e expõe `--version` (`1.3.0`);
- formaliza o envelope JSONL com `proxy_schema_version: 1.0.0`;
- usa staging versionado em `data/staging/lpai-proxy-k3-schema-v1-runs.jsonl`, sem tocar o staging legado;
- restringe escrita a `data/staging/` com proteção contra `..`, symlink, hardlink, troca TOCTOU e colisão com artefatos canônicos;
- valida linhas existentes e novas contra JSON Schema antes de rede e antes do append;
- protege concorrência com lock POSIX e append de linha única;
- endurece cache/download de imagens contra escrita indireta, SSRF, MIME inválido e payload excessivo;
- preserva todos os campos previstos no §16, sem calcular `purificacao_composto` ou qualquer score agregado;
- adiciona README operacional e testes sem rede.

## Segurança metodológica

A saída permanece `proxy_only`, com `authority: proxy`, `human_class: null` e `merge_policy: requires_human_adjudication`. O script não promove nem modifica ledger, exports ou corpus. Ausência de evidência não é convertida em zero.

## Arquivos

- `tools/scripts/lpai_proxy_coder_k3.py`
- `tools/scripts/README-lpai-proxy.md`
- `tools/schemas/lpai-proxy-record.schema.json`
- `tests/test_lpai_proxy_coder_k3.py`

## Validação

- 83 testes focados passaram;
- 338 testes da suíte completa passaram, além de 2 subtests;
- Ruff e `git diff --check` passaram;
- 335/335 registros do ledger principal válidos;
- 286/286 registros de purificação válidos;
- export idempotente e 335/335 itens sincronizados por URL;
- revisão independente: READY FOR PR.

## Fora de escopo

Nenhuma alteração em ledgers canônicos, exports, `records_to_corpus.py`, CI ou fluxo de promoção. A implementação segura de escrita é deliberadamente POSIX-only e está documentada.